### PR TITLE
Fixes wrong package name in useRateLimiter example

### DIFF
--- a/packages/plugins/rate-limiter/README.md
+++ b/packages/plugins/rate-limiter/README.md
@@ -12,7 +12,7 @@ yarn add @envelop/rate-limiter
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useRateLimiter, IdentifyFn } from '@envelop/generic-auth';
+import { useRateLimiter, IdentifyFn } from '@envelop/rate-limiter';
 
 const identifyFn: IdentifyFn = async context => {
   return context.request.ip;


### PR DESCRIPTION
## Description

This PR fixes #485 where wrong package name is used in useRateLimiter example.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

