### PR TITLE
feat: support hooking into execute stream (defer/stream)

### DIFF
--- a/.changeset/six-crabs-flash.md
+++ b/.changeset/six-crabs-flash.md
@@ -1,0 +1,5 @@
+---
+'@envelop/execute-subscription-event': patch
+---
+
+initial release

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -8,8 +8,9 @@ import {
   Source,
   ExecutionResult,
   SubscriptionArgs,
+  ExecutionArgs,
 } from 'graphql';
-import { PolymorphicSubscribeArguments } from '@envelop/types';
+import { AsyncIterableIteratorOrValue, PolymorphicExecuteArguments, PolymorphicSubscribeArguments } from '@envelop/types';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
 
 export const envelopIsIntrospectionSymbol = Symbol('ENVELOP_IS_INTROSPECTION');
@@ -78,6 +79,29 @@ export async function* mapAsyncIterator<TInput, TOutput = TInput>(
     yield map(value);
   }
 }
+
+export function getExecuteArgs(args: PolymorphicExecuteArguments): ExecutionArgs {
+  return args.length === 1
+    ? args[0]
+    : {
+        schema: args[0],
+        document: args[1],
+        rootValue: args[2],
+        contextValue: args[3],
+        variableValues: args[4],
+        operationName: args[5],
+        fieldResolver: args[6],
+        typeResolver: args[7],
+      };
+}
+
+/**
+ * Utility function for making a execute function that handles polymorphic arguments.
+ */
+export const makeExecute =
+  (executeFn: (args: ExecutionArgs) => PromiseOrValue<AsyncIterableIteratorOrValue<ExecutionResult>>) =>
+  (...polyArgs: PolymorphicExecuteArguments): PromiseOrValue<AsyncIterableIteratorOrValue<ExecutionResult>> =>
+    executeFn(getExecuteArgs(polyArgs));
 
 export async function* finalAsyncIterator<TInput>(
   asyncIterable: AsyncIterableIterator<TInput>,

--- a/packages/core/test/common.ts
+++ b/packages/core/test/common.ts
@@ -1,4 +1,5 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
+import { mapAsyncIterator } from '../src';
 
 export const schema = makeExecutableSchema({
   typeDefs: /* GraphQL */ `
@@ -13,12 +14,24 @@ export const schema = makeExecutableSchema({
 
     type Subscription {
       alphabet: String!
+      message: String!
     }
   `,
   resolvers: {
     Query: {
       me: () => {
         return { _id: 1, firstName: 'Dotan', lastName: 'Simha' };
+      },
+    },
+    Subscription: {
+      message: {
+        subscribe: (_, __, context) => {
+          if (!context || 'subscribeSource' in context === false) {
+            throw new Error('No subscribeSource provided for context :(');
+          }
+          return context.subscribeSource;
+        },
+        resolve: (_, __, context) => context.message,
       },
     },
     User: {
@@ -34,5 +47,11 @@ export const query = /* GraphQL */ `
       id
       name
     }
+  }
+`;
+
+export const subscriptionOperationString = /* GraphQL */ `
+  subscription {
+    message
   }
 `;

--- a/packages/core/test/common.ts
+++ b/packages/core/test/common.ts
@@ -4,6 +4,7 @@ export const schema = makeExecutableSchema({
   typeDefs: /* GraphQL */ `
     type Query {
       me: User!
+      alphabet: [String]!
     }
     type User {
       id: ID!

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -1,5 +1,5 @@
-import { createSpiedPlugin, createTestkit } from '@envelop/testing';
-import { execute, GraphQLSchema } from 'graphql';
+import { assertStreamExecutionValue, collectAsyncIteratorValues, createSpiedPlugin, createTestkit } from '@envelop/testing';
+import { execute, ExecutionResult, GraphQLSchema } from 'graphql';
 import { schema, query } from './common';
 
 describe('execute', () => {
@@ -137,5 +137,135 @@ describe('execute', () => {
       result: 'Dotan Simha',
       setResult: expect.any(Function),
     });
+  });
+
+  it('Should be able to manipulate streams', async () => {
+    const streamExecuteFn = async function* () {
+      for (const value of ['a', 'b', 'c', 'd']) {
+        yield { data: { alphabet: value } };
+      }
+    };
+
+    const teskit = createTestkit(
+      [
+        {
+          onExecute({ setExecuteFn }) {
+            setExecuteFn(streamExecuteFn);
+
+            return {
+              onExecuteDone: () => {
+                return {
+                  onNext: ({ setResult }) => {
+                    setResult({ data: { alphabet: 'x' } });
+                  },
+                };
+              },
+            };
+          },
+        },
+      ],
+      schema
+    );
+
+    const result = await teskit.execute(/* GraphQL */ `
+      query {
+        alphabet
+      }
+    `);
+    assertStreamExecutionValue(result);
+    const values = await collectAsyncIteratorValues(result);
+    expect(values).toEqual([
+      { data: { alphabet: 'x' } },
+      { data: { alphabet: 'x' } },
+      { data: { alphabet: 'x' } },
+      { data: { alphabet: 'x' } },
+    ]);
+  });
+
+  it('Should be able to invoke something after the stream has ended.', async () => {
+    expect.assertions(1);
+    const streamExecuteFn = async function* () {
+      for (const value of ['a', 'b', 'c', 'd']) {
+        yield { data: { alphabet: value } };
+      }
+    };
+
+    const teskit = createTestkit(
+      [
+        {
+          onExecute({ setExecuteFn }) {
+            setExecuteFn(streamExecuteFn);
+
+            return {
+              onExecuteDone: () => {
+                let latestResult: ExecutionResult;
+                return {
+                  onNext: ({ result }) => {
+                    latestResult = result;
+                  },
+                  onEnd: () => {
+                    expect(latestResult).toEqual({ data: { alphabet: 'd' } });
+                  },
+                };
+              },
+            };
+          },
+        },
+      ],
+      schema
+    );
+
+    const result = await teskit.execute(/* GraphQL */ `
+      query {
+        alphabet
+      }
+    `);
+    assertStreamExecutionValue(result);
+    // run AsyncGenerator
+    await collectAsyncIteratorValues(result);
+  });
+
+  it('Should be able to invoke something after the stream has ended (manual return).', async () => {
+    expect.assertions(1);
+    const streamExecuteFn = async function* () {
+      for (const value of ['a', 'b', 'c', 'd']) {
+        yield { data: { alphabet: value } };
+      }
+    };
+
+    const teskit = createTestkit(
+      [
+        {
+          onExecute({ setExecuteFn }) {
+            setExecuteFn(streamExecuteFn);
+
+            return {
+              onExecuteDone: () => {
+                let latestResult: ExecutionResult;
+                return {
+                  onNext: ({ result }) => {
+                    latestResult = result;
+                  },
+                  onEnd: () => {
+                    expect(latestResult).toEqual({ data: { alphabet: 'a' } });
+                  },
+                };
+              },
+            };
+          },
+        },
+      ],
+      schema
+    );
+
+    const result = await teskit.execute(/* GraphQL */ `
+      query {
+        alphabet
+      }
+    `);
+    assertStreamExecutionValue(result);
+    const instance = result[Symbol.asyncIterator]();
+    await instance.next();
+    await instance.return!();
   });
 });

--- a/packages/plugins/execute-subscription-event/README.md
+++ b/packages/plugins/execute-subscription-event/README.md
@@ -1,0 +1,51 @@
+## `@envelop/execute-subscription-event`
+
+Utilities for hooking into the [ExecuteSubscriptionEvent](<https://spec.graphql.org/draft/#ExecuteSubscriptionEvent()>) phase.
+
+### `useContextValuePerExecuteSubscriptionEvent`
+
+Create a new context object per `ExecuteSubscriptionEvent` phase, allowing to bypass common issues with context objects such as [`DataLoader`](https://github.com/dotansimha/envelop/issues/80) [caching](https://github.com/graphql/graphql-js/issues/894) [issues](https://github.com/apollographql/subscriptions-transport-ws/issues/330).
+
+```ts
+import { envelop } from '@envelop/core';
+import { useContextValuePerExecuteSubscriptionEvent } from '@envelop/execute-subscription-event';
+import { createContext, createDataLoaders } from './context';
+
+const getEnveloped = envelop({
+  plugins: [
+    useContext(() => createContext())
+    useContextValuePerExecuteSubscriptionEvent(() => ({
+      // Existing context is merged with this context partial
+      // By recreating the DataLoader we ensure no DataLoader caches from the previous event/initial field subscribe call are are hit
+      contextPartial: {
+        dataLoaders: createDataLoaders()
+      },
+    })),
+    // ... other plugins ...
+  ],
+});
+```
+
+Alternatively, you can also provide a callback that is invoked after each [`ExecuteSubscriptionEvent`](<https://spec.graphql.org/draft/#ExecuteSubscriptionEvent()>) phase.
+
+```ts
+import { envelop } from '@envelop/core';
+import { useContextValuePerExecuteSubscriptionEvent } from '@envelop/execute-subscription-event';
+import { createContext, createDataLoaders } from './context';
+
+const getEnveloped = envelop({
+  plugins: [
+    useContext(() => createContext())
+    useContextValuePerExecuteSubscriptionEvent(({ args }) => ({
+      onEnd: () => {
+        // Note that onEnd is invoked only after each ExecuteSubscriptionEvent phase
+        // This means the initial event will still use the cache from potential subscribe dataloader calls
+        // If you use this to clear DataLoader caches it is recommended to not do any DataLoader calls within your field subscribe function.
+        args.contextValue.dataLoaders.users.clearAll()
+        args.contextValue.dataLoaders.posts.clearAll()
+      }
+    })),
+    // ... other plugins ...
+  ],
+});
+```

--- a/packages/plugins/execute-subscription-event/package.json
+++ b/packages/plugins/execute-subscription-event/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@envelop/execute-subscription-event",
+  "version": "0.0.0",
+  "author": "Laurin Quast <laurinquast@googlemail.com>",
+  "license": "MIT",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/envelop.git",
+    "directory": "packages/plugins/disable-introspection"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@n1ru4l/push-pull-async-iterable-iterator": "3.0.0",
+    "bob-the-bundler": "1.4.1",
+    "graphql": "15.5.1",
+    "typescript": "4.3.5"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/execute-subscription-event/src/index.ts
+++ b/packages/plugins/execute-subscription-event/src/index.ts
@@ -1,0 +1,42 @@
+import { SubscriptionArgs, execute } from 'graphql';
+import { Plugin } from '@envelop/types';
+import { makeExecute, DefaultContext } from '@envelop/core';
+import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
+import { subscribe } from './subscribe';
+
+export type ContextFactoryOptions = {
+  /** The arguments with which the subscription was set up. */
+  args: SubscriptionArgs;
+};
+
+export type ContextFactoryHook<TContextValue> = {
+  /** Context that will be used for the "ExecuteSubscriptionEvent" phase. */
+  contextPartial: Partial<TContextValue>;
+  /** Optional callback that is invoked once the "ExecuteSubscriptionEvent" phase has ended. Useful for cleanup, such as tearing down database connections. */
+  onEnd?: () => void;
+};
+
+export type ContextFactoryType<TContextValue = DefaultContext> = (
+  options: ContextFactoryOptions
+) => PromiseOrValue<ContextFactoryHook<TContextValue> | void>;
+
+export const useExtendContextValuePerExecuteSubscriptionEvent = <TContextValue = unknown>(
+  createContext: ContextFactoryType<TContextValue>
+): Plugin<TContextValue> => {
+  return {
+    onSubscribe({ args, setSubscribeFn }) {
+      const executeNew = makeExecute(async executionArgs => {
+        const context = await createContext({ args });
+        try {
+          return execute({
+            ...executionArgs,
+            contextValue: { ...executionArgs.contextValue, ...context?.contextPartial },
+          });
+        } finally {
+          context?.onEnd?.();
+        }
+      });
+      setSubscribeFn(subscribe(executeNew));
+    },
+  };
+};

--- a/packages/plugins/execute-subscription-event/src/subscribe.ts
+++ b/packages/plugins/execute-subscription-event/src/subscribe.ts
@@ -1,0 +1,49 @@
+import { createSourceEventStream } from 'graphql';
+
+import { ExecuteFunction, makeSubscribe, SubscribeFunction } from '@envelop/core';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import mapAsyncIterator from 'graphql/subscription/mapAsyncIterator';
+
+/**
+ * This is a almost identical port from graphql-js subscribe.
+ * The only difference is that a custom `execute` function can be injected for customizing the behavior.
+ */
+export const subscribe = (execute: ExecuteFunction): SubscribeFunction =>
+  makeSubscribe(async args => {
+    const { schema, document, rootValue, contextValue, variableValues, operationName, fieldResolver, subscribeFieldResolver } =
+      args;
+
+    const resultOrStream = await createSourceEventStream(
+      schema,
+      document,
+      rootValue,
+      contextValue,
+      variableValues ?? undefined,
+      operationName,
+      subscribeFieldResolver
+    );
+
+    if (!isAsyncIterable(resultOrStream)) {
+      return resultOrStream;
+    }
+
+    // For each payload yielded from a subscription, map it over the normal
+    // GraphQL `execute` function, with `payload` as the rootValue.
+    // This implements the "MapSourceToResponseEvent" algorithm described in
+    // the GraphQL specification. The `execute` function provides the
+    // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
+    // "ExecuteQuery" algorithm, for which `execute` is also used.
+    const mapSourceToResponse = async (payload: object) =>
+      execute({
+        schema,
+        document,
+        rootValue: payload,
+        contextValue,
+        variableValues,
+        operationName,
+        fieldResolver,
+      });
+
+    // Map every source value to a ExecutionResult value as described above.
+    return mapAsyncIterator(resultOrStream, mapSourceToResponse);
+  });

--- a/packages/plugins/execute-subscription-event/test/use-extend-context-value-per-subscription-event.spec.ts
+++ b/packages/plugins/execute-subscription-event/test/use-extend-context-value-per-subscription-event.spec.ts
@@ -1,0 +1,78 @@
+import { assertStreamExecutionValue, createTestkit } from '@envelop/testing';
+import { schema, subscriptionOperationString } from '../../../core/test/common';
+import { useExtendContextValuePerExecuteSubscriptionEvent } from '../src';
+import { useExtendContext } from '@envelop/core';
+import { makePushPullAsyncIterableIterator } from '@n1ru4l/push-pull-async-iterable-iterator';
+
+describe('useContextValuePerExecuteSubscriptionEvent', () => {
+  it('it can be used for injecting a context that is different from the subscription context', async () => {
+    expect.assertions(4);
+    const { pushValue, asyncIterableIterator } = makePushPullAsyncIterableIterator<unknown>();
+    const subscriptionContextValue: {
+      subscribeSource: AsyncIterableIterator<unknown>;
+      message: string;
+    } = { subscribeSource: asyncIterableIterator, message: 'this is only used during subscribe phase' };
+
+    let counter = 0;
+
+    const testInstance = createTestkit(
+      [
+        useExtendContext(() => subscriptionContextValue),
+        useExtendContextValuePerExecuteSubscriptionEvent(() => ({
+          contextPartial: {
+            message: `${counter}`,
+          },
+        })),
+      ],
+      schema
+    );
+
+    const result = await testInstance.execute(subscriptionOperationString);
+    assertStreamExecutionValue(result);
+
+    pushValue({});
+
+    for await (const value of result) {
+      expect(value.errors).toBeUndefined();
+      if (counter === 0) {
+        expect(value.data?.message).toEqual('0');
+        counter = 1;
+        pushValue({});
+      } else if (counter === 1) {
+        expect(value.data?.message).toEqual('1');
+        return;
+      }
+    }
+  });
+
+  it('invokes cleanup function after value is published', async () => {
+    expect.assertions(3);
+    const { pushValue, asyncIterableIterator } = makePushPullAsyncIterableIterator<unknown>();
+
+    let onEnd = jest.fn();
+    const testInstance = createTestkit(
+      [
+        useExtendContext(() => ({ subscribeSource: asyncIterableIterator })),
+        useExtendContextValuePerExecuteSubscriptionEvent(() => ({
+          contextPartial: {
+            message: `hi`,
+          },
+          onEnd,
+        })),
+      ],
+      schema
+    );
+
+    const result = await testInstance.execute(subscriptionOperationString);
+    assertStreamExecutionValue(result);
+
+    pushValue({});
+
+    for await (const value of result) {
+      expect(value.errors).toBeUndefined();
+      expect(value.data?.message).toEqual('hi');
+      expect(onEnd.mock.calls).toHaveLength(1);
+      return;
+    }
+  });
+});

--- a/packages/types/src/graphql.ts
+++ b/packages/types/src/graphql.ts
@@ -1,5 +1,30 @@
-import type { DocumentNode, GraphQLFieldResolver, GraphQLSchema, SubscriptionArgs, ExecutionResult } from 'graphql';
+import type {
+  DocumentNode,
+  GraphQLFieldResolver,
+  GraphQLSchema,
+  SubscriptionArgs,
+  ExecutionResult,
+  ExecutionArgs,
+  GraphQLTypeResolver,
+} from 'graphql';
 import type { Maybe, PromiseOrValue, AsyncIterableIteratorOrValue } from './utils';
+
+export type PolymorphicExecuteArguments =
+  | [ExecutionArgs]
+  | [
+      GraphQLSchema,
+      DocumentNode,
+      any,
+      any,
+      Maybe<{ [key: string]: any }>,
+      Maybe<string>,
+      Maybe<GraphQLFieldResolver<any, any>>,
+      Maybe<GraphQLTypeResolver<any, any>>
+    ];
+
+export type ExecuteFunction = (
+  ...args: PolymorphicExecuteArguments
+) => PromiseOrValue<AsyncIterableIteratorOrValue<ExecutionResult>>;
 
 export type PolymorphicSubscribeArguments =
   | [SubscriptionArgs]

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -16,7 +16,7 @@ import type {
 } from 'graphql';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
-import { DefaultContext } from 'packages/core/src';
+import { AsyncIterableIteratorOrValue, DefaultContext, ExecuteFunction } from 'packages/core/src';
 import { SubscribeFunction } from './graphql';
 import { Plugin } from './plugin';
 
@@ -137,7 +137,7 @@ export type OnResolverCalledHook<
 
 /** onExecute */
 export type TypedExecutionArgs<ContextType> = Omit<ExecutionArgs, 'contextValue'> & { contextValue: ContextType };
-export type OriginalExecuteFn = typeof execute;
+export type OriginalExecuteFn = ExecuteFunction;
 export type OnExecuteEventPayload<ContextType> = {
   executeFn: OriginalExecuteFn;
   args: TypedExecutionArgs<ContextType>;
@@ -145,8 +145,21 @@ export type OnExecuteEventPayload<ContextType> = {
   setResultAndStopExecution: (newResult: ExecutionResult) => void;
   extendContext: (contextExtension: Partial<ContextType>) => void;
 };
-export type OnExecuteDoneEventPayload = { result: ExecutionResult; setResult: (newResult: ExecutionResult) => void };
-export type OnExecuteDoneHook = (options: OnExecuteDoneEventPayload) => void;
+export type OnExecuteDoneHookResultOnNextHookPayload = {
+  result: ExecutionResult;
+  setResult: (newResult: ExecutionResult) => void;
+};
+export type OnExecuteDoneHookResultOnNextHook = (payload: OnExecuteDoneHookResultOnNextHookPayload) => void | Promise<void>;
+export type OnExecuteDoneHookResultOnEndHook = () => void;
+export type OnExecuteDoneHookResult = {
+  onNext?: OnExecuteDoneHookResultOnNextHook;
+  onEnd?: OnExecuteDoneHookResultOnEndHook;
+};
+export type OnExecuteDoneEventPayload = {
+  result: AsyncIterableIteratorOrValue<ExecutionResult>;
+  setResult: (newResult: AsyncIterableIteratorOrValue<ExecutionResult>) => void;
+};
+export type OnExecuteDoneHook = (options: OnExecuteDoneEventPayload) => void | OnExecuteDoneHookResult;
 export type OnExecuteHookResult<ContextType> = {
   onExecuteDone?: OnExecuteDoneHook;
   onResolverCalled?: OnResolverCalledHook<any, DefaultArgs, ContextType>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,6 +1941,11 @@
     "@n1ru4l/graphql-live-query" "0.7.1"
     "@n1ru4l/push-pull-async-iterable-iterator" "^2.1.4"
 
+"@n1ru4l/push-pull-async-iterable-iterator@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.0.0.tgz#22dc34094c2de5f21b9a798d0ffab16b45de0eb7"
+  integrity sha512-gwoIwo/Dt1GOI+lbcG1G7IeRM2K+Fo0op3OGyFJ4tXUCf2a3Q8lUCm81aoevrXC0nu4gbAXeOWy7wWxjpSvZUw==
+
 "@n1ru4l/push-pull-async-iterable-iterator@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.1.4.tgz#a90225474352f9f159bff979905f707b9c6bcf04"


### PR DESCRIPTION
This PR is built upon https://github.com/dotansimha/envelop/pull/428 and serves as a POC for hoking into the phases where execute returns an AsyncIterable (which will be introduced as part of the next GraphQL major release for defer/stream support). Today, returning AsyncIterable from execute is already supported by various GraphQL servers such as graphql-helix, graphql-ws and graphql over Socket.io.

Adding this to envelop is a breaking change as the type signature of the `ExecuteDone` hook changes. The result type is now `AsyncIterable<ExecutionResult> | ExecutionResult`. Furthermore, the type signature of `execute` is changed to now return  `AsyncIterable<ExecutionResult> | ExecutionResult`.

