### PR TITLE
useOperationFieldPermissions

### DIFF
--- a/.changeset/smooth-poems-develop.md
+++ b/.changeset/smooth-poems-develop.md
@@ -1,0 +1,5 @@
+---
+'@envelop/operation-field-permissions': patch
+---
+
+New plugin: operation-field-permissions

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ We provide a few built-in plugins within the `@envelop/core`, and many more plug
 | useLiveQuery     | [`@envelop/live-query`](./packages/plugins/live-query)   | The easiest way of adding live queries to your GraphQL server!                                                                       |
 | useFragmentArguments     | [`@envelop/fragment-arguments`](./packages/plugins/fragment-arguments)   | Adds support for using arguments on fragments                                                                      |
 | useApolloServerErrors     | [`@envelop/apollo-server-errors`](./packages/plugins/apollo-server-errors)   | Exposes execution error in the same structure as Apollo-Server                                                                      |
+| useOperationFieldPermissions     | [`@envelop/operation-field-permissions`](./packages/plugins/operation-field-permissions)   | Extended validation rule for creating user-aware permissions, based on types and fields                                                                      |
 
 ## Sharing / Composing `envelop`s
 

--- a/packages/plugins/operation-field-permissions/CHANGELOG.md
+++ b/packages/plugins/operation-field-permissions/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @envelop/operation-field-permissions

--- a/packages/plugins/operation-field-permissions/CHANGELOG.md
+++ b/packages/plugins/operation-field-permissions/CHANGELOG.md
@@ -1,1 +1,0 @@
-# @envelop/operation-field-permissions

--- a/packages/plugins/operation-field-permissions/README.md
+++ b/packages/plugins/operation-field-permissions/README.md
@@ -1,6 +1,8 @@
 ## `@envelop/operation-field-permissions`
 
