### PR TITLE
feat(extended-validation): support programmatic graphql-js api

### DIFF
--- a/.changeset/big-kiwis-sniff.md
+++ b/.changeset/big-kiwis-sniff.md
@@ -1,0 +1,5 @@
+---
+'@envelop/extended-validation': minor
+---
+
+also support oneOf via extensions fields

--- a/packages/plugins/extended-validation/README.md
+++ b/packages/plugins/extended-validation/README.md
@@ -52,11 +52,28 @@ export const MyRule: ExtendedValidationRule = (validationContext, executionArgs)
 
 This directive provides validation for input types and implements the concept of union inputs. You can find the [complete spec RFC here](https://github.com/graphql/graphql-spec/pull/825).
 
-To use that validation rule, make sure to include the following directive in your schema:
+You can use union inputs either via a the SDL flow, by annotating types and fields with `@oneOf` or via the `extensions` field.
+
+First, make sure to add that rule to your plugin usage:
+
+````ts
+import { useExtendedValidation, OneOfInputObjectsRule } from '@envelop/extended-validation';
+
+const getEnveloped = evelop({
+  plugins: [
+    useExtendedValidation({
+      rules: [OneOfInputObjectsRule],
+    }),
+  ],
+});
+
+#### Schema Directive Flow
+
+Make sure to include the following directive in your schema:
 
 ```graphql
 directive @oneOf on INPUT_OBJECT | FIELD_DEFINITION
-```
+````
 
 Then, apply it to field definitions, or to a complete `input` type:
 
@@ -64,7 +81,7 @@ Then, apply it to field definitions, or to a complete `input` type:
 ## Apply to entire input type
 input FindUserInput @oneOf {
   id: ID
-  organizationAndRegistrationNumber: OrganizationAndRegistrationNumberInput
+  organizationAndRegistrationNumber: GraphQLInt
 }
 
 ## Or, apply to a set of input arguments
@@ -74,16 +91,44 @@ type Query {
 }
 ```
 
-Then, make sure to add that rule to your plugin usage:
+#### Programmatic extensions flow
 
-```ts
-import { useExtendedValidation, OneOfInputObjectsRule } from '@envelop/extended-validation';
+```tsx
+const GraphQLFindUserInput = new GraphQLInputObjectType({
+  name: 'FindUserInput',
+  fields: {
+    id: {
+      type: GraphQLID,
+    },
+    organizationAndRegistrationNumber: {
+      type: GraphQLInt,
+    },
+  },
+  extensions: {
+    oneOf: true,
+  },
+});
 
-const getEnveloped = evelop({
-  plugins: [
-    useExtendedValidation({
-      rules: [OneOfInputObjectsRule],
-    }),
-  ],
+const Query = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    foo: {
+      type: GraphQLString,
+      args: {
+        id: {
+          type: GraphQLID,
+        },
+        str1: {
+          type: GraphQLString,
+        },
+        str2: {
+          type: GraphQLString,
+        },
+      },
+      extensions: {
+        oneOf: true,
+      },
+    },
+  },
 });
 ```

--- a/packages/plugins/extended-validation/src/common.ts
+++ b/packages/plugins/extended-validation/src/common.ts
@@ -15,10 +15,6 @@ export function getDirectiveFromAstNode(
   astNode: { directives?: ReadonlyArray<DirectiveNode> },
   names: string | string[]
 ): null | DirectiveNode {
-  if (!astNode) {
-    return null;
-  }
-
   const directives = astNode.directives || [];
   const namesArr = Array.isArray(names) ? names : [names];
   const authDirective = directives.find(d => namesArr.includes(d.name.value));

--- a/packages/plugins/extended-validation/src/rules/one-of.ts
+++ b/packages/plugins/extended-validation/src/rules/one-of.ts
@@ -19,9 +19,10 @@ export const OneOfInputObjectsRule: ExtendedValidationRule = (validationContext,
         const values = getArgumentValues(fieldType, node, executionArgs.variableValues);
 
         if (fieldType) {
-          const fieldTypeDirective = getDirectiveFromAstNode(fieldType.astNode, 'oneOf');
+          const isOneOfFieldType =
+            fieldType.extensions?.oneOf || (fieldType.astNode && getDirectiveFromAstNode(fieldType.astNode, 'oneOf'));
 
-          if (fieldTypeDirective) {
+          if (isOneOfFieldType) {
             if (Object.keys(values).length !== 1) {
               validationContext.reportError(
                 new GraphQLError(
@@ -38,14 +39,10 @@ export const OneOfInputObjectsRule: ExtendedValidationRule = (validationContext,
 
           if (argType) {
             const inputType = unwrapType(argType.type);
+            const isOneOfInputType =
+              inputType.extensions?.oneOf || (inputType.astNode && getDirectiveFromAstNode(inputType.astNode, 'oneOf'));
 
-            if (!inputType || !inputType.astNode) {
-              continue;
-            }
-
-            const inputTypeDirective = getDirectiveFromAstNode(inputType.astNode, 'oneOf');
-
-            if (inputTypeDirective) {
+            if (isOneOfInputType) {
               const argValue = values[arg.name.value] || {};
 
               if (Object.keys(argValue).length !== 1) {

--- a/packages/plugins/extended-validation/src/rules/one-of.ts
+++ b/packages/plugins/extended-validation/src/rules/one-of.ts
@@ -12,7 +12,7 @@ export const OneOfInputObjectsRule: ExtendedValidationRule = (validationContext,
       if (node.arguments?.length) {
         const fieldType = validationContext.getFieldDef();
 
-        if (!fieldType || !fieldType.astNode) {
+        if (!fieldType) {
           return;
         }
 

--- a/packages/plugins/extended-validation/test/one-of.spec.ts
+++ b/packages/plugins/extended-validation/test/one-of.spec.ts
@@ -1,9 +1,18 @@
-import { buildSchema } from 'graphql';
+import {
+  buildSchema,
+  GraphQLObjectType,
+  GraphQLInputObjectType,
+  GraphQLString,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLSchema,
+} from 'graphql';
 import { createTestkit } from '@envelop/testing';
 import { useExtendedValidation, ONE_OF_DIRECTIVE_SDL, OneOfInputObjectsRule } from '../src';
 
 describe('oneOf', () => {
-  const testSchema = buildSchema(/* GraphQL */ `
+  const astSchema = buildSchema(/* GraphQL */ `
     ${ONE_OF_DIRECTIVE_SDL}
 
     type Query {
@@ -21,235 +30,297 @@ describe('oneOf', () => {
     }
   `);
 
-  describe('INPUT_OBJECT', () => {
-    const DOCUMENT_WITH_WHOLE_INPUT = /* GraphQL */ `
-      query user($input: UserUniqueCondition!) {
-        user(input: $input) {
-          id
-        }
-      }
-    `;
-
-    it.each([
-      [
-        'Valid: Exactly one key is specified through literal',
-        {
-          document: `query user { user(input: { id: 1 }) { id }}`,
-          variables: {},
-          expectedError: null,
+  const GraphQLUser = new GraphQLObjectType({
+    name: 'User',
+    fields: {
+      id: {
+        type: GraphQLNonNull(GraphQLID),
+      },
+    },
+  });
+  const GraphQLUserUniqueCondition = new GraphQLInputObjectType({
+    name: 'UserUniqueCondition',
+    fields: {
+      id: {
+        type: GraphQLID,
+      },
+      username: {
+        type: GraphQLString,
+      },
+    },
+    extensions: {
+      oneOf: true,
+    },
+  });
+  const GraphQLQuery = new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      user: {
+        type: GraphQLUser,
+        args: {
+          input: {
+            type: GraphQLUserUniqueCondition,
+          },
         },
-      ],
-      [
-        'Valid: Exactly one key is specified through variables',
-        {
-          document: DOCUMENT_WITH_WHOLE_INPUT,
-          variables: {
-            input: {
+      },
+      findUser: {
+        type: GraphQLUser,
+        args: {
+          byID: {
+            type: GraphQLID,
+          },
+          byUsername: {
+            type: GraphQLString,
+          },
+          byEmail: {
+            type: GraphQLString,
+          },
+          byRegistrationNumber: {
+            type: GraphQLInt,
+          },
+        },
+        extensions: {
+          oneOf: true,
+        },
+      },
+    },
+  });
+  const programmaticSchema = new GraphQLSchema({ query: GraphQLQuery });
+
+  describe.each([
+    ['AST via Directive', astSchema],
+    ['Programmatic via extensions.oneOf', programmaticSchema],
+  ])('%s', (_, testSchema) => {
+    describe('INPUT_OBJECT', () => {
+      const DOCUMENT_WITH_WHOLE_INPUT = /* GraphQL */ `
+        query user($input: UserUniqueCondition!) {
+          user(input: $input) {
+            id
+          }
+        }
+      `;
+
+      it.each([
+        [
+          'Valid: Exactly one key is specified through literal',
+          {
+            document: `query user { user(input: { id: 1 }) { id }}`,
+            variables: {},
+            expectedError: null,
+          },
+        ],
+        [
+          'Valid: Exactly one key is specified through variables',
+          {
+            document: DOCUMENT_WITH_WHOLE_INPUT,
+            variables: {
+              input: {
+                id: 1,
+              },
+            },
+            expectedError: null,
+          },
+        ],
+        [
+          'Valid: Mixed variables resolved into a single value',
+          {
+            document: `query user($username: String) { user(input: { id: 1, username: $username }) { id }}`,
+            variables: {},
+            expectedError: null,
+          },
+        ],
+        [
+          'Valid: Mixed variables resolved into a single value - separate variables',
+          {
+            document: `query user($id: ID, $username: String) { user(input: { id: $id, username: $username }) { id }}`,
+            variables: {
               id: 1,
             },
+            expectedError: null,
           },
-          expectedError: null,
-        },
-      ],
-      [
-        'Valid: Mixed variables resolved into a single value',
-        {
-          document: `query user($username: String) { user(input: { id: 1, username: $username }) { id }}`,
-          variables: {},
-          expectedError: null,
-        },
-      ],
-      [
-        'Valid: Mixed variables resolved into a single value - separate variables',
-        {
-          document: `query user($id: ID, $username: String) { user(input: { id: $id, username: $username }) { id }}`,
-          variables: {
-            id: 1,
-          },
-          expectedError: null,
-        },
-      ],
-      [
-        'Invalid: Mixed variables leading to multiple values',
-        {
-          document: `query user($username: String) { user(input: { id: 1, username: $username }) { id }}`,
-          variables: {
-            username: 'test',
-          },
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        'Invalid: More than one value specified through literals',
-        {
-          document: `query user { user(input: { id: 1, username: "t" }) { id }}`,
-          variables: {},
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        'Invalid: More than one value specified through literals with null value',
-        {
-          document: `query user { user(input: { id: null, username: "t" }) { id }}`,
-          variables: {},
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        'Invalid: All values specified explicity with null values',
-        {
-          document: `query user { user(input: { id: null, username: null }) { id }}`,
-          variables: {},
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        `Invalid: When variables are empty`,
-        {
-          document: DOCUMENT_WITH_WHOLE_INPUT,
-          variables: {},
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        `Invalid: When specific variable is empty and provided as input type variable`,
-        {
-          document: DOCUMENT_WITH_WHOLE_INPUT,
-          variables: {
-            input: {},
-          },
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-      [
-        'Invalid: More than one value is specific',
-        {
-          document: DOCUMENT_WITH_WHOLE_INPUT,
-          variables: {
-            input: {
-              id: 1,
+        ],
+        [
+          'Invalid: Mixed variables leading to multiple values',
+          {
+            document: `query user($username: String) { user(input: { id: 1, username: $username }) { id }}`,
+            variables: {
               username: 'test',
             },
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
           },
-          expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
-        },
-      ],
-    ])('%s', async (title, { document, variables, expectedError }) => {
-      const testInstance = createTestkit(
-        [
-          useExtendedValidation({
-            rules: [OneOfInputObjectsRule],
-          }),
         ],
-        testSchema
-      );
+        [
+          'Invalid: More than one value specified through literals',
+          {
+            document: `query user { user(input: { id: 1, username: "t" }) { id }}`,
+            variables: {},
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+        [
+          'Invalid: More than one value specified through literals with null value',
+          {
+            document: `query user { user(input: { id: null, username: "t" }) { id }}`,
+            variables: {},
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+        [
+          'Invalid: All values specified explicity with null values',
+          {
+            document: `query user { user(input: { id: null, username: null }) { id }}`,
+            variables: {},
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+        [
+          `Invalid: When variables are empty`,
+          {
+            document: DOCUMENT_WITH_WHOLE_INPUT,
+            variables: {},
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+        [
+          `Invalid: When specific variable is empty and provided as input type variable`,
+          {
+            document: DOCUMENT_WITH_WHOLE_INPUT,
+            variables: {
+              input: {},
+            },
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+        [
+          'Invalid: More than one value is specific',
+          {
+            document: DOCUMENT_WITH_WHOLE_INPUT,
+            variables: {
+              input: {
+                id: 1,
+                username: 'test',
+              },
+            },
+            expectedError: 'Exactly one key must be specified for input type "UserUniqueCondition"',
+          },
+        ],
+      ])('%s', async (title, { document, variables, expectedError }) => {
+        const testInstance = createTestkit(
+          [
+            useExtendedValidation({
+              rules: [OneOfInputObjectsRule],
+            }),
+          ],
+          testSchema
+        );
 
-      const result = await testInstance.execute(document, variables);
+        const result = await testInstance.execute(document, variables);
 
-      if (expectedError) {
-        expect(result.errors).toBeDefined();
-        expect(result.errors!.length).toBe(1);
-        expect(result.errors![0].message).toBe(expectedError);
-      } else {
-        expect(result.errors).toBeUndefined();
-      }
-    });
-  });
-
-  describe('FIELD_DEFINITION', () => {
-    const DOCUMENT = /* GraphQL */ `
-      query user($byID: ID, $byUsername: String, $byEmail: String, $byRegistrationNumber: Int) {
-        findUser(byID: $byID, byUsername: $byUsername, byEmail: $byEmail, byRegistrationNumber: $byRegistrationNumber) {
-          id
+        if (expectedError) {
+          expect(result.errors).toBeDefined();
+          expect(result.errors!.length).toBe(1);
+          expect(result.errors![0].message).toBe(expectedError);
+        } else {
+          expect(result.errors).toBeUndefined();
         }
-      }
-    `;
+      });
+    });
 
-    it.each([
-      [
-        'Valid: One value specified correctly through variables',
-        {
-          document: DOCUMENT,
-          variables: {
-            byID: 1,
-          },
-          expectedError: null,
-        },
-      ],
-      [
-        'Valid: Mixed values of variables and literal without variables specified',
-        {
-          document: /* GraphQL */ `
-            query user($username: String) {
-              findUser(byID: 1, byUsername: $username) {
-                id
-              }
-            }
-          `,
-          variables: {},
-          expectedError: null,
-        },
-      ],
-      [
-        'Invalid: Multiple values specified through variables',
-        {
-          document: DOCUMENT,
-          variables: {
-            byID: 1,
-            byUsername: 'test',
-          },
-          expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
-        },
-      ],
-      [
-        'Invalid: Multiple values specified through literal',
-        {
-          document: /* GraphQL */ `
-            query user {
-              findUser(byID: 1, byUsername: "test") {
-                id
-              }
-            }
-          `,
-          variables: {},
-          expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
-        },
-      ],
-      [
-        'Invalid: Mixed values of variables and literal',
-        {
-          document: /* GraphQL */ `
-            query user($username: String) {
-              findUser(byID: 1, byUsername: $username) {
-                id
-              }
-            }
-          `,
-          variables: {
-            username: 'test',
-          },
-          expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
-        },
-      ],
-    ])('%s', async (title, { document, variables, expectedError }) => {
-      const testInstance = createTestkit(
+    describe('FIELD_DEFINITION', () => {
+      const DOCUMENT = /* GraphQL */ `
+        query user($byID: ID, $byUsername: String, $byEmail: String, $byRegistrationNumber: Int) {
+          findUser(byID: $byID, byUsername: $byUsername, byEmail: $byEmail, byRegistrationNumber: $byRegistrationNumber) {
+            id
+          }
+        }
+      `;
+
+      it.each([
         [
-          useExtendedValidation({
-            rules: [OneOfInputObjectsRule],
-          }),
+          'Valid: One value specified correctly through variables',
+          {
+            document: DOCUMENT,
+            variables: {
+              byID: 1,
+            },
+            expectedError: null,
+          },
         ],
-        testSchema
-      );
+        [
+          'Valid: Mixed values of variables and literal without variables specified',
+          {
+            document: /* GraphQL */ `
+              query user($username: String) {
+                findUser(byID: 1, byUsername: $username) {
+                  id
+                }
+              }
+            `,
+            variables: {},
+            expectedError: null,
+          },
+        ],
+        [
+          'Invalid: Multiple values specified through variables',
+          {
+            document: DOCUMENT,
+            variables: {
+              byID: 1,
+              byUsername: 'test',
+            },
+            expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
+          },
+        ],
+        [
+          'Invalid: Multiple values specified through literal',
+          {
+            document: /* GraphQL */ `
+              query user {
+                findUser(byID: 1, byUsername: "test") {
+                  id
+                }
+              }
+            `,
+            variables: {},
+            expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
+          },
+        ],
+        [
+          'Invalid: Mixed values of variables and literal',
+          {
+            document: /* GraphQL */ `
+              query user($username: String) {
+                findUser(byID: 1, byUsername: $username) {
+                  id
+                }
+              }
+            `,
+            variables: {
+              username: 'test',
+            },
+            expectedError: 'Exactly one key must be specified for input for field "User.findUser"',
+          },
+        ],
+      ])('%s', async (title, { document, variables, expectedError }) => {
+        const testInstance = createTestkit(
+          [
+            useExtendedValidation({
+              rules: [OneOfInputObjectsRule],
+            }),
+          ],
+          testSchema
+        );
 
-      const result = await testInstance.execute(document, variables);
+        const result = await testInstance.execute(document, variables);
 
-      if (expectedError) {
-        expect(result.errors).toBeDefined();
-        expect(result.errors!.length).toBe(1);
-        expect(result.errors![0].message).toBe(expectedError);
-      } else {
-        expect(result.errors).toBeUndefined();
-      }
+        if (expectedError) {
+          expect(result.errors).toBeDefined();
+          expect(result.errors!.length).toBe(1);
+          expect(result.errors![0].message).toBe(expectedError);
+        } else {
+          expect(result.errors).toBeUndefined();
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

This allows using the oneOf validation rule without the SDL schema flow.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

With unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
