### PR TITLE
add jsdoc comments for hooks

### DIFF
--- a/.changeset/violet-snails-smell.md
+++ b/.changeset/violet-snails-smell.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+'@envelop/types': patch
+---
+
+add jsdoc comments for hook types

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -54,7 +54,7 @@ export function isIntrospectionOperationString(operation: string | Source): bool
   return (typeof operation === 'string' ? operation : operation.body).indexOf('__schema') !== -1;
 }
 
-export function getSubscribeArgs(args: PolymorphicSubscribeArguments): SubscriptionArgs {
+function getSubscribeArgs(args: PolymorphicSubscribeArguments): SubscriptionArgs {
   return args.length === 1
     ? args[0]
     : {
@@ -87,7 +87,7 @@ export async function* mapAsyncIterator<TInput, TOutput = TInput>(
   }
 }
 
-export function getExecuteArgs(args: PolymorphicExecuteArguments): ExecutionArgs {
+function getExecuteArgs(args: PolymorphicExecuteArguments): ExecutionArgs {
   return args.length === 1
     ? args[0]
     : {

--- a/packages/types/src/get-enveloped.ts
+++ b/packages/types/src/get-enveloped.ts
@@ -1,7 +1,7 @@
 import { Plugin } from './plugin';
 import { GraphQLSchema } from 'graphql';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
-import { OriginalExecuteFn, OriginalParseFn, OriginalSubscribeFn, OriginalValidateFn } from './hooks';
+import { ExecuteFunction, ParseFunction, SubscribeFunction, ValidateFunction } from './graphql';
 import { ArbitraryObject, Spread } from './utils';
 export { ArbitraryObject } from './utils';
 
@@ -9,10 +9,10 @@ export type EnvelopContextFnWrapper<TFunction extends Function, ContextType = un
 
 export type GetEnvelopedFn<PluginsContext> = {
   <InitialContext extends ArbitraryObject>(initialContext?: InitialContext): {
-    execute: OriginalExecuteFn;
-    validate: OriginalValidateFn;
-    subscribe: OriginalSubscribeFn;
-    parse: OriginalParseFn;
+    execute: ExecuteFunction;
+    validate: ValidateFunction;
+    subscribe: SubscribeFunction;
+    parse: ParseFunction;
     contextFactory: <ContextExtension>(
       contextExtension?: ContextExtension
     ) => PromiseOrValue<Spread<[InitialContext, PluginsContext, ContextExtension]>>;

--- a/packages/types/src/graphql.ts
+++ b/packages/types/src/graphql.ts
@@ -7,9 +7,12 @@ import type {
   GraphQLTypeResolver,
   subscribe,
   execute,
+  parse,
+  validate,
 } from 'graphql';
 import type { Maybe } from './utils';
 
+/** @private */
 export type PolymorphicExecuteArguments =
   | [ExecutionArgs]
   | [
@@ -25,6 +28,7 @@ export type PolymorphicExecuteArguments =
 
 export type ExecuteFunction = typeof execute;
 
+/** @private */
 export type PolymorphicSubscribeArguments =
   | [SubscriptionArgs]
   | [
@@ -39,3 +43,15 @@ export type PolymorphicSubscribeArguments =
     ];
 
 export type SubscribeFunction = typeof subscribe;
+
+export type ParseFunction = typeof parse;
+
+export type ValidateFunction = typeof validate;
+
+export type ValidateFunctionParameter = {
+  schema: Parameters<ValidateFunction>[0];
+  documentAST: Parameters<ValidateFunction>[1];
+  rules?: Parameters<ValidateFunction>[2];
+  typeInfo?: Parameters<ValidateFunction>[3];
+  options?: Parameters<ValidateFunction>[4];
+};

--- a/packages/types/src/graphql.ts
+++ b/packages/types/src/graphql.ts
@@ -49,9 +49,22 @@ export type ParseFunction = typeof parse;
 export type ValidateFunction = typeof validate;
 
 export type ValidateFunctionParameter = {
+  /**
+   * GraphQL schema instance.
+   */
   schema: Parameters<ValidateFunction>[0];
+  /**
+   * Parsed document node.
+   */
   documentAST: Parameters<ValidateFunction>[1];
+  /**
+   * The rules used for validation.
+   * validate uses specifiedRules as exported by the GraphQL module if this parameter is undefined.
+   */
   rules?: Parameters<ValidateFunction>[2];
+  /**
+   * TypeInfo instance which is used for getting schema information during validation
+   */
   typeInfo?: Parameters<ValidateFunction>[3];
   options?: Parameters<ValidateFunction>[4];
 };

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -10,12 +10,36 @@ import {
 } from './hooks';
 
 export interface Plugin<PluginContext extends Record<string, any> = {}> {
+  /**
+   * Invoked for each call to getEnveloped.
+   */
   onEnveloped?: OnEnvelopedHook<PluginContext>;
+  /**
+   * Invoked each time the GraphQL schema has been replaced from within a plugin.
+   */
   onSchemaChange?: OnSchemaChangeHook;
+  /**
+   * Invoked when a plugin is initialized.
+   */
   onPluginInit?: OnPluginInitHook;
+  /**
+   * Invoked for each execute call.
+   */
   onExecute?: OnExecuteHook<PluginContext>;
+  /**
+   * Invoked for each subscribe call.
+   */
   onSubscribe?: OnSubscribeHook<PluginContext>;
+  /**
+   * Invoked for each parse call.
+   */
   onParse?: OnParseHook<PluginContext>;
+  /**
+   * Invoked for each validate call.
+   */
   onValidate?: OnValidateHook<PluginContext>;
+  /**
+   * Invoked for each time the context is builded.
+   */
   onContextBuilding?: OnContextBuildingHook<PluginContext>;
 }

--- a/website/docs/guides/securing-your-graphql-api.md
+++ b/website/docs/guides/securing-your-graphql-api.md
@@ -321,7 +321,7 @@ const getEnveloped = envelop({
 });
 ```
 
-And then in your GraphQL schema, you can define the limitations in a declerative way:
+And then in your GraphQL schema, you can define the limitations in a declarative way:
 
 ```graphql
 type Query {


### PR DESCRIPTION
This gives some more context when hovering on stuff within VS Code,  handy when writing plugins. I also tried generating api docs from the comments, but it is quite messy, so will solve that in another pr