### PR TITLE
Save id of persisted operation to the context

### DIFF
--- a/.changeset/perfect-toys-compete.md
+++ b/.changeset/perfect-toys-compete.md
@@ -1,0 +1,5 @@
+---
+'@envelop/persisted-operations': minor
+---
+
+Save operation id to the context

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -1,5 +1,5 @@
 import { Plugin } from '@envelop/types';
-import { DocumentNode, ExecutionArgs, GraphQLError, parse } from 'graphql';
+import { DocumentNode, GraphQLError, parse } from 'graphql';
 
 export class NonPersistedOperationError extends Error {}
 

--- a/packages/plugins/persisted-operations/tests/persisted-operations.spec.ts
+++ b/packages/plugins/persisted-operations/tests/persisted-operations.spec.ts
@@ -37,7 +37,7 @@ describe('usePersistedOperations', () => {
       testSchema
     );
 
-    const result = await testInstance.execute(`persisted_1`);
+    const result = await testInstance.execute(`persisted_1`, {}, {});
     expect(result.errors).toBeUndefined();
     expect(result.data.foo).toBe('test');
   });
@@ -57,7 +57,7 @@ describe('usePersistedOperations', () => {
       testSchema
     );
 
-    const result = await testInstance.execute(`persisted_1`);
+    const result = await testInstance.execute(`persisted_1`, {}, {});
     expect(result.errors).toBeUndefined();
     expect(result.data.foo).toBe('test');
   });


### PR DESCRIPTION
No way to actually access context on parse phase so used a workaround.