### PR TITLE
Better type safety for `OnEnveloped` hook

### DIFF
--- a/.changeset/smart-shirts-work.md
+++ b/.changeset/smart-shirts-work.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+'@envelop/types': patch
+---
+
+Better type safety for OnEnveloped hook

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -38,7 +38,7 @@ export type EnvelopOrchestrator<
   InitialContext extends ArbitraryObject = ArbitraryObject,
   PluginsContext extends ArbitraryObject = ArbitraryObject
 > = {
-  init: (initialContext: InitialContext) => void;
+  init: (initialContext?: Maybe<InitialContext>) => void;
   parse: EnvelopContextFnWrapper<ReturnType<GetEnvelopedFn<PluginsContext>>['parse'], InitialContext>;
   validate: EnvelopContextFnWrapper<ReturnType<GetEnvelopedFn<PluginsContext>>['validate'], InitialContext>;
   execute: ReturnType<GetEnvelopedFn<PluginsContext>>['execute'];
@@ -109,6 +109,10 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
       onEnveloped({
         context: initialContext,
         extendContext: extension => {
+          if (!initialContext) {
+            return;
+          }
+
           Object.assign(initialContext, extension);
         },
         setSchema: modifiedSchema => replaceSchema(modifiedSchema, i),

--- a/packages/core/src/traced-orchestrator.ts
+++ b/packages/core/src/traced-orchestrator.ts
@@ -28,7 +28,7 @@ export function traceOrchestrator<TInitialContext extends ArbitraryObject, TPlug
   return {
     ...orchestrator,
     init: (ctx = {} as any) => {
-      ctx._envelopTracing = ctx._envelopTracing || {};
+      ctx!._envelopTracing = ctx!._envelopTracing || {};
       const done = createTracer('init', ctx || {});
 
       try {

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -15,6 +15,7 @@ import {
   validate,
   ValidationRule,
 } from 'graphql';
+import { Maybe } from 'graphql/jsutils/Maybe';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
 import { DefaultContext } from 'packages/core/src';
 import { Plugin } from './plugin';
@@ -37,7 +38,7 @@ export type OnPluginInitHook = (options: OnPluginInitEventPayload) => void;
 /** onPluginInit */
 export type OnEnvelopedHookEventPayload<ContextType> = {
   setSchema: SetSchemaFn;
-  context: Readonly<ContextType>;
+  context: Readonly<Maybe<ContextType>>;
   extendContext: (contextExtension: Partial<ContextType>) => void;
 };
 export type OnEnvelopedHook<ContextType> = (options: OnEnvelopedHookEventPayload<ContextType>) => void;

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -27,3 +27,4 @@ export type Unarray<T> = T extends Array<infer U> ? U : T;
 
 export type ArbitraryObject = Record<string | number | symbol, any>;
 export type PromiseOrValue<T> = T | Promise<T>;
+export type Maybe<T> = T | null | undefined;


### PR DESCRIPTION
Better take on: https://github.com/dotansimha/envelop/pull/417 . Basically, we set the `initialContext` to be optional, in order to force plugins that implements `OnEnveloped` to do a check before using it. This is done in order to ensure that plugins that uses `OnEnveloped` doesn't use `context` when it's called without it. 
 