### PR TITLE
Added support for static call for `getEneveloped` 

### DIFF
--- a/.changeset/selfish-queens-argue.md
+++ b/.changeset/selfish-queens-argue.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Added the option to pass `null` to getEnveloped, in order to skip `OnEnveloped` phase

--- a/.changeset/unlucky-clouds-promise.md
+++ b/.changeset/unlucky-clouds-promise.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+'@envelop/types': patch
+---
+
+Allow passing `null` to getEnveloped in order to access static methods

--- a/examples/graphql-ws/index.ts
+++ b/examples/graphql-ws/index.ts
@@ -33,13 +33,15 @@ const getEnveloped = envelop({
   plugins: [useSchema(schema), useLogger(), useTiming()],
 });
 
-const { execute, subscribe } = getEnveloped({});
+// Set this to `null` in order to get the static instnaces of `getEnveloped`.
+const { execute, subscribe } = getEnveloped(null);
 
 useServer(
   {
     execute,
     subscribe,
     onSubscribe: async (ctx, msg) => {
+      // Here we can it again with a real initial context, which leads to a complete lifecycle execution.
       const { schema, contextFactory, parse, validate } = getEnveloped({
         connectionParams: ctx.connectionParams,
         socket: ctx.extra.socket,

--- a/packages/core/src/create.ts
+++ b/packages/core/src/create.ts
@@ -12,14 +12,21 @@ export function envelop<PluginsType extends Plugin<any>[]>(options: {
     orchestrator = traceOrchestrator(orchestrator);
   }
 
-  const getEnveloped = <TInitialContext extends ArbitraryObject>(initialContext: TInitialContext = {} as TInitialContext) => {
-    orchestrator.init(initialContext);
+  const getEnveloped = <TInitialContext extends ArbitraryObject>(initialContext: null | TInitialContext) => {
+    const initialCtx = initialContext || ({} as TInitialContext);
+
+    // If `initialContext` is null, we want to skip `onEnveloped` phase, so `init` function isn't called.
+    // This is done when there is a need for separating the static call (to get execute/subscribe) and the dynamic call (with the improved `context`).
+    if (initialContext !== null) {
+      orchestrator.init(initialCtx);
+    }
+
     const typedOrchestrator = orchestrator as EnvelopOrchestrator<TInitialContext, ComposeContext<PluginsType>>;
 
     return {
-      parse: typedOrchestrator.parse(initialContext),
-      validate: typedOrchestrator.validate(initialContext),
-      contextFactory: typedOrchestrator.contextFactory(initialContext),
+      parse: typedOrchestrator.parse(initialCtx),
+      validate: typedOrchestrator.validate(initialCtx),
+      contextFactory: typedOrchestrator.contextFactory(initialCtx),
       execute: typedOrchestrator.execute,
       subscribe: typedOrchestrator.subscribe,
       schema: typedOrchestrator.schema!,
@@ -28,5 +35,5 @@ export function envelop<PluginsType extends Plugin<any>[]>(options: {
 
   getEnveloped._plugins = options.plugins;
 
-  return getEnveloped as any;
+  return getEnveloped as GetEnvelopedFn<ComposeContext<PluginsType>>;
 }

--- a/packages/core/test/enveloped.spec.ts
+++ b/packages/core/test/enveloped.spec.ts
@@ -1,0 +1,38 @@
+import { createSpiedPlugin } from '@envelop/testing';
+import { envelop } from '../src';
+
+describe('OnEnveloped', () => {
+  it('Should not call OnEnveloped when passed with null', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const getEnveloped = envelop({ plugins: [spiedPlugin.plugin] });
+    getEnveloped(null);
+    expect(spiedPlugin.spies.onEnveloped).not.toHaveBeenCalled();
+  });
+
+  it('Should call OnEnveloped when no args is passed, fallback to {} as context', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const getEnveloped = envelop({ plugins: [spiedPlugin.plugin] });
+    getEnveloped();
+    expect(spiedPlugin.spies.onEnveloped).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: {},
+      })
+    );
+  });
+
+  it('Should call OnEnveloped when passed with initial context', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const getEnveloped = envelop({ plugins: [spiedPlugin.plugin] });
+    getEnveloped({});
+    expect(spiedPlugin.spies.onEnveloped).toHaveBeenCalled();
+  });
+
+  it('Should call OnEnveloped correct with each flow requirements', async () => {
+    const spiedPlugin = createSpiedPlugin();
+    const getEnveloped = envelop({ plugins: [spiedPlugin.plugin] });
+    getEnveloped(null);
+    expect(spiedPlugin.spies.onEnveloped).not.toHaveBeenCalled();
+    getEnveloped({});
+    expect(spiedPlugin.spies.onEnveloped).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/types/src/get-enveloped.ts
+++ b/packages/types/src/get-enveloped.ts
@@ -8,7 +8,7 @@ export { ArbitraryObject } from './utils';
 export type EnvelopContextFnWrapper<TFunction extends Function, ContextType = unknown> = (context: ContextType) => TFunction;
 
 export type GetEnvelopedFn<PluginsContext> = {
-  <InitialContext extends ArbitraryObject>(initialContext?: InitialContext): {
+  <InitialContext extends ArbitraryObject>(initialContext?: InitialContext | null): {
     execute: OriginalExecuteFn;
     validate: OriginalValidateFn;
     subscribe: OriginalSubscribeFn;

--- a/website/docs/plugins/lifecycle.mdx
+++ b/website/docs/plugins/lifecycle.mdx
@@ -49,6 +49,8 @@ myHttpServer.on('request', async req => {
 });
 ```
 
+> Note: the initial `context` can be also set to `null` in order skip `onEnveloped` hook of your plugins. Use this only if you are integrating `envelop` with other libraries that needs access to static definition of `execute` / `subscribe` (like `graphql-ws`).
+
 Plugins might also use this `context` to keep a contextual reference for objects they might need across stages.
 
 So for example, if you wish to make some data from `parse` stage available for you in `execute` phase, you can extend the context while running `onParse` and then access that data in `onExecute`:
@@ -83,6 +85,10 @@ This method is called only once when the plugin is being initialized. This hook 
 ### `onEnveloped(api)`
 
 This method is called every time `getEnveloped` is called, and per request. This is useful if you need to do some setup right before an incoming execution flow.
+
+**Note:**: If `getEnveloped` is called with initial context set explicitly to `null`, this hook will no get called. This is done in order to distinguish a static call to `getEnveloped` from a dynamic call (where the context matters).
+
+> If you wish to measure execution time (for example, for tracing and metrics), you can use this hook for the begining of the execution, and use `onAfterExecute` for the end.
 
 **API**:
 


### PR DESCRIPTION
We recently added a new phase for `OnEnveloped` which being triggered when `getEnveloped` function is called. 
This is an API suggestion for allowing static calls to `getEnveloped`, in order to skip `OnEnveloped` call. This allows `envelop` to integrate with libraries that need access to `execute` or `subscribe` before you have a `req` incoming. 

To get `execute` / `subscribe` (`OnEnveloped` isn't triggered):

```ts
const { execute, subscribe } = getEnveloped(null);
```

To get access to all (`OnEnveloped` is triggered):

```ts
const { parse, validate, schema, contextFactory } = getEnveloped({ req });
```
