### PR TITLE
fix graphql-jit implementation with lru cache

### DIFF
--- a/.changeset/calm-seals-check.md
+++ b/.changeset/calm-seals-check.md
@@ -1,0 +1,5 @@
+---
+'@envelop/graphql-jit': patch
+---
+
+Fix issues with executor and caching

--- a/packages/plugins/graphql-jit/package.json
+++ b/packages/plugins/graphql-jit/package.json
@@ -20,7 +20,8 @@
     "prepack": "bob prepack"
   },
   "dependencies": {
-    "graphql-jit": "^0.5.0"
+    "graphql-jit": "^0.5.0",
+    "tiny-lru": "7.0.6"
   },
   "devDependencies": {
     "graphql-jit": "0.5.0",

--- a/packages/plugins/graphql-jit/src/index.ts
+++ b/packages/plugins/graphql-jit/src/index.ts
@@ -1,18 +1,81 @@
 /* eslint-disable no-console */
 import { Plugin } from '@envelop/types';
-import { GraphQLError } from 'graphql';
-import { compileQuery, isCompiledQuery, CompilerOptions } from 'graphql-jit';
+import { GraphQLError, DocumentNode, ExecutionResult, Source } from 'graphql';
+import { compileQuery, isCompiledQuery, CompilerOptions, CompiledQuery } from 'graphql-jit';
+import lru from 'tiny-lru';
+
+const DEFAULT_MAX = 1000;
+const DEFAULT_TTL = 3600000;
+
+export type JitCacheOptions = {
+  /**
+   * Maximum size of LRU Cache
+   * @default 1000
+   */
+  max?: number;
+  /**
+   * TTL in milliseconds
+   * @default 3600000
+   */
+  ttl?: number;
+};
 
 export const useGraphQlJit = (
   compilerOptions: Partial<CompilerOptions> = {},
-  pluginOptions: Partial<{
-    onError: (r: ReturnType<typeof compileQuery>) => void;
-  }> = {}
+  pluginOptions: {
+    onError?: (r: ReturnType<typeof compileQuery>) => void;
+  } & JitCacheOptions = {}
 ): Plugin => {
+  const max = typeof pluginOptions.max === 'number' ? pluginOptions.max : DEFAULT_MAX;
+  const ttl = typeof pluginOptions.ttl === 'number' ? pluginOptions.ttl : DEFAULT_TTL;
+
+  const DocumentSourceMap = new WeakMap<DocumentNode, string>();
+
+  const jitCache = lru<
+    | CompiledQuery
+    | ExecutionResult<
+        {
+          [key: string]: any;
+        },
+        {
+          [key: string]: any;
+        }
+      >
+  >(max, ttl);
+
   return {
+    onParse({ params: { source } }) {
+      const key = source instanceof Source ? source.body : source;
+
+      return ({ result }) => {
+        if (!result || result instanceof Error) return;
+
+        DocumentSourceMap.set(result, key);
+      };
+    },
     onExecute({ args, setExecuteFn }) {
       setExecuteFn(function jitExecutor() {
-        const compiledQuery = compileQuery(args.schema, args.document, args.operationName ?? undefined, compilerOptions);
+        let compiledQuery:
+          | CompiledQuery
+          | ExecutionResult<
+              {
+                [key: string]: any;
+              },
+              {
+                [key: string]: any;
+              }
+            >
+          | undefined;
+
+        const documentSource = DocumentSourceMap.get(args.document);
+
+        if (documentSource) compiledQuery = jitCache.get(documentSource);
+
+        if (!compiledQuery) {
+          compiledQuery = compileQuery(args.schema, args.document, args.operationName ?? undefined, compilerOptions);
+
+          if (documentSource) jitCache.set(documentSource, compiledQuery);
+        }
 
         if (!isCompiledQuery(compiledQuery)) {
           if (pluginOptions?.onError) {

--- a/packages/plugins/graphql-jit/src/index.ts
+++ b/packages/plugins/graphql-jit/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Plugin } from '@envelop/types';
-import { GraphQLError, DocumentNode, ExecutionResult, Source } from 'graphql';
-import { compileQuery, isCompiledQuery, CompilerOptions, CompiledQuery } from 'graphql-jit';
+import { GraphQLError, DocumentNode, Source } from 'graphql';
+import { compileQuery, isCompiledQuery, CompilerOptions } from 'graphql-jit';
 import lru from 'tiny-lru';
 
 const DEFAULT_MAX = 1000;
@@ -31,17 +31,7 @@ export const useGraphQlJit = (
 
   const DocumentSourceMap = new WeakMap<DocumentNode, string>();
 
-  const jitCache = lru<
-    | CompiledQuery
-    | ExecutionResult<
-        {
-          [key: string]: any;
-        },
-        {
-          [key: string]: any;
-        }
-      >
-  >(max, ttl);
+  const jitCache = lru<ReturnType<typeof compileQuery>>(max, ttl);
 
   return {
     onParse({ params: { source } }) {
@@ -55,17 +45,7 @@ export const useGraphQlJit = (
     },
     onExecute({ args, setExecuteFn }) {
       setExecuteFn(function jitExecutor() {
-        let compiledQuery:
-          | CompiledQuery
-          | ExecutionResult<
-              {
-                [key: string]: any;
-              },
-              {
-                [key: string]: any;
-              }
-            >
-          | undefined;
+        let compiledQuery: ReturnType<typeof compileQuery> | undefined;
 
         const documentSource = DocumentSourceMap.get(args.document);
 


### PR DESCRIPTION
## Description

The current graphql-jit implementation doesn't work as intended since the result of the compilation is meant to be cached, and not being compiled on every execution, as it was detected while using it in benchmarks that using the plugin meant worse performance than not using it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

**Test Environment**:

- OS: macOS v11.3
- `@envelop/core`: v0.1.14
- NodeJS: v16.0.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
