### PR TITLE
Allow to reuse existing transaction

### DIFF
--- a/.changeset/khaki-cougars-behave.md
+++ b/.changeset/khaki-cougars-behave.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': minor
+---
+
+Add trackResolvers

--- a/.changeset/many-moons-sip.md
+++ b/.changeset/many-moons-sip.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': minor
+---
+
+Allow to reuse existing transaction


### PR DESCRIPTION
It's kind of breaking because we store `Span` instead of `Transaction` under `Symbol('SENTRY_GRAPHQL')` property of context but not really breaking because the symbol is not exported by the sentry plugin so nothing has access to it.

By default it works exactly as before, when `startTransaction` flag is `false` then we create a Child Span for already existing transaction. With `renameTransaction` we are able to set a new name.

The `transactionName` and `operationName` are to let people provide custom values other than `execute` and `{operationName}`.

@dotansimha I ported our setup from Hive