### PR TITLE
WIP: Operation Migration plugin

### DIFF
--- a/.changeset/cool-waves-tan.md
+++ b/.changeset/cool-waves-tan.md
@@ -1,0 +1,5 @@
+---
+'@envelop/operation-migration': patch
+---
+
+Introduce new plugin

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -263,12 +263,18 @@ export function createEnvelopOrchestrator(plugins: Plugin[]): EnvelopOrchestrato
       setResult: (newResult: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => void;
     }) => void)[] = [];
     let context = args.contextValue || {};
+    let variables = args.variableValues || {};
 
     for (const onSubscribe of beforeCallbacks.subscribe) {
       const after = onSubscribe({
         subscribeFn,
         setSubscribeFn: newSubscribeFn => {
           subscribeFn = newSubscribeFn;
+        },
+        setVariables: newVariables => {
+          if (newVariables) {
+            variables = newVariables;
+          }
         },
         extendContext: extension => {
           context = { ...context, ...extension };
@@ -293,6 +299,7 @@ export function createEnvelopOrchestrator(plugins: Plugin[]): EnvelopOrchestrato
     let result = await subscribeFn({
       ...args,
       contextValue: context,
+      variableValues: variables,
     });
 
     for (const afterCb of afterCalls) {
@@ -339,6 +346,7 @@ export function createEnvelopOrchestrator(plugins: Plugin[]): EnvelopOrchestrato
         const afterCalls: ((options: { result: ExecutionResult; setResult: (newResult: ExecutionResult) => void }) => void)[] =
           [];
         let context = args.contextValue || {};
+        let variables = args.variableValues || {};
 
         for (const onExecute of beforeCallbacks.execute) {
           let stopCalled = false;
@@ -347,6 +355,11 @@ export function createEnvelopOrchestrator(plugins: Plugin[]): EnvelopOrchestrato
             executeFn,
             setExecuteFn: newExecuteFn => {
               executeFn = newExecuteFn;
+            },
+            setVariables: newVariables => {
+              if (newVariables) {
+                variables = newVariables;
+              }
             },
             setResultAndStopExecution: stopResult => {
               stopCalled = true;
@@ -390,6 +403,7 @@ export function createEnvelopOrchestrator(plugins: Plugin[]): EnvelopOrchestrato
         result = await executeFn({
           ...args,
           contextValue: context,
+          variableValues: variables,
         });
 
         for (const afterCb of afterCalls) {

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -11,6 +11,7 @@ describe('execute', () => {
     expect(spiedPlugin.spies.beforeResolver).toHaveBeenCalledTimes(3);
     expect(spiedPlugin.spies.beforeExecute).toHaveBeenCalledWith({
       executeFn: expect.any(Function),
+      setVariables: expect.any(Function),
       setExecuteFn: expect.any(Function),
       extendContext: expect.any(Function),
       setResultAndStopExecution: expect.any(Function),

--- a/packages/plugins/graphql-jit/test/graphql-jit.spec.ts
+++ b/packages/plugins/graphql-jit/test/graphql-jit.spec.ts
@@ -1,4 +1,4 @@
-import { createSpiedPlugin, createTestkit } from '@envelop/testing';
+import { createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { execute } from 'graphql';
 import { useGraphQlJit } from '../src';

--- a/packages/plugins/operation-migration/README.md
+++ b/packages/plugins/operation-migration/README.md
@@ -1,0 +1,11 @@
+## `@envelop/operation-migration`
+
+## Getting Started
+
+```
+yarn add @envelop/operation-migration
+```
+
+## Usage Example
+
+TODO

--- a/packages/plugins/operation-migration/package.json
+++ b/packages/plugins/operation-migration/package.json
@@ -9,8 +9,18 @@
     "url": "https://github.com/dotansimha/envelop.git",
     "directory": "packages/plugins/operation-migration"
   },
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"
@@ -19,7 +29,9 @@
     "test": "jest",
     "prepack": "bob prepack"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@envelop/types": "0.2.1"
+  },
   "devDependencies": {
     "bob-the-bundler": "1.2.0",
     "graphql": "15.5.0",

--- a/packages/plugins/operation-migration/package.json
+++ b/packages/plugins/operation-migration/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@envelop/operation-migration",
+  "version": "0.0.0",
+  "author": "Dotan Simha <dotansimha@gmail.com>",
+  "license": "MIT",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/envelop.git",
+    "directory": "packages/plugins/operation-migration"
+  },
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "bob-the-bundler": "1.2.0",
+    "graphql": "15.5.0",
+    "typescript": "4.2.3"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/operation-migration/src/enum.ts
+++ b/packages/plugins/operation-migration/src/enum.ts
@@ -14,7 +14,13 @@ export function migrateEnum(rawRules: MigrateEnumRule | MigrateEnumRule[]): Oper
       const typeInfoVisitor = visitWithTypeInfo(typeInfo, {
         leave: {
           EnumValue: node => {
-            const type = getNamedType(typeInfo.getArgument().type);
+            const arg = typeInfo.getArgument();
+
+            if (!arg) {
+              return;
+            }
+
+            const type = getNamedType(arg.type);
 
             if (isEnumType(type)) {
               for (const rule of rules) {
@@ -65,7 +71,7 @@ export function migrateEnum(rawRules: MigrateEnumRule | MigrateEnumRule[]): Oper
         Object.keys(rulesByType).reduce((prev, typeName) => {
           return {
             ...prev,
-            [typeName]: value => {
+            [typeName]: (value: any) => {
               for (const rule of rules) {
                 if (rule.toName === value) {
                   return rule.fromName;

--- a/packages/plugins/operation-migration/src/enum.ts
+++ b/packages/plugins/operation-migration/src/enum.ts
@@ -1,0 +1,86 @@
+import { getNamedType, isEnumType, visit, visitWithTypeInfo } from 'graphql';
+import { OperationMigration } from './types';
+import { visitResult } from '@graphql-tools/utils';
+import { buildRuleMap, unwrap } from './utils';
+
+export type MigrateEnumRule = { enumName: string; fromName: string; toName: string };
+
+export function migrateEnum(rawRules: MigrateEnumRule | MigrateEnumRule[]): OperationMigration {
+  const rules = Array.isArray(rawRules) ? rawRules : [rawRules];
+  const rulesByType = buildRuleMap(rules, 'enumName');
+
+  return {
+    migrateAst: (document, schema, typeInfo) => {
+      const typeInfoVisitor = visitWithTypeInfo(typeInfo, {
+        leave: {
+          EnumValue: node => {
+            const type = getNamedType(typeInfo.getArgument().type);
+
+            if (isEnumType(type)) {
+              for (const rule of rules) {
+                if (type.name === rule.enumName && node.value === rule.fromName) {
+                  return {
+                    ...node,
+                    value: rule.toName,
+                  };
+                }
+              }
+            }
+          },
+        },
+      });
+
+      const modifiedDocument = visit(document, typeInfoVisitor);
+
+      return { document: modifiedDocument };
+    },
+    migrateVariables: (document, variables, schema) => {
+      if (!variables || Object.keys(variables).length === 0) {
+        return { variablesValue: variables };
+      }
+
+      visit(document, {
+        VariableDefinition: node => {
+          const baseType = unwrap(node.type);
+          const variableName = node.variable.name.value;
+
+          for (const rule of rules) {
+            if (baseType.name.value === rule.enumName && variables[variableName] === rule.fromName) {
+              variables[variableName] = rule.toName;
+            }
+          }
+        },
+      });
+
+      return { variablesValue: variables };
+    },
+    migrateResult: (document, result, schema, typeInfo) => {
+      const modifiedResult = visitResult(
+        result,
+        {
+          document,
+          variables: {},
+        },
+        schema,
+        Object.keys(rulesByType).reduce((prev, typeName) => {
+          return {
+            ...prev,
+            [typeName]: value => {
+              for (const rule of rules) {
+                if (rule.toName === value) {
+                  return rule.fromName;
+                }
+              }
+
+              return value;
+            },
+          };
+        }, {})
+      );
+
+      return {
+        result: modifiedResult,
+      };
+    },
+  };
+}

--- a/packages/plugins/operation-migration/src/field-name.ts
+++ b/packages/plugins/operation-migration/src/field-name.ts
@@ -14,7 +14,13 @@ export function migrateFieldName(rawRules: MigrateFieldNameRile | MigrateFieldNa
       const typeInfoVisitor = visitWithTypeInfo(typeInfo, {
         leave: {
           Field: node => {
-            const type = getNamedType(typeInfo.getParentType());
+            const parentType = typeInfo.getParentType();
+
+            if (!parentType) {
+              return;
+            }
+
+            const type = getNamedType(parentType);
 
             if (isObjectType(type) || isInterfaceType(type)) {
               for (const rule of rules) {
@@ -50,7 +56,7 @@ export function migrateFieldName(rawRules: MigrateFieldNameRile | MigrateFieldNa
           return {
             ...prev,
             [typeName]: {
-              __leave: value => {
+              __leave: (value: any) => {
                 if (value && typeof value === 'object') {
                   for (const rule of rules) {
                     if (rule.toName in value) {

--- a/packages/plugins/operation-migration/src/field-name.ts
+++ b/packages/plugins/operation-migration/src/field-name.ts
@@ -1,0 +1,79 @@
+import { getNamedType, isInterfaceType, isObjectType, Kind, visit, visitWithTypeInfo } from 'graphql';
+import { OperationMigration } from './types';
+import { visitResult } from '@graphql-tools/utils';
+import { buildRuleMap } from './utils';
+
+export type MigrateFieldNameRile = { typeName: string; fromName: string; toName: string };
+
+export function migrateFieldName(rawRules: MigrateFieldNameRile | MigrateFieldNameRile[]): OperationMigration {
+  const rules = Array.isArray(rawRules) ? rawRules : [rawRules];
+  const rulesByType = buildRuleMap(rules, 'typeName');
+
+  return {
+    migrateAst: (document, schema, typeInfo) => {
+      const typeInfoVisitor = visitWithTypeInfo(typeInfo, {
+        leave: {
+          Field: node => {
+            const type = getNamedType(typeInfo.getParentType());
+
+            if (isObjectType(type) || isInterfaceType(type)) {
+              for (const rule of rules) {
+                if (type.name === rule.typeName && node.name.value === rule.fromName) {
+                  return <typeof node>{
+                    ...node,
+                    name: {
+                      kind: Kind.NAME,
+                      value: rule.toName,
+                      loc: node.name.loc,
+                    },
+                  };
+                }
+              }
+            }
+          },
+        },
+      });
+
+      const modifiedDocument = visit(document, typeInfoVisitor);
+
+      return { document: modifiedDocument };
+    },
+    migrateResult: (document, result, schema, typeInfo) => {
+      const modifiedResult = visitResult(
+        result,
+        {
+          document,
+          variables: {},
+        },
+        schema,
+        Object.keys(rulesByType).reduce((prev, typeName) => {
+          return {
+            ...prev,
+            [typeName]: {
+              __leave: value => {
+                if (value && typeof value === 'object') {
+                  for (const rule of rules) {
+                    if (rule.toName in value) {
+                      const { [rule.toName]: fieldValue, ...rest } = value;
+
+                      return {
+                        ...rest,
+                        [rule.fromName]: fieldValue,
+                      };
+                    }
+                  }
+                }
+
+                return value;
+              },
+            },
+          };
+        }, {})
+      );
+
+      return {
+        result: modifiedResult,
+      };
+    },
+  };
+}

--- a/packages/plugins/operation-migration/src/index.ts
+++ b/packages/plugins/operation-migration/src/index.ts
@@ -1,0 +1,2 @@
+export * from './plugin';
+export * from './types';

--- a/packages/plugins/operation-migration/src/plugin.ts
+++ b/packages/plugins/operation-migration/src/plugin.ts
@@ -1,0 +1,58 @@
+import { Plugin } from '@envelop/types';
+import { GraphQLSchema, TypeInfo } from 'graphql';
+import { OperationMigration } from './types';
+
+export type OperationMigrationOptions = {
+  migrations: OperationMigration[];
+};
+
+export const useOperationMigration = (pluginOptions: OperationMigrationOptions): Plugin => {
+  let currentSchema: GraphQLSchema;
+  let typeInfo: TypeInfo;
+
+  return {
+    onSchemaChange({ schema }) {
+      currentSchema = schema;
+      typeInfo = new TypeInfo(currentSchema);
+    },
+    onParse({ setParsedDocument }) {
+      return ({ result }) => {
+        if (result instanceof Error) {
+          return;
+        }
+
+        let document = result;
+
+        for (const migration of pluginOptions.migrations.filter(p => p.migrateAst)) {
+          const out = migration.migrateAst(document, currentSchema, typeInfo);
+          document = out.document;
+        }
+
+        setParsedDocument(document);
+      };
+    },
+    onExecute({ args, setVariables }) {
+      let variables = args.variableValues;
+
+      for (const migration of pluginOptions.migrations.filter(p => p.migrateVariables)) {
+        const out = migration.migrateVariables(args.document, variables, args.schema, typeInfo);
+        variables = out.variablesValue;
+      }
+
+      setVariables(variables);
+
+      return {
+        onExecuteDone: ({ result, setResult }) => {
+          let modifiedResult = result;
+
+          for (const migration of pluginOptions.migrations.filter(p => p.migrateResult)) {
+            const out = migration.migrateResult(args.document, modifiedResult, args.schema, typeInfo);
+            modifiedResult = out.result;
+          }
+
+          setResult(modifiedResult);
+        },
+      };
+    },
+  };
+};

--- a/packages/plugins/operation-migration/src/type-name.ts
+++ b/packages/plugins/operation-migration/src/type-name.ts
@@ -1,4 +1,4 @@
-import { Kind, visit } from 'graphql';
+import { Kind, visit, visitWithTypeInfo } from 'graphql';
 import { OperationMigration } from './types';
 import { visitResult } from '@graphql-tools/utils';
 import { buildRuleMap } from './utils';
@@ -8,11 +8,10 @@ export type MigrateTypeNameRile = { fromName: string; toName: string };
 export function migrateTypeName(rawRules: MigrateTypeNameRile | MigrateTypeNameRile[]): OperationMigration {
   const rules = Array.isArray(rawRules) ? rawRules : [rawRules];
   const rulesByType = buildRuleMap(rules, 'toName');
-  console.log(rulesByType);
 
   return {
-    migrateAst: document => {
-      const visitor = {
+    migrateAst: (document, schema, typeInfo) => {
+      const visitor = visitWithTypeInfo(typeInfo, {
         leave: {
           NamedType: node => {
             for (const rule of rules) {
@@ -29,7 +28,7 @@ export function migrateTypeName(rawRules: MigrateTypeNameRile | MigrateTypeNameR
             }
           },
         },
-      };
+      });
 
       const modifiedDocument = visit(document, visitor);
 
@@ -46,22 +45,22 @@ export function migrateTypeName(rawRules: MigrateTypeNameRile | MigrateTypeNameR
         Object.keys(rulesByType).reduce((prev, typeName) => {
           return {
             ...prev,
-            // [typeName]: {
-            //   __leave: value => {
-            //     if (value && typeof value === 'object') {
-            //       for (const rule of rules) {
-            //         if ('__typename' in value && value.__typename === rule.toName) {
-            //           return {
-            //             ...value,
-            //             __typename: rule.fromName,
-            //           };
-            //         }
-            //       }
-            //     }
+            [typeName]: {
+              __leave: (value: any) => {
+                if (value && typeof value === 'object') {
+                  for (const rule of rules) {
+                    if ('__typename' in value && value.__typename === rule.toName) {
+                      return {
+                        ...value,
+                        __typename: rule.fromName,
+                      };
+                    }
+                  }
+                }
 
-            //     return value;
-            //   },
-            // },
+                return value;
+              },
+            },
           };
         }, {})
       );

--- a/packages/plugins/operation-migration/src/type-name.ts
+++ b/packages/plugins/operation-migration/src/type-name.ts
@@ -1,0 +1,74 @@
+import { Kind, visit } from 'graphql';
+import { OperationMigration } from './types';
+import { visitResult } from '@graphql-tools/utils';
+import { buildRuleMap } from './utils';
+
+export type MigrateTypeNameRile = { fromName: string; toName: string };
+
+export function migrateTypeName(rawRules: MigrateTypeNameRile | MigrateTypeNameRile[]): OperationMigration {
+  const rules = Array.isArray(rawRules) ? rawRules : [rawRules];
+  const rulesByType = buildRuleMap(rules, 'toName');
+  console.log(rulesByType);
+
+  return {
+    migrateAst: document => {
+      const visitor = {
+        leave: {
+          NamedType: node => {
+            for (const rule of rules) {
+              if (node.name.value === rule.fromName) {
+                return <typeof node>{
+                  ...node,
+                  name: {
+                    kind: Kind.NAME,
+                    value: rule.toName,
+                    loc: node.name.loc,
+                  },
+                };
+              }
+            }
+          },
+        },
+      };
+
+      const modifiedDocument = visit(document, visitor);
+
+      return { document: modifiedDocument };
+    },
+    migrateResult: (document, result, schema) => {
+      const modifiedResult = visitResult(
+        result,
+        {
+          document,
+          variables: {},
+        },
+        schema,
+        Object.keys(rulesByType).reduce((prev, typeName) => {
+          return {
+            ...prev,
+            // [typeName]: {
+            //   __leave: value => {
+            //     if (value && typeof value === 'object') {
+            //       for (const rule of rules) {
+            //         if ('__typename' in value && value.__typename === rule.toName) {
+            //           return {
+            //             ...value,
+            //             __typename: rule.fromName,
+            //           };
+            //         }
+            //       }
+            //     }
+
+            //     return value;
+            //   },
+            // },
+          };
+        }, {})
+      );
+
+      return {
+        result: modifiedResult,
+      };
+    },
+  };
+}

--- a/packages/plugins/operation-migration/src/types.ts
+++ b/packages/plugins/operation-migration/src/types.ts
@@ -1,0 +1,29 @@
+import { DocumentNode, GraphQLSchema, TypeInfo } from 'graphql';
+
+export type OutFunction<TOriginalResult, TModifiedResult> = (originalResult: TOriginalResult) => TModifiedResult;
+
+export type OperationMigration<TOriginalResult = unknown, TModifiedResult = TOriginalResult> = {
+  migrateAst?(
+    document: DocumentNode,
+    schema: GraphQLSchema,
+    typeInfo: TypeInfo
+  ): {
+    document: DocumentNode;
+  };
+  migrateVariables?(
+    document: DocumentNode,
+    variablesValue: Record<string, any>,
+    schema: GraphQLSchema,
+    typeInfo: TypeInfo
+  ): {
+    variablesValue: Record<string, any>;
+  };
+  migrateResult?(
+    document: DocumentNode,
+    result: TOriginalResult,
+    schema: GraphQLSchema,
+    typeInfo: TypeInfo
+  ): {
+    result: TModifiedResult;
+  };
+};

--- a/packages/plugins/operation-migration/src/types.ts
+++ b/packages/plugins/operation-migration/src/types.ts
@@ -1,8 +1,8 @@
-import { DocumentNode, GraphQLSchema, TypeInfo } from 'graphql';
+import { DocumentNode, ExecutionResult, GraphQLSchema, TypeInfo } from 'graphql';
 
 export type OutFunction<TOriginalResult, TModifiedResult> = (originalResult: TOriginalResult) => TModifiedResult;
 
-export type OperationMigration<TOriginalResult = unknown, TModifiedResult = TOriginalResult> = {
+export type OperationMigration<TOriginalResult = ExecutionResult, TModifiedResult = TOriginalResult> = {
   migrateAst?(
     document: DocumentNode,
     schema: GraphQLSchema,

--- a/packages/plugins/operation-migration/src/utils.ts
+++ b/packages/plugins/operation-migration/src/utils.ts
@@ -1,0 +1,21 @@
+import { Kind, NamedTypeNode, TypeNode } from 'graphql';
+
+export function unwrap(type: TypeNode): NamedTypeNode {
+  if (type.kind === Kind.LIST_TYPE || type.kind === Kind.NON_NULL_TYPE) {
+    return unwrap(type.type);
+  }
+
+  return type;
+}
+
+export function buildRuleMap<RuleType extends Record<string, any>>(rules: RuleType[], fieldName: keyof RuleType): Record<string, RuleType[]> {
+  return rules.reduce((prev, rule) => {
+    if (!prev[rule[fieldName]]) {
+      prev[rule[fieldName]] = [];
+    }
+
+    prev[rule[fieldName]].push(rule);
+
+    return prev;
+  }, {} as Record<string, RuleType[]>);
+}

--- a/packages/plugins/operation-migration/test/enum.spec.ts
+++ b/packages/plugins/operation-migration/test/enum.spec.ts
@@ -1,0 +1,83 @@
+import { print } from 'graphql';
+import { createSpiedPlugin, createTestkit } from '@envelop/testing';
+import { useOperationMigration } from '../src';
+import { migrateEnum } from '../src/enum';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('migrateEnum', () => {
+  const oldName = 'OLD_VAL';
+  const newName = 'NEW_VAL';
+
+  const testSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        foo(v: Foo!): String
+        testValue: Foo!
+      }
+
+      enum Foo {
+        ${newName}
+        OTHER_VAL
+      }
+    `,
+    resolvers: {
+      Query: {
+        testValue: () => newName,
+      },
+    },
+  });
+
+  it('Should migrate enum value correctly at the level of the ast', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateEnum({ enumName: 'Foo', fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query test { foo(v: ${oldName}) }`);
+    expect(result.errors).toBeUndefined();
+    const executeDocument = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['document'];
+    expect(print(executeDocument)).toContain(newName);
+    expect(print(executeDocument)).not.toContain(oldName);
+  });
+
+  it('Should migrate enum value correctly at the level of the variables', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateEnum({ enumName: 'Foo', fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query test($v: Foo!) { foo(v: $v) }`, { v: oldName });
+    expect(result.errors).toBeUndefined();
+    const variableValues = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['variableValues'];
+    expect(variableValues.v).toBe(newName);
+  });
+
+  it('Should migrate enum value correctly at the level of the result', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateEnum({ enumName: 'Foo', fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query test { testValue }`, { v: oldName });
+    expect(result.errors).toBeUndefined();
+    expect(result.data.testValue).toBe(oldName);
+  });
+});

--- a/packages/plugins/operation-migration/test/field-name.spec.ts
+++ b/packages/plugins/operation-migration/test/field-name.spec.ts
@@ -1,0 +1,64 @@
+import { print } from 'graphql';
+import { createSpiedPlugin, createTestkit } from '@envelop/testing';
+import { useOperationMigration } from '../src';
+import { migrateFieldName } from '../src/field-name';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('migrateFieldName', () => {
+  const oldName = 'oldFieldName';
+  const newName = 'newFieldName';
+
+  const testSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        testValue: Foo!
+      }
+
+      type Foo {
+        ${newName}: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        testValue: () => ({ [newName]: 'NEW_VAL' }),
+      },
+    },
+  });
+
+  it('Should migrate field name correctly at the level of the ast', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateFieldName({ typeName: 'Foo', fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query test { testValue { ${oldName} } }`);
+    expect(result.errors).toBeUndefined();
+    const executeDocument = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['document'];
+    expect(print(executeDocument)).toContain(newName);
+    expect(print(executeDocument)).not.toContain(oldName);
+  });
+
+  it('Should migrate field name correctly at the level of the result', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateFieldName({ typeName: 'Foo', fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query test { testValue { ${oldName} } }`);
+    expect(result.errors).toBeUndefined();
+    expect(result.data.testValue[newName]).toBeUndefined();
+    expect(result.data.testValue[oldName]).toBeDefined();
+  });
+});

--- a/packages/plugins/operation-migration/test/type-name.spec.ts
+++ b/packages/plugins/operation-migration/test/type-name.spec.ts
@@ -1,0 +1,67 @@
+import { print } from 'graphql';
+import { createSpiedPlugin, createTestkit } from '@envelop/testing';
+import { useOperationMigration } from '../src';
+import { migrateTypeName } from '../src/type-name';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('migrateTypeName', () => {
+  const oldName = 'OldFoo';
+  const newName = 'Foo';
+
+  const testSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        testValue: Foo!
+      }
+
+      type Foo {
+        f: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        testValue: () => ({ f: '1' }),
+      },
+    },
+  });
+
+  it('Should migrate field name correctly at the level of the ast', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateTypeName({ fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query { testValue { ... on OldFoo { f }} }`);
+    expect(result.errors).toBeUndefined();
+    const executeDocument = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['document'];
+    expect(print(executeDocument)).toContain(newName);
+    expect(print(executeDocument)).not.toContain(oldName);
+  });
+
+  it('Should migrate field name correctly at the level of the result', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const testInstance = createTestkit(
+      [
+        spiedPlugin.plugin,
+        useOperationMigration({
+          migrations: [migrateTypeName({ fromName: oldName, toName: newName })],
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute(`query { testValue { __typename ... on OldFoo { f }} }`);
+    const executeDocument = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['document'];
+    console.log(print(executeDocument));
+
+    console.log(result.errors[0].stack);
+    expect(result.errors).toBeUndefined();
+    expect(result.data.testValue.__typename).toBe(oldName);
+  });
+});

--- a/packages/plugins/operation-migration/test/type-name.spec.ts
+++ b/packages/plugins/operation-migration/test/type-name.spec.ts
@@ -57,10 +57,6 @@ describe('migrateTypeName', () => {
     );
 
     const result = await testInstance.execute(`query { testValue { __typename ... on OldFoo { f }} }`);
-    const executeDocument = (spiedPlugin.spies.beforeExecute.mock.calls[0] as any)[0]['args']['document'];
-    console.log(print(executeDocument));
-
-    console.log(result.errors[0].stack);
     expect(result.errors).toBeUndefined();
     expect(result.data.testValue.__typename).toBe(oldName);
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,6 +64,7 @@ export interface Plugin<PluginContext = DefaultContext> {
   onExecute?: (options: {
     executeFn: typeof execute;
     args: ExecutionArgs;
+    setVariables: (newVariables: ExecutionArgs['variableValues']) => void;
     setExecuteFn: (newExecute: typeof execute) => void;
     setResultAndStopExecution: (newResult: ExecutionResult) => void;
     extendContext: (contextExtension: Partial<PluginContext>) => void;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,6 +72,7 @@ export interface Plugin<PluginContext = DefaultContext> {
   onSubscribe?: (options: {
     subscribeFn: typeof subscribe;
     args: SubscriptionArgs;
+    setVariables: (newVariables: ExecutionArgs['variableValues']) => void;
     setSubscribeFn: (newSubscribe: typeof subscribe) => void;
     extendContext: (contextExtension: Partial<PluginContext>) => void;
   }) => void | OnSubscribeHookResult<PluginContext>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noImplicitThis": true,
     "strict": true,
     "alwaysStrict": true,
-    "noImplicitReturns": true,
+    "noImplicitReturns": false,
     "noUnusedLocals": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The goal of this plugin is to allow to migrate **operation** SDL + result based on pre-defined / custom rules. The goal is to allow schemas to evolve and update, without the need for deprecating fields that eventually bloats the schema, by allowing developers to change the running schema, but apply changes to the operation SDL/AST, variables JSON, and execution result. 

This is useful in cases where you are not in control of the executed operations (like, a mobile app that queries the server and can run old versions with old operations SDL). 

For example (migrate enum value that was changed):

```graphql
// OLD ENUM
enum Foo {
  A
  B
  OLD_VAL
}

// NEW ENUM
enum Foo {
   A 
   B
   NEW_VAL # this was changed from OLD_VAL
}
```

```ts
// Plugin usage:
useOperationMigration({
    migrations: [migrateEnum({ enumName: 'Foo', fromName: 'OLD_VAL', toName: 'NEW_VAL' })],
}),
```

Ideas / TODO:
- [x] Map all relevant places for migration
- [x] Initial implementation
- [x] Migrate enum value
- [x] Migrate field name
- [ ] Migrate field argument name
- [ ] Migrate scalar?
- [ ] Migrate type name? (mainly for fragments?) 
