### PR TITLE
feat: execute/subscribe AsyncIterable API

### DIFF
--- a/packages/core/src/graphql-typings.d.ts
+++ b/packages/core/src/graphql-typings.d.ts
@@ -1,4 +1,4 @@
 declare module 'graphql/jsutils/isAsyncIterable' {
-  function isAsyncIterable(input: unknown): input is AsyncIterable<any>;
+  function isAsyncIterable(input: unknown): input is AsyncIterableIterator<unknown>;
   export default isAsyncIterable;
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -21,8 +21,8 @@ export function getExecuteArgs(args: PolymorphicExecuteArguments): ExecutionArgs
  * Utility function for making a execute function that handles polymorphic arguments.
  */
 export const makeExecute =
-  (executeFn: (args: ExecutionArgs) => PromiseOrValue<ExecutionResult>) =>
-  (...polyArgs: PolymorphicExecuteArguments): PromiseOrValue<ExecutionResult> =>
+  (executeFn: (args: ExecutionArgs) => PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>>) =>
+  (...polyArgs: PolymorphicExecuteArguments): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> =>
     executeFn(getExecuteArgs(polyArgs));
 
 export function getSubscribeArgs(args: PolymorphicSubscribeArguments): SubscriptionArgs {
@@ -47,3 +47,23 @@ export const makeSubscribe =
   (subscribeFn: (args: SubscriptionArgs) => PromiseOrValue<AsyncIterableIterator<ExecutionResult> | ExecutionResult>) =>
   (...polyArgs: PolymorphicSubscribeArguments): PromiseOrValue<AsyncIterableIterator<ExecutionResult> | ExecutionResult> =>
     subscribeFn(getSubscribeArgs(polyArgs));
+
+export async function* mapAsyncIterator<TInput, TOutput = TInput>(
+  asyncIterable: AsyncIterableIterator<TInput>,
+  map: (input: TInput) => Promise<TOutput> | TOutput
+): AsyncIterableIterator<TOutput> {
+  for await (const value of asyncIterable) {
+    yield map(value);
+  }
+}
+
+export async function* finalAsyncIterator<TInput>(
+  asyncIterable: AsyncIterableIterator<TInput>,
+  onFinal: () => void
+): AsyncIterableIterator<TInput> {
+  try {
+    yield* asyncIterable;
+  } finally {
+    onFinal();
+  }
+}

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -213,7 +213,7 @@ describe('execute', () => {
     await collectAsyncIteratorValues(result);
   });
 
-  it.skip('Should be able to invoke something after the stream has ended (manual return).', async () => {
+  it('Should be able to invoke something after the stream has ended (manual return).', async () => {
     expect.assertions(1);
     const streamExecuteFn = async function* () {
       for (const value of ['a', 'b', 'c', 'd']) {
@@ -235,7 +235,7 @@ describe('execute', () => {
                     latestResult = result;
                   },
                   onEnd: () => {
-                    expect(latestResult).toEqual(undefined);
+                    expect(latestResult).toEqual({ data: { alphabet: 'a' } });
                   },
                 };
               },
@@ -248,6 +248,8 @@ describe('execute', () => {
 
     const result: ReturnType<ExecuteFunction> = await teskit.executeRaw({} as any);
     assertAsyncIterator(result);
-    result[Symbol.asyncIterator]().return!();
+    const instance = result[Symbol.asyncIterator]();
+    await instance.next();
+    await instance.return!();
   });
 });

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -31,6 +31,7 @@ describe('execute', () => {
     expect(spiedPlugin.spies.afterResolver).toHaveBeenCalledTimes(3);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledTimes(1);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledWith({
+      isStream: false,
       setResult: expect.any(Function),
       result: {
         data: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,7 +32,9 @@ export type PolymorphicExecuteArguments =
       Maybe<GraphQLTypeResolver<any, any>>
     ];
 
-export type ExecuteFunction = (...args: PolymorphicExecuteArguments) => PromiseOrValue<ExecutionResult>;
+export type ExecuteFunction = (
+  ...args: PolymorphicExecuteArguments
+) => PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>>;
 
 export type PolymorphicSubscribeArguments =
   | [SubscriptionArgs]
@@ -74,16 +76,34 @@ export type OnResolverCalledHooks<ContextType = DefaultContext, ArgsType = Defau
   true
 >;
 
+export type OnExecutionDoneHookResult = {
+  onNext?: (options: { result: ExecutionResult; setResult: (newResult: ExecutionResult) => void }) => void;
+  onEnd?: () => void;
+};
+
+export type onSubscriptionDoneResult = OnExecutionDoneHookResult;
+
+type ExecuteDoneNonStreamOptions = {
+  result: ExecutionResult;
+  setResult: (newResult: ExecutionResult | AsyncIterableIterator<ExecutionResult>) => void;
+  isStream: false;
+};
+
+type ExecuteDoneStreamOptions = {
+  result: AsyncIterableIterator<ExecutionResult>;
+  setResult: (newResult: ExecutionResult | AsyncIterableIterator<ExecutionResult>) => void;
+  isStream: true;
+};
+
+export type ExecuteDoneOptions = ExecuteDoneNonStreamOptions | ExecuteDoneStreamOptions;
+
 export type OnExecuteHookResult<ContextType = DefaultContext> = {
-  onExecuteDone?: (options: { result: ExecutionResult; setResult: (newResult: ExecutionResult) => void }) => void;
+  onExecuteDone?: (options: ExecuteDoneOptions) => OnExecutionDoneHookResult | void;
   onResolverCalled?: OnResolverCalledHooks<ContextType>;
 };
 
 export type OnSubscribeHookResult<ContextType = DefaultContext> = {
-  onSubscribeResult?: (options: {
-    result: AsyncIterableIterator<ExecutionResult> | ExecutionResult;
-    setResult: (newResult: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => void;
-  }) => void;
+  onSubscribeResult?: (options: ExecuteDoneOptions) => void | onSubscriptionDoneResult;
   onResolverCalled?: OnResolverCalledHooks<ContextType>;
 };
 


### PR DESCRIPTION
~~This is a POC for hooking into the phases of the async iterable returned from execute or subscribe (similar to the approach described in https://github.com/dotansimha/envelop/issues/182).~~

It is currently based upon ~~https://github.com/dotansimha/envelop/pull/187 and~~ https://github.com/dotansimha/envelop/pull/183. It should be rebased once it is merged into main.~~

The idea is to let the `onSubscribeResult` and `onExecuteDone` handlers return an object with the properties `onNext` and `onFinal` which will be invoked in case we have an async iterable.

~~Currently, tests are missing, as I first want to gather feedback on whether this could be the way to go.~~

~~The relevant commit is https://github.com/dotansimha/envelop/pull/211/commits/aea90c4b054c461aab2cab48bdfdb6e67c9dfd33~~