### PR TITLE
Initial implementation of persisted queries plugin

### DIFF
--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -35,7 +35,7 @@ const getEnveloped = envelop({
 
 -----
 
-await persistedQueriesStore.build(); // get store ready, in this case by loading persisted-quries files
+await persistedQueriesStore.load(); // get store ready, in this case by loading persisted-quries files
 
 server.listen() // once queries are loaded you can safely start the server
 ```

--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -1,4 +1,4 @@
-## `@envelop/persisted-operations`
+## `@envelop/persisted-queries`
 
 TODO
 
@@ -9,8 +9,6 @@ yarn add @envelop/persisted-queries
 ```
 
 ## Basic Usage
-
-TODO
 
 For convenience the plugin expose a Class which allow you to setup a basic store from one or more JSON files.  
 You can use this or build your own store that implements `PersistedQueriesStore` typescript interface exported by the plugin.
@@ -29,28 +27,36 @@ const getEnveloped = envelop({
   plugins: [
     usePersistedQueries({
       store: persistedQueriesStore,
-      onlyPersisted: true,
-      setQueryId: (context) => context.request.body.queryId
+      onlyPersisted: true, // default `false`. When set to true, will reject queries that don't have a valid query id
     }),
     // ... other plugins ...
   ],
 });
 
-...
+-----
 
-const { parse, validate, contextFactory, execute, schema } = config.getEnveloped({ request });
-
-...
-
-await persistedQueriesStore.buildStore(); // load persisted-quries files
+await persistedQueriesStore.buildStore(); // get store ready, in this case by loading persisted-quries files
 
 server.listen() // once queries are loaded you can safely start the server
 ```
 
+TODO: explain default behaviour which identifies query id from standard "query" param (GraphQL source)
+
 ## Advanced usage
 
-TODO
+In order to build custom logic you probably want to pass the request object (or part of it) to `getEnveloped`, so that this will be available as the initial context
 
-- default behaviour to identify query id from standard "query" param
-- how to match ids from a single queries list
-- pass request object to getEnveloped, in order to set initial context necessary to access request data
+```ts
+httpServer.on('request', (request, response) => {
+  const { parse, validate, contextFactory, execute, schema } = getEnveloped({ request });
+  // ...
+}
+```
+
+TODO, describe the following:
+
+- lists are named after file name (without extension) when using `JsonFilesStore`
+- build custom logic to set query id: `setQueryId: (context) => context.request.body.queryId // set custom logic to get queryId`
+- how to match ids from a single queries list: `pickSingleList: (context) => `${context.request.headers.applicationName}_persistedQueries``
+- `setQueryId` and `pickSingleList` can return undefined, explain what happens
+- building your own store

--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -1,0 +1,51 @@
+## `@envelop/persisted-operations`
+
+TODO
+
+## Getting Started
+
+```
+yarn add @envelop/persisted-queries
+```
+
+## Basic Usage
+
+TODO
+
+For convenience the plugin expose a Class which allow you to setup a basic store from one or more JSON files.  
+You can use this or build your own store that implements `PersistedQueriesStore` typescript interface exported by the plugin.
+
+```ts
+import { resolve } from 'path';
+import { envelop } from '@envelop/core';
+import { usePersistedQueries, JsonFilesStore } from '@envelop/persisted-queries';
+
+const persistedQueriesStore = new JsonFilesStore([
+  resolve(process.cwd(), 'assets/clientOne_persistedQueries.json'),
+  resolve(process.cwd(), 'assets/clientTwo_persistedQueries.json'),
+]);
+
+const getEnveloped = envelop({
+  plugins: [
+    usePersistedQueries({
+      store: persistedQueriesStore,
+      onlyPersisted: true,
+      setQueryId: (context) => context.request.body.queryId
+    }),
+    // ... other plugins ...
+  ],
+});
+
+...
+
+await persistedQueriesStore.buildStore(); // load persisted-quries files
+server.listen() // once queries are loaded you can safely start the server
+```
+
+## Advanced usage
+
+TODO
+
+- default behaviour to identify query id from standard "query" param
+- how to match ids from a single queries list
+- 

--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -35,7 +35,7 @@ const getEnveloped = envelop({
 
 -----
 
-await persistedQueriesStore.buildStore(); // get store ready, in this case by loading persisted-quries files
+await persistedQueriesStore.build(); // get store ready, in this case by loading persisted-quries files
 
 server.listen() // once queries are loaded you can safely start the server
 ```
@@ -55,8 +55,9 @@ httpServer.on('request', (request, response) => {
 
 TODO, describe the following:
 
-- lists are named after file name (without extension) when using `JsonFilesStore`
+-  when using `JsonFilesStore`, lists are named after file name (without extension)
 - build custom logic to set query id: `setQueryId: (context) => context.request.body.queryId // set custom logic to get queryId`
-- how to match ids from a single queries list: `pickSingleList: (context) => `${context.request.headers.applicationName}_persistedQueries``
+- how to match ids from a single queries list: `` pickSingleList: (context) => `${context.request.headers.applicationName}_persistedQueries` ``
 - `setQueryId` and `pickSingleList` can return undefined, explain what happens
 - building your own store
+- update the store during runtime with updated or new lists, without restarting the server

--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -38,7 +38,12 @@ const getEnveloped = envelop({
 
 ...
 
+const { parse, validate, contextFactory, execute, schema } = config.getEnveloped({ request });
+
+...
+
 await persistedQueriesStore.buildStore(); // load persisted-quries files
+
 server.listen() // once queries are loaded you can safely start the server
 ```
 
@@ -48,4 +53,4 @@ TODO
 
 - default behaviour to identify query id from standard "query" param
 - how to match ids from a single queries list
-- 
+- pass request object to getEnveloped, in order to set initial context necessary to access request data

--- a/packages/plugins/persisted-queries/README.md
+++ b/packages/plugins/persisted-queries/README.md
@@ -27,7 +27,7 @@ const getEnveloped = envelop({
   plugins: [
     usePersistedQueries({
       store: persistedQueriesStore,
-      onlyPersisted: true, // default `false`. When set to true, will reject queries that don't have a valid query id
+      onlyPersisted: true, // default `false`. When set to true, will reject requests that don't have a valid query id
     }),
     // ... other plugins ...
   ],
@@ -58,6 +58,8 @@ TODO, describe the following:
 -  when using `JsonFilesStore`, lists are named after file name (without extension)
 - build custom logic to set query id: `setQueryId: (context) => context.request.body.queryId // set custom logic to get queryId`
 - how to match ids from a single queries list: `` pickSingleList: (context) => `${context.request.headers.applicationName}_persistedQueries` ``
+- custom handling of file read errors `.then(lists => { listsResults.forEach(listResult => { if (listResult instanceof Error) { console.log('error', listResult.message); } }) });`
 - `setQueryId` and `pickSingleList` can return undefined, explain what happens
+- `documentId` property set in context with query id; to be retrieved for other usage (e.g. logging)
 - building your own store
 - update the store during runtime with updated or new lists, without restarting the server

--- a/packages/plugins/persisted-queries/package.json
+++ b/packages/plugins/persisted-queries/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@envelop/persisted-queries",
+  "version": "0.0.1",
+  "author": "Santino Puleio <santinopuleio@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/envelop.git",
+    "directory": "packages/plugins/persisted-queries"
+  },
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "prepack": "bob prepack"
+  },
+  "devDependencies": {
+    "bob-the-bundler": "1.4.1",
+    "graphql": "15.5.1",
+    "typescript": "4.3.4"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/persisted-queries/src/index.ts
+++ b/packages/plugins/persisted-queries/src/index.ts
@@ -1,0 +1,2 @@
+export * from './jsonFilesStore';
+export * from './plugin';

--- a/packages/plugins/persisted-queries/src/jsonFilesStore.ts
+++ b/packages/plugins/persisted-queries/src/jsonFilesStore.ts
@@ -15,18 +15,21 @@ export class JsonFilesStore implements PersistedQueriesStore {
     return this.store;
   }
 
-  public load(): Promise<string[]> {
+  public load(whitelist: string[] = []): Promise<string[]> {
     const readListPromises = [];
 
     for (const filePath of this.paths) {
       const extension = extname(filePath);
+      const listName = basename(filePath, extension);
 
       if (extension !== '.json') {
         console.error(`Persisted query file must be JSON format, received: ${filePath}`);
         continue;
+      } else if (whitelist.length && !whitelist.includes(listName)) {
+        // in case of whitelist (most likely to update existing store), only process lists whose name is whitelisted
+        continue;
       }
 
-      const listName = basename(filePath, extension);
       const queriesFile = filePath && (isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath));
 
       readListPromises.push(

--- a/packages/plugins/persisted-queries/src/jsonFilesStore.ts
+++ b/packages/plugins/persisted-queries/src/jsonFilesStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { basename, extname, isAbsolute, resolve } from 'path';
 import { readFile } from 'fs/promises';
 import { PersistedQueriesStore, PersistedQueriesStoreList } from './plugin';
@@ -14,7 +15,7 @@ export class JsonFilesStore implements PersistedQueriesStore {
     return this.store;
   }
 
-  public async build(): Promise<void> {
+  public load(): Promise<string[]> {
     const readListPromises = [];
 
     for (const filePath of this.paths) {
@@ -33,13 +34,15 @@ export class JsonFilesStore implements PersistedQueriesStore {
           .then(content => {
             console.info(`Successfully loaded persisted queries from "${listName}"`);
             this.store.set(listName, JSON.parse(content));
+            return filePath;
           })
-          .catch(() => {
+          .catch(error => {
             console.error(`Could not load persisted queries from: ${filePath}`);
+            return error;
           })
       );
     }
 
-    await Promise.all(readListPromises);
+    return Promise.all(readListPromises);
   }
 }

--- a/packages/plugins/persisted-queries/src/jsonFilesStore.ts
+++ b/packages/plugins/persisted-queries/src/jsonFilesStore.ts
@@ -1,0 +1,45 @@
+import { basename, extname, isAbsolute, resolve } from 'path';
+import { readFile } from 'fs/promises';
+import { PersistedQueriesStore, PersistedQueriesStoreList } from './plugin';
+
+export class JsonFilesStore implements PersistedQueriesStore {
+  private store: PersistedQueriesStoreList = new Map();
+  private paths: string[];
+
+  constructor(jsonFilePaths: string[]) {
+    this.paths = jsonFilePaths;
+  }
+
+  listsMap(): PersistedQueriesStoreList {
+    return this.store;
+  }
+
+  public async buildStore(): Promise<void> {
+    const readListPromises = [];
+
+    for (const filePath of this.paths) {
+      const extension = extname(filePath);
+
+      if (extension !== '.json') {
+        console.error(`Persisted query file must be JSON format, received: ${filePath}`);
+        continue;
+      }
+
+      const listName = basename(filePath, extension);
+      const queriesFile = filePath && (isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath));
+
+      readListPromises.push(
+        readFile(queriesFile, 'utf8')
+          .then(content => {
+            console.info(`Successfully loaded persisted queries from "${listName}"`);
+            this.store.set(listName, JSON.parse(content));
+          })
+          .catch(() => {
+            console.error(`Could not load persisted queries from: ${filePath}`);
+          })
+      );
+    }
+
+    await Promise.all(readListPromises);
+  }
+}

--- a/packages/plugins/persisted-queries/src/jsonFilesStore.ts
+++ b/packages/plugins/persisted-queries/src/jsonFilesStore.ts
@@ -10,11 +10,11 @@ export class JsonFilesStore implements PersistedQueriesStore {
     this.paths = jsonFilePaths;
   }
 
-  listsMap(): PersistedQueriesStoreList {
+  get(): PersistedQueriesStoreList {
     return this.store;
   }
 
-  public async buildStore(): Promise<void> {
+  public async build(): Promise<void> {
     const readListPromises = [];
 
     for (const filePath of this.paths) {

--- a/packages/plugins/persisted-queries/src/plugin.ts
+++ b/packages/plugins/persisted-queries/src/plugin.ts
@@ -8,7 +8,7 @@ export type PersistedQueriesStoreList = Map<string, { [key: string]: string }>;
 
 export interface PersistedQueriesStore {
   get(): PersistedQueriesStoreList;
-  build(): Promise<void>;
+  load(): Promise<string[]>;
 }
 
 interface PluginContext {

--- a/packages/plugins/persisted-queries/src/plugin.ts
+++ b/packages/plugins/persisted-queries/src/plugin.ts
@@ -8,7 +8,6 @@ export type PersistedQueriesStoreList = Map<string, { [key: string]: string }>;
 
 export interface PersistedQueriesStore {
   get(): PersistedQueriesStoreList;
-  load(): Promise<string[]>;
 }
 
 interface PluginContext {

--- a/packages/plugins/persisted-queries/src/plugin.ts
+++ b/packages/plugins/persisted-queries/src/plugin.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Plugin, DefaultContext } from '@envelop/core';
 import { DocumentNode, parse, Source, GraphQLError } from 'graphql';
 
@@ -17,8 +18,8 @@ interface PluginContext {
 export type UsePersistedQueriesOptions = {
   store: PersistedQueriesStore;
   onlyPersisted?: boolean;
-  setQueryId?: (context: Readonly<DefaultContext>) => string;
-  pickSingleList?: (context: Readonly<DefaultContext>) => string;
+  setQueryId?: (context: Readonly<DefaultContext>) => string | undefined;
+  pickSingleList?: (context: Readonly<DefaultContext>) => string | undefined;
 };
 
 const DEFAULT_OPTIONS: Omit<UsePersistedQueriesOptions, 'store'> = {

--- a/packages/plugins/persisted-queries/src/plugin.ts
+++ b/packages/plugins/persisted-queries/src/plugin.ts
@@ -7,8 +7,8 @@ const contextProperty = 'documentId';
 export type PersistedQueriesStoreList = Map<string, { [key: string]: string }>;
 
 export interface PersistedQueriesStore {
-  listsMap(): PersistedQueriesStoreList;
-  buildStore(): Promise<void>;
+  get(): PersistedQueriesStoreList;
+  build(): Promise<void>;
 }
 
 interface PluginContext {
@@ -31,10 +31,10 @@ export const usePersistedQueries = (rawOptions: UsePersistedQueriesOptions): Plu
     ...DEFAULT_OPTIONS,
     ...(rawOptions || {}),
   };
-  const store = options.store.listsMap();
 
   return {
     onParse({ context, params, extendContext, setParsedDocument }) {
+      const store = options.store.get(); // retrieve fresh instance of store Map
       const queryId = options.setQueryId ? options.setQueryId(context) : queryIdFromSource(params.source);
       const pickedListName = options.pickSingleList && options.pickSingleList(context);
       const pickedList = pickedListName ? store.get(pickedListName) : undefined;

--- a/packages/plugins/persisted-queries/src/plugin.ts
+++ b/packages/plugins/persisted-queries/src/plugin.ts
@@ -1,0 +1,96 @@
+import { Plugin, DefaultContext } from '@envelop/core';
+import { DocumentNode, parse, Source, GraphQLError } from 'graphql';
+
+const contextProperty = 'documentId';
+
+export type PersistedQueriesStoreList = Map<string, { [key: string]: string }>;
+
+export interface PersistedQueriesStore {
+  listsMap(): PersistedQueriesStoreList;
+  buildStore(): Promise<void>;
+}
+
+interface PluginContext {
+  [contextProperty]?: string;
+}
+
+export type UsePersistedQueriesOptions = {
+  store: PersistedQueriesStore;
+  onlyPersisted?: boolean;
+  setQueryId?: (context: Readonly<DefaultContext>) => string;
+  pickSingleList?: (context: Readonly<DefaultContext>) => string;
+};
+
+const DEFAULT_OPTIONS: Omit<UsePersistedQueriesOptions, 'store'> = {
+  onlyPersisted: false,
+};
+
+export const usePersistedQueries = (rawOptions: UsePersistedQueriesOptions): Plugin<PluginContext> => {
+  const options: UsePersistedQueriesOptions = {
+    ...DEFAULT_OPTIONS,
+    ...(rawOptions || {}),
+  };
+  const store = options.store.listsMap();
+
+  return {
+    onParse({ context, params, extendContext, setParsedDocument }) {
+      const queryId = options.setQueryId ? options.setQueryId(context) : queryIdFromSource(params.source);
+      const pickedListName = options.pickSingleList && options.pickSingleList(context);
+      const pickedList = pickedListName ? store.get(pickedListName) : undefined;
+      const hasPickedList = Boolean(pickedList);
+
+      // if a list has been picked, check for persisted query within that list
+      if (queryId && pickedListName && hasPickedList && pickedList![queryId]) {
+        return handleSuccess(setParsedDocument, extendContext, pickedList![queryId], queryId, pickedListName);
+      }
+
+      // if no list picked, search throughout all persisted queries lists available
+      if (queryId && !pickedListName) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [listName, queries] of store) {
+          if (queries[queryId]) {
+            return handleSuccess(setParsedDocument, extendContext, queries[queryId], queryId, listName);
+          }
+        }
+      }
+
+      // no match found, if onlyPersisted throw error; otherwise oepration flow can progress
+      if (options.onlyPersisted) return handleFailure(queryId, pickedListName, hasPickedList);
+    },
+  };
+};
+
+function queryIdFromSource(source: string | Source): string | undefined {
+  return typeof source === 'string' && source.length && source.indexOf('{') === -1 ? source : undefined;
+}
+
+function handleSuccess(
+  setParsedDocument: (doc: DocumentNode) => void,
+  extendContext: (contextExtension: PluginContext) => void,
+  rawDocument: string | Source,
+  queryId: string,
+  listName: string
+) {
+  console.info(`Persisted query matched in "${listName}", with id "${queryId}"`);
+
+  extendContext({ [contextProperty]: queryId });
+  setParsedDocument(parse(rawDocument));
+}
+
+function handleFailure(queryId?: string, listName?: string, isListAvailable?: boolean) {
+  if (!queryId) {
+    console.error('Query id not sent when "onlyPersisted" is set to true, unable to process request');
+
+    throw new GraphQLError('Must provide query id');
+  }
+
+  console.error(
+    // eslint-disable-next-line no-nested-ternary
+    listName
+      ? isListAvailable
+        ? `Unable to match query with id "${queryId}", within requested list "${listName}"`
+        : `Requested persisted queries list not available. List: "${listName}", query id "${queryId}"`
+      : `Unable to match query with id "${queryId}", across all provided lists`
+  );
+  throw new GraphQLError(listName ? 'Unable to match query within requested list' : `Unable to match query with id "${queryId}"`);
+}


### PR DESCRIPTION
## Description

This draft PR is for implementing a persisted queries plugin with the following goals:
- Handle multiple persisted queries list, to potentially support multiple clients integrating with a single GraphQL server
- Provide a basic implementation for a store that handle static JSON files (as generated by most common clients)
- Provide a mechanism to update the store at runtime, even targeting specific lists only (whitelist)

Since the plugin is meant to support multiple JSON files, it also offers an option to match from a single list only.
This allows developers to implement logic to target a single list, so you can avoid matching against all lists when you know your request comes from a specific application and so must be available in a single list.
The point is not necessarily to improve performance, in fact matching against multiple lists might still be implemented with o(1) cost (since it's just a lookup job), but more about offering proper support for multiple applications; in fact it might be that different applications have one or more equal queries, that would result in the same SHA256 id. By handling multiple and separate queries lists there is no worry of conflicts and file might just be provided to the server as they're generated by clients.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Being just a draft, this is open for a conversation.
I am planning to add tests once we finalise the strategy.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This plugin might be seen in conflict with the existing persisted-oeprations, but it differs as it is more intended (but not limited) to handle static lists.  
The main difference is the concept of handling multiple lists to support multiple client applications.  
Also this plugin provides an implementation for a store (again targeting a basic usage with static files), which is useful to be used as a guide for developers wanting to implement their own store from other sources (such as databases).

Ultimately I am open to merge the two plugins so that we offer a solution that is flexible enough and provides a basic store implementation.