### PR TITLE
improve disable introspection with conditional

### DIFF
--- a/.changeset/green-mails-tickle.md
+++ b/.changeset/green-mails-tickle.md
@@ -1,0 +1,5 @@
+---
+'@envelop/disable-introspection': minor
+---
+
+add optional conditional "disableIf" with context and params

--- a/packages/plugins/disable-introspection/src/index.ts
+++ b/packages/plugins/disable-introspection/src/index.ts
@@ -1,10 +1,21 @@
 import { NoSchemaIntrospectionCustomRule } from 'graphql';
-import { Plugin } from '@envelop/types';
+import { Plugin, DefaultContext } from '@envelop/types';
 
-export const useDisableIntrospection = (): Plugin => {
+export interface DisableIntrospectionOptions {
+  disableIf?: (args: { context: DefaultContext; params: Parameters<NonNullable<Plugin['onValidate']>>[0]['params'] }) => boolean;
+}
+
+export const useDisableIntrospection = (options?: DisableIntrospectionOptions): Plugin => {
+  const disableIf = options?.disableIf;
   return {
-    onValidate: ({ addValidationRule }) => {
-      addValidationRule(NoSchemaIntrospectionCustomRule);
-    },
+    onValidate: disableIf
+      ? ({ addValidationRule, context, params }) => {
+          if (disableIf({ context, params })) {
+            addValidationRule(NoSchemaIntrospectionCustomRule);
+          }
+        }
+      : ({ addValidationRule }) => {
+          addValidationRule(NoSchemaIntrospectionCustomRule);
+        },
   };
 };


### PR DESCRIPTION
Currently the disable introspection plugin didn't allow any customization / conditionals, for example, to only disable introspection if "X" authorization header is not present/allowed

I had to use `Parameters<NonNullable<Plugin['onValidate']>>[0]['params']` because the params type was inlined, maybe it could be worth it to refactor all the plugins options types into their own interfaces