-Disallow executing operations that select certain fields. Useful if you want to restrict the scope of certain public API users to a subset of the public GraphQL schema.
+Disallow executing operations that select certain fields. Useful if you want to restrict the scope of certain public API users to a subset of the public GraphQL schema, without triggering execution (e.g. how [graphql-shield](https://github.com/maticzav/graphql-shield) works).
+
+**Note:** This plugin and authorization on a resolver level (or via middleware) are complementary. You should still verify whether a viewer is allowed to access certain data within your resolvers.
 
 ## Installation
 

--- a/packages/plugins/operation-field-permissions/README.md
+++ b/packages/plugins/operation-field-permissions/README.md
@@ -1,0 +1,63 @@
+## `@envelop/operation-field-permissions`
+
+Disallow executing operations that select certain fields. Useful if you want to restrict the scope of certain public API users to a subset of the public GraphQL schema.
+
+## Installation
+
+```bash
+yarn add @envelop/operation-field-permissions
+```
+
+## Usage Example
+
+```ts
+import { envelop, useSchema } from '@envelop/core';
+import { useOperationFieldPermissions } from 'envelop/operation-field-permissions';
+
+const getEnveloped = envelop({
+  plugins: [
+    useSchema(schema),
+    useOperationFieldPermissions({
+      // we can access graphql context here
+      getPermissions: async context => new Set(['Query.greetings', ...context.viewer.permissions]),
+    }),
+    /* ... other envelops */
+  ],
+});
+```
+
+**Schema**
+
+```graphql
+type Query {
+  greetings: [String!]!
+  foo: String
+}
+```
+
+**Operation**
+
+```graphql
+query {
+  foo
+}
+```
+
+**Response**
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Insufficient permissions for selecting 'Query.foo'.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 2
+        }
+      ]
+    }
+  ]
+}
+```

--- a/packages/plugins/operation-field-permissions/package.json
+++ b/packages/plugins/operation-field-permissions/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@envelop/operation-field-permissions",
+  "version": "0.0.1",
+  "author": "Laurin Quast <laurinquast@googlemail.com.com>",
+  "license": "MIT",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/envelop.git",
+    "directory": "packages/plugins/operation-field-permissions"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {
+    "@envelop/extended-validation": "0.2.0",
+    "@envelop/core": "0.3.1"
+  },
+  "devDependencies": {
+    "bob-the-bundler": "1.4.1",
+    "graphql": "15.5.1",
+    "typescript": "4.3.2"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/operation-field-permissions/src/index.ts
+++ b/packages/plugins/operation-field-permissions/src/index.ts
@@ -1,4 +1,4 @@
-import { envelop, Plugin, useEnvelop, useExtendContext } from '@envelop/core';
+import { Plugin, useExtendContext } from '@envelop/core';
 import { ExtendedValidationRule, useExtendedValidation } from '@envelop/extended-validation';
 import { GraphQLType, GraphQLList, GraphQLNonNull, GraphQLError } from 'graphql';
 
@@ -76,17 +76,20 @@ type OperationScopeOptions<TContext> = {
 
 const defaultFormatError = (schemaCoordinate: string) => `Insufficient permissions for selecting '${schemaCoordinate}'.`;
 
-export const useOperationPermissions = <TContext>(opts: OperationScopeOptions<TContext>): Plugin =>
-  useEnvelop(
-    envelop({
-      plugins: [
+export const useOperationPermissions = <TContext>(opts: OperationScopeOptions<TContext>): Plugin => {
+  return {
+    onPluginInit({ addPlugin }) {
+      addPlugin(
         useExtendedValidation({
           rules: [
             OperationScopeRule({
               formatError: opts.formatError ?? defaultFormatError,
             }),
           ],
-        }),
+        })
+      );
+
+      addPlugin(
         useExtendContext(async context => {
           const permissions = await opts.getPermissions(context as TContext);
 
@@ -102,7 +105,8 @@ export const useOperationPermissions = <TContext>(opts: OperationScopeOptions<TC
           return {
             [OPERATION_PERMISSIONS_SYMBOL]: scopeContext,
           };
-        }),
-      ],
-    })
-  );
+        })
+      );
+    },
+  };
+};

--- a/packages/plugins/operation-field-permissions/src/index.ts
+++ b/packages/plugins/operation-field-permissions/src/index.ts
@@ -1,0 +1,108 @@
+import { envelop, Plugin, useEnvelop, useExtendContext } from '@envelop/core';
+import { ExtendedValidationRule, useExtendedValidation } from '@envelop/extended-validation';
+import { GraphQLType, GraphQLList, GraphQLNonNull, GraphQLError } from 'graphql';
+
+type PromiseOrValue<T> = T | Promise<T>;
+
+const getWrappedType = (graphqlType: GraphQLType): Exclude<GraphQLType, GraphQLList<any> | GraphQLNonNull<any>> => {
+  if (graphqlType instanceof GraphQLList || graphqlType instanceof GraphQLNonNull) {
+    return getWrappedType(graphqlType.ofType);
+  }
+  return graphqlType;
+};
+
+const OPERATION_PERMISSIONS_SYMBOL = Symbol('OPERATION_PERMISSIONS_SYMBOL');
+
+const getWildcardTypes = (scope: Set<string>): Set<string> => {
+  const wildcardTypes = new Set<string>();
+  for (const item of scope) {
+    if (item.endsWith('*')) {
+      const [typeName] = item.split('.');
+      wildcardTypes.add(typeName);
+    }
+  }
+  return wildcardTypes;
+};
+
+const toSet = (input: string | Set<string>) => (typeof input === 'string' ? new Set([input]) : input);
+
+type ScopeContext = {
+  allowAll: boolean;
+  wildcardTypes: Set<string>;
+  schemaCoordinates: Set<string>;
+};
+
+const getContext = (input: unknown): ScopeContext => {
+  if (typeof input !== 'object' || !input || !(OPERATION_PERMISSIONS_SYMBOL in input)) {
+    throw new Error('OperationScopeRule was used without context.');
+  }
+  return input[OPERATION_PERMISSIONS_SYMBOL];
+};
+
+type OperationScopeRuleOptions = {
+  formatError: (schemaCoordinate: string) => string;
+};
+
+/**
+ * Validate whether a user is allowed to execute a certain GraphQL operation.
+ */
+const OperationScopeRule =
+  (options: OperationScopeRuleOptions): ExtendedValidationRule =>
+  (context, executionArgs) => {
+    const permissionContext = getContext(executionArgs.contextValue);
+    return {
+      Field(node) {
+        const parentType = context.getParentType();
+        if (parentType) {
+          const wrappedType = getWrappedType(parentType);
+          const schemaCoordinate = `${wrappedType.name}.${node.name.value}`;
+
+          if (
+            !permissionContext.allowAll &&
+            !permissionContext.wildcardTypes.has(wrappedType.name) &&
+            !permissionContext.schemaCoordinates.has(schemaCoordinate)
+          ) {
+            context.reportError(new GraphQLError(options.formatError(schemaCoordinate), [node]));
+          }
+        }
+      },
+    };
+  };
+
+type OperationScopeOptions<TContext> = {
+  getPermissions: (context: TContext) => PromiseOrValue<Set<string> | string>;
+  formatError?: OperationScopeRuleOptions['formatError'];
+};
+
+const defaultFormatError = (schemaCoordinate: string) => `Insufficient permissions for selecting '${schemaCoordinate}'.`;
+
+export const useOperationPermissions = <TContext>(opts: OperationScopeOptions<TContext>): Plugin =>
+  useEnvelop(
+    envelop({
+      plugins: [
+        useExtendedValidation({
+          rules: [
+            OperationScopeRule({
+              formatError: opts.formatError ?? defaultFormatError,
+            }),
+          ],
+        }),
+        useExtendContext(async context => {
+          const permissions = await opts.getPermissions(context as TContext);
+
+          const schemaCoordinates = toSet(permissions);
+          const wildcardTypes = getWildcardTypes(schemaCoordinates);
+
+          const scopeContext: ScopeContext = {
+            schemaCoordinates,
+            wildcardTypes,
+            allowAll: schemaCoordinates.has('*'),
+          };
+
+          return {
+            [OPERATION_PERMISSIONS_SYMBOL]: scopeContext,
+          };
+        }),
+      ],
+    })
+  );

--- a/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
+++ b/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
@@ -1,0 +1,95 @@
+import { useOperationPermissions } from '../src';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { createTestkit } from '@envelop/testing';
+
+const schema = makeExecutableSchema({
+  typeDefs: [
+    /* GraphQL */ `
+      type Query {
+        greetings: [String!]
+        foo: String
+        user: User
+      }
+
+      type User {
+        id: ID!
+      }
+    `,
+  ],
+  resolvers: {},
+});
+
+const query = /* GraphQL */ `
+  {
+    greetings
+    foo
+    user {
+      id
+    }
+  }
+`;
+
+describe('useOperationPermissions', () => {
+  it('allow everything', async () => {
+    const kit = createTestkit(
+      [
+        useOperationPermissions({
+          getPermissions: () => '*',
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(query);
+    expect(result.errors).toBeUndefined();
+  });
+  it('allow only one field', async () => {
+    const kit = createTestkit(
+      [
+        useOperationPermissions({
+          getPermissions: () => 'Query.greetings',
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(query);
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Insufficient permissions for selecting 'Query.foo'.],
+  [GraphQLError: Insufficient permissions for selecting 'Query.user'.],
+  [GraphQLError: Insufficient permissions for selecting 'User.id'.],
+]
+`);
+  });
+  it('allow wildcard for types', async () => {
+    const kit = createTestkit(
+      [
+        useOperationPermissions({
+          getPermissions: () => 'Query.*',
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(query);
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Insufficient permissions for selecting 'User.id'.],
+]
+`);
+  });
+  it('allow selecting specific fields', async () => {
+    const kit = createTestkit(
+      [
+        useOperationPermissions({
+          getPermissions: () => new Set(['Query.greetings', 'Query.foo', 'Query.user', 'User.id']),
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(query);
+    expect(result.errors).toBeUndefined();
+  });
+});

--- a/website/src/lib/plugins.ts
+++ b/website/src/lib/plugins.ts
@@ -218,4 +218,11 @@ export const pluginsArr: RawPlugin[] = [
     iconUrl: '/assets/logos/apollo.png',
     tags: ['utilities', 'error-handling'],
   },
+  {
+    identifier: 'use-operation-field-permissions',
+    title: 'useOperationFieldPermissions',
+    npmPackage: '@envelop/operation-field-permissions',
+    iconUrl: '/assets/logos/graphql.png',
+    tags: ['security', 'authorization'],
+  },
 ];


### PR DESCRIPTION
This envelop plugin restricts operation execution via schema coordinates/type wildcards.

Closes https://github.com/dotansimha/envelop/issues/240

Feel free to propose a better plugin name