### PR TITLE
Fix root operation in newrelic plugin

### DIFF
--- a/.changeset/brown-moles-kick.md
+++ b/.changeset/brown-moles-kick.md
@@ -1,0 +1,7 @@
+---
+'@envelop/newrelic': patch
+---
+
+Fixed retrieval of root operation from Envelop context
+
+NOTE: There is a breaking behaviour. When using the `operationNameProperty` option, this will be checked against the `document` object rather than the `operation` object as in initial version.

--- a/packages/plugins/newrelic/README.md
+++ b/packages/plugins/newrelic/README.md
@@ -44,7 +44,7 @@ const getEnveloped = envelop({
       trackResolvers: true, // default `false`. When set to `true`, track resolvers as segments to monitor their performance
       includeResolverArgs: false, // default `false`. When set to `true`, includes all the arguments passed to resolvers with their values
       rootFieldsNaming: true, // default `false`. When set to `true` append the names of operation root fields to the transaction name
-      operationNameProperty: 'hash', // default empty. When passed will check for the property name passed, within the operation object. Will eventually use its value as operation name. Useful for custom operation properties (e.g. queryId/hash)
+      operationNameProperty: 'id', // default empty. When passed will check for the property name passed, within the document object. Will eventually use its value as operation name. Useful for custom document properties (e.g. queryId/hash)
     }),
   ],
 });


### PR DESCRIPTION
## Description

As surfaced in #307 , the newrelic plugin was relying on the operation object being available in context.
Turns out this is not added by Envelop, but might be added by the GraphQL server implementation.

I have refactored the plugin to rely on properties set by Envelop, so it can be trusted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The PR actually introduces a breaking behaviour.
The option that is passed to set a custom operation name, will look within the document object rather than the operation object.

This is documented in changeset, and I'm pretty sure it won't create issues since the plugin is very fresh and this goes beyond standard usage.