### PR TITLE
fix ESM graphql import

### DIFF
--- a/.changeset/stale-pugs-fry.md
+++ b/.changeset/stale-pugs-fry.md
@@ -1,0 +1,14 @@
+---
+'@envelop/core': patch
+'@envelop/apollo-server-errors': patch
+'@envelop/apollo-tracing': patch
+'@envelop/execute-subscription-event': patch
+'@envelop/newrelic': patch
+'@envelop/opentelemetry': patch
+'@envelop/preload-assets': patch
+'@envelop/prometheus': patch
+'@envelop/sentry': patch
+'@envelop/testing': patch
+---
+
+fix ESM graphql import

--- a/packages/core/src/graphql-typings.d.ts
+++ b/packages/core/src/graphql-typings.d.ts
@@ -1,4 +1,4 @@
-declare module 'graphql/jsutils/isAsyncIterable' {
+declare module 'graphql/jsutils/isAsyncIterable.js' {
   function isAsyncIterable(input: unknown): input is AsyncIterableIterator<any>;
   export default isAsyncIterable;
 }

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -24,7 +24,7 @@ import {
   ExecuteFunction,
   AsyncIterableIteratorOrValue,
 } from '@envelop/types';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 import {
   DocumentNode,
   execute,

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type ErrorHandler = (errors: readonly GraphQLError[]) => void;
 

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export class EnvelopError extends GraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {

--- a/packages/core/src/plugins/use-payload-formatter.ts
+++ b/packages/core/src/plugins/use-payload-formatter.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@envelop/types';
 import { ExecutionResult } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type FormatterFunction = (result: ExecutionResult<any, any>) => false | ExecutionResult<any, any>;
 

--- a/packages/core/src/traced-orchestrator.ts
+++ b/packages/core/src/traced-orchestrator.ts
@@ -2,7 +2,7 @@ import { DocumentNode, ExecutionArgs, GraphQLFieldResolver, GraphQLSchema, Graph
 import { Maybe } from 'graphql/jsutils/Maybe';
 import { ArbitraryObject } from '@envelop/types';
 import { EnvelopOrchestrator } from './orchestrator';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const HR_TO_NS = 1e9;
 const NS_TO_MS = 1e6;

--- a/packages/plugins/apollo-server-errors/src/index.ts
+++ b/packages/plugins/apollo-server-errors/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '@envelop/types';
 import { formatApolloErrors } from 'apollo-server-errors';
 import type { ExecutionResult } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const makeHandleResult =
   (options: Parameters<typeof formatApolloErrors>[1] = {}) =>

--- a/packages/plugins/apollo-tracing/src/index.ts
+++ b/packages/plugins/apollo-tracing/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '@envelop/types';
 import { TracingFormat } from 'apollo-tracing';
 import { GraphQLType, ResponsePath, responsePathAsArray } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const HR_TO_NS = 1e9;
 const NS_TO_MS = 1e6;

--- a/packages/plugins/execute-subscription-event/src/subscribe.ts
+++ b/packages/plugins/execute-subscription-event/src/subscribe.ts
@@ -1,7 +1,7 @@
 import { createSourceEventStream } from 'graphql';
 
 import { ExecuteFunction, makeSubscribe, SubscribeFunction } from '@envelop/core';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 import mapAsyncIterator from 'graphql/subscription/mapAsyncIterator';
 
 /**

--- a/packages/plugins/newrelic/src/index.ts
+++ b/packages/plugins/newrelic/src/index.ts
@@ -2,7 +2,7 @@ import { shim as instrumentationApi } from 'newrelic';
 import { Plugin, OnResolverCalledHook } from '@envelop/types';
 import { print, FieldNode, Kind, OperationDefinitionNode } from 'graphql';
 import { Path } from 'graphql/jsutils/Path';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 enum AttributeName {
   COMPONENT_NAME = 'Envelop_NewRelic_Plugin',

--- a/packages/plugins/opentelemetry/src/index.ts
+++ b/packages/plugins/opentelemetry/src/index.ts
@@ -3,7 +3,7 @@ import { SpanAttributes, SpanKind } from '@opentelemetry/api';
 import * as opentelemetry from '@opentelemetry/api';
 import { BasicTracerProvider, ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 import { print } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export enum AttributeName {
   EXECUTION_ERROR = 'graphql.execute.error',

--- a/packages/plugins/preload-assets/src/index.ts
+++ b/packages/plugins/preload-assets/src/index.ts
@@ -1,5 +1,5 @@
 import { Plugin } from '@envelop/types';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type UsePreloadAssetsOpts = {
   shouldPreloadAssets?: (context: unknown) => boolean;

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -14,7 +14,7 @@ import {
 import { PrometheusTracingPluginConfig } from './config';
 import { TypeInfo } from 'graphql';
 import { isIntrospectionOperationString } from '@envelop/core';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export { PrometheusTracingPluginConfig, createCounter, createHistogram, createSummary, FillLabelsFnParams };
 

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -5,7 +5,7 @@ import { Plugin, OnResolverCalledHook } from '@envelop/types';
 import * as Sentry from '@sentry/node';
 import { Span } from '@sentry/types';
 import { ExecutionArgs, Kind, OperationDefinitionNode, print, responsePathAsArray } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type SentryPluginOptions = {
   startTransaction?: boolean;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -2,7 +2,7 @@ import { DocumentNode, ExecutionResult, getOperationAST, GraphQLError, GraphQLSc
 import { envelop, useSchema } from '@envelop/core';
 import { GetEnvelopedFn, Plugin } from '@envelop/types';
 import { cloneSchema, isDocumentNode } from '@graphql-tools/utils';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createSpiedPlugin() {


### PR DESCRIPTION
ESM compatibility was broken with the import of `'graphql/jsutils/isAsyncIterable'`, since the extension was not specified.

This issue can be reproduced simply going to the `with-esm` example and run "yarn start"

<img width="1432" alt="Screenshot at Jul 22 20-11-50" src="https://user-images.githubusercontent.com/8672915/126724345-74b319a7-ad0a-4698-9401-83607048cd3e.png">
