### PR TITLE
Added `handleStreamOrSingleExecutionResult ` helper

### DIFF
--- a/.changeset/eighty-squids-call.md
+++ b/.changeset/eighty-squids-call.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+'@envelop/types': patch
+---
+
+Added new helper `handleStreamOrSingleExecutionResult`

--- a/.changeset/sharp-mice-begin.md
+++ b/.changeset/sharp-mice-begin.md
@@ -1,0 +1,16 @@
+---
+'@envelop/core': patch
+'@envelop/apollo-server-errors': patch
+'@envelop/apollo-tracing': patch
+'@envelop/execute-subscription-event': patch
+'@envelop/newrelic': patch
+'@envelop/opentelemetry': patch
+'@envelop/preload-assets': patch
+'@envelop/prometheus': patch
+'@envelop/resource-limitations': patch
+'@envelop/sentry': patch
+'@envelop/testing': patch
+'@envelop/types': patch
+---
+
+Update usage of plugins to use the correct `isAsyncIterable` and new helper `handleStreamOrSingleExecutionResult`

--- a/packages/core/src/graphql-typings.d.ts
+++ b/packages/core/src/graphql-typings.d.ts
@@ -1,4 +1,0 @@
-declare module 'graphql/jsutils/isAsyncIterable.js' {
-  function isAsyncIterable(input: unknown): input is AsyncIterableIterator<any>;
-  export default isAsyncIterable;
-}

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -23,8 +23,8 @@ import {
   OnExecuteDoneHookResultOnEndHook,
   ExecuteFunction,
   AsyncIterableIteratorOrValue,
+  isAsyncIterable,
 } from '@envelop/types';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 import {
   DocumentNode,
   execute,

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -1,6 +1,5 @@
-import { Plugin } from '@envelop/types';
+import { Plugin, handleStreamOrSingleExecutionResult } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type ErrorHandler = (errors: readonly GraphQLError[]) => void;
 
@@ -16,16 +15,8 @@ export const useErrorHandler = (errorHandler: ErrorHandler): Plugin => ({
   onExecute() {
     const handleResult = makeHandleResult(errorHandler);
     return {
-      onExecuteDone({ result }) {
-        if (isAsyncIterable(result)) {
-          return {
-            onNext({ result }) {
-              handleResult({ result });
-            },
-          };
-        }
-        handleResult({ result });
-        return undefined;
+      onExecuteDone(payload) {
+        return handleStreamOrSingleExecutionResult(payload, handleResult);
       },
     };
   },

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -1,6 +1,5 @@
-import { Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export class EnvelopError extends GraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
@@ -37,16 +36,8 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
   return {
     onExecute() {
       return {
-        onExecuteDone({ result, setResult }) {
-          if (isAsyncIterable(result)) {
-            return {
-              onNext: ({ result, setResult }) => {
-                handleResult({ result, setResult });
-              },
-            };
-          }
-          handleResult({ result, setResult });
-          return undefined;
+        onExecuteDone(payload) {
+          return handleStreamOrSingleExecutionResult(payload, handleResult);
         },
       };
     },

--- a/packages/core/src/plugins/use-payload-formatter.ts
+++ b/packages/core/src/plugins/use-payload-formatter.ts
@@ -1,6 +1,5 @@
-import { Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { ExecutionResult } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type FormatterFunction = (result: ExecutionResult<any, any>) => false | ExecutionResult<any, any>;
 
@@ -17,17 +16,8 @@ export const usePayloadFormatter = (formatter: FormatterFunction): Plugin => ({
   onExecute() {
     const handleResult = makeHandleResult(formatter);
     return {
-      onExecuteDone({ result, setResult }) {
-        if (isAsyncIterable(result)) {
-          return {
-            onNext({ result, setResult }) {
-              handleResult({ result, setResult });
-            },
-          };
-        }
-
-        handleResult({ result, setResult });
-        return undefined;
+      onExecuteDone(payload) {
+        return handleStreamOrSingleExecutionResult(payload, handleResult);
       },
     };
   },

--- a/packages/core/src/traced-orchestrator.ts
+++ b/packages/core/src/traced-orchestrator.ts
@@ -1,8 +1,7 @@
 import { DocumentNode, ExecutionArgs, GraphQLFieldResolver, GraphQLSchema, GraphQLTypeResolver, SubscriptionArgs } from 'graphql';
 import { Maybe } from 'graphql/jsutils/Maybe';
-import { ArbitraryObject } from '@envelop/types';
+import { ArbitraryObject, isAsyncIterable } from '@envelop/types';
 import { EnvelopOrchestrator } from './orchestrator';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const HR_TO_NS = 1e9;
 const NS_TO_MS = 1e6;

--- a/packages/plugins/apollo-server-errors/src/index.ts
+++ b/packages/plugins/apollo-server-errors/src/index.ts
@@ -1,7 +1,6 @@
-import { Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { formatApolloErrors } from 'apollo-server-errors';
 import type { ExecutionResult } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const makeHandleResult =
   (options: Parameters<typeof formatApolloErrors>[1] = {}) =>
@@ -23,16 +22,8 @@ export const useApolloServerErrors = (options: Parameters<typeof formatApolloErr
       const handleResult = makeHandleResult(options);
 
       return {
-        onExecuteDone({ result, setResult }) {
-          if (isAsyncIterable(result)) {
-            return {
-              onNext: ({ result, setResult }) => {
-                handleResult({ result, setResult });
-              },
-            };
-          }
-          handleResult({ result, setResult });
-          return undefined;
+        onExecuteDone(payload) {
+          return handleStreamOrSingleExecutionResult(payload, handleResult);
         },
       };
     },

--- a/packages/plugins/apollo-tracing/src/index.ts
+++ b/packages/plugins/apollo-tracing/src/index.ts
@@ -1,7 +1,6 @@
-import { Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { TracingFormat } from 'apollo-tracing';
 import { GraphQLType, ResponsePath, responsePathAsArray } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const HR_TO_NS = 1e9;
 const NS_TO_MS = 1e6;
@@ -55,7 +54,7 @@ export const useApolloTracing = (): Plugin => {
             resolversTiming.push(resolverCall);
           };
         },
-        onExecuteDone({ result }) {
+        onExecuteDone(payload) {
           const endTime = new Date();
 
           const tracing: TracingFormat = {
@@ -80,15 +79,10 @@ export const useApolloTracing = (): Plugin => {
             },
           };
 
-          if (!isAsyncIterable(result)) {
+          return handleStreamOrSingleExecutionResult(payload, ({ result }) => {
             result.extensions = result.extensions || {};
             result.extensions.tracing = tracing;
-          } else {
-            // eslint-disable-next-line no-console
-            console.warn(
-              `Plugin "apollo-tracing" encountered a AsyncIterator which is not supported yet, so tracing data is not available for the operation.`
-            );
-          }
+          });
         },
       };
     },

--- a/packages/plugins/execute-subscription-event/src/subscribe.ts
+++ b/packages/plugins/execute-subscription-event/src/subscribe.ts
@@ -1,7 +1,7 @@
 import { createSourceEventStream } from 'graphql';
 
 import { ExecuteFunction, makeSubscribe, SubscribeFunction } from '@envelop/core';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
+import { isAsyncIterable } from '@envelop/types';
 import mapAsyncIterator from 'graphql/subscription/mapAsyncIterator';
 
 /**

--- a/packages/plugins/newrelic/src/index.ts
+++ b/packages/plugins/newrelic/src/index.ts
@@ -1,8 +1,7 @@
 import { shim as instrumentationApi } from 'newrelic';
-import { Plugin, OnResolverCalledHook } from '@envelop/types';
+import { Plugin, OnResolverCalledHook, isAsyncIterable } from '@envelop/types';
 import { print, FieldNode, Kind, OperationDefinitionNode } from 'graphql';
 import { Path } from 'graphql/jsutils/Path';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 enum AttributeName {
   COMPONENT_NAME = 'Envelop_NewRelic_Plugin',

--- a/packages/plugins/opentelemetry/src/index.ts
+++ b/packages/plugins/opentelemetry/src/index.ts
@@ -1,9 +1,8 @@
-import { Plugin, OnExecuteHookResult } from '@envelop/types';
+import { Plugin, OnExecuteHookResult, isAsyncIterable } from '@envelop/types';
 import { SpanAttributes, SpanKind } from '@opentelemetry/api';
 import * as opentelemetry from '@opentelemetry/api';
 import { BasicTracerProvider, ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 import { print } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export enum AttributeName {
   EXECUTION_ERROR = 'graphql.execute.error',

--- a/packages/plugins/preload-assets/src/index.ts
+++ b/packages/plugins/preload-assets/src/index.ts
@@ -1,4 +1,4 @@
-import { handleMaybeStream, Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 
 export type UsePreloadAssetsOpts = {
   shouldPreloadAssets?: (context: unknown) => boolean;
@@ -19,7 +19,7 @@ export const usePreloadAssets = (opts?: UsePreloadAssetsOpts): Plugin => ({
             return;
           }
 
-          return handleMaybeStream(payload, ({ result, setResult }) => {
+          return handleStreamOrSingleExecutionResult(payload, ({ result, setResult }) => {
             setResult({
               ...result,
               extensions: {

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
-import { Plugin, OnExecuteHookResult, OnParseHook, OnValidateHook, OnContextBuildingHook, OnExecuteHook } from '@envelop/types';
+import {
+  Plugin,
+  OnExecuteHookResult,
+  OnParseHook,
+  OnValidateHook,
+  OnContextBuildingHook,
+  OnExecuteHook,
+  isAsyncIterable,
+} from '@envelop/types';
 import { Summary, Counter, Histogram, register as defaultRegistry } from 'prom-client';
 import {
   getHistogramFromConfig,
@@ -14,7 +22,6 @@ import {
 import { PrometheusTracingPluginConfig } from './config';
 import { TypeInfo } from 'graphql';
 import { isIntrospectionOperationString } from '@envelop/core';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export { PrometheusTracingPluginConfig, createCounter, createHistogram, createSummary, FillLabelsFnParams };
 

--- a/packages/plugins/resource-limitations/src/index.ts
+++ b/packages/plugins/resource-limitations/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@envelop/types';
+import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { ExtendedValidationRule, useExtendedValidation } from '@envelop/extended-validation';
 import {
   ExecutionArgs,
@@ -13,7 +13,6 @@ import {
   GraphQLType,
 } from 'graphql';
 import { getArgumentValues } from 'graphql/execution/values.js';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 const getWrappedType = (graphqlType: GraphQLType): Exclude<GraphQLType, GraphQLList<any> | GraphQLNonNull<any>> => {
   if (graphqlType instanceof GraphQLList || graphqlType instanceof GraphQLNonNull) {
@@ -220,11 +219,8 @@ export const useResourceLimitations = (params?: UseResourceLimitationsParams): P
     },
     onExecute({ args }) {
       return {
-        onExecuteDone({ result }) {
-          if (isAsyncIterable(result)) {
-            return;
-          }
-          handleResult({ result, args });
+        onExecuteDone(payload) {
+          return handleStreamOrSingleExecutionResult(payload, ({ result }) => handleResult({ result, args }));
         },
       };
     },

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-console */
 /* eslint-disable dot-notation */
-import { Plugin, OnResolverCalledHook } from '@envelop/types';
+import { Plugin, OnResolverCalledHook, isAsyncIterable } from '@envelop/types';
 import * as Sentry from '@sentry/node';
 import { Span } from '@sentry/types';
 import { ExecutionArgs, Kind, OperationDefinitionNode, print, responsePathAsArray } from 'graphql';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 export type SentryPluginOptions = {
   startTransaction?: boolean;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,8 +1,7 @@
 import { DocumentNode, ExecutionResult, getOperationAST, GraphQLError, GraphQLSchema, print } from 'graphql';
 import { envelop, useSchema } from '@envelop/core';
-import { GetEnvelopedFn, Plugin } from '@envelop/types';
+import { GetEnvelopedFn, Plugin, isAsyncIterable } from '@envelop/types';
 import { cloneSchema, isDocumentNode } from '@graphql-tools/utils';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createSpiedPlugin() {

--- a/packages/types/src/async-utils.ts
+++ b/packages/types/src/async-utils.ts
@@ -1,7 +1,25 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { OnExecuteDoneEventPayload, OnExecuteDoneHookResult, OnExecuteDoneHookResultOnNextHook } from '@envelop/core';
-import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
+import { ExecutionResult } from 'graphql';
 
-export function handleMaybeStream(
+/**
+ * Returns true if the provided object implements the AsyncIterator protocol via
+ * implementing a `Symbol.asyncIterator` method.
+ *
+ * Source: https://github.com/graphql/graphql-js/blob/main/src/jsutils/isAsyncIterable.ts
+ */
+export function isAsyncIterable(maybeAsyncIterable: any): maybeAsyncIterable is AsyncIterableIterator<ExecutionResult> {
+  return typeof maybeAsyncIterable?.[Symbol.asyncIterator] === 'function';
+}
+
+/**
+ * A utility function for hanlding `onExecuteDone` hook result, for simplifying the hanlding of AsyncIterable returned from `execute`.
+ *
+ * @param payload The payload send to `onExecuteDone` hook function
+ * @param fn The handler to be executed on each result
+ * @returns a subscription for streamed results, or undefined in case of an non-async
+ */
+export function handleStreamOrSingleExecutionResult(
   payload: OnExecuteDoneEventPayload,
   fn: OnExecuteDoneHookResultOnNextHook
 ): void | OnExecuteDoneHookResult {

--- a/packages/types/src/async-utils.ts
+++ b/packages/types/src/async-utils.ts
@@ -1,0 +1,18 @@
+import { OnExecuteDoneEventPayload, OnExecuteDoneHookResult, OnExecuteDoneHookResultOnNextHook } from '@envelop/core';
+import isAsyncIterable from 'graphql/jsutils/isAsyncIterable.js';
+
+export function handleMaybeStream(
+  payload: OnExecuteDoneEventPayload,
+  fn: OnExecuteDoneHookResultOnNextHook
+): void | OnExecuteDoneHookResult {
+  if (isAsyncIterable(payload.result)) {
+    return { onNext: fn };
+  } else {
+    fn({
+      result: payload.result,
+      setResult: payload.setResult,
+    });
+
+    return undefined;
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export * from './plugin';
 export * from './get-enveloped';
 export * from './graphql';
 export * from './utils';
+export * from './async-utils';

--- a/website/docs/plugins/lifecycle.mdx
+++ b/website/docs/plugins/lifecycle.mdx
@@ -163,8 +163,50 @@ You can return an `object` from that function, with the following fields:
 
 Triggered when the execution of the operation is done.
 
-- `result` - the execution result.
+- `result` - the execution result, or AsyncIterable in case of stream response.
 - `setResult` - replaces the result. can either be with data or errors.
+
+Since `envelop` aims to support stream responses (for live queries, or `@stream/@defer`), the `result` might be an `AsyncIterable` of multiple execution results.
+
+If you wish you plugin to support this, please make sure to use the `handleStreamOrSingleExecutionResult` helper, like that:
+
+```ts
+import { Plugin, handleStreamOrSingleExecutionResult } from '@envelop/types';
+
+const myPlugin = (): Plugin => {
+  return {
+    onExecute({ args }) {
+      return {
+        onExecuteDone: payload => {
+          return handleStreamOrSingleExecutionResult(payload, ({ result, setResult }) => {
+            // Here you can access result, and modify it with setResult if needed
+          });
+        },
+      };
+    },
+  };
+};
+```
+
+Alternately, if you don't need to support stream responses, you can use the `isAsyncIterable` function as type-guard:
+
+```ts
+import { Plugin, isAsyncIterable } from '@envelop/types';
+
+const myPlugin = (): Plugin => {
+  return {
+    onExecute({ args }) {
+      return {
+        onExecuteDone: ({ result, setResult }) => {
+          if (isAsyncIterable(result)) {
+            // Here you can access result, and modify it with setResult if needed
+          }
+        },
+      };
+    },
+  };
+};
+```
 
 **`onResolverCalled` API**:
 


### PR DESCRIPTION
In this PR:
- Added `handleStreamOrSingleExecutionResult` helper for making it simpler to deal with stream responses.
- Added documentation on how to implement `onExecuteDone` hook.
- Moved `isAsyncIterable` into our repo, to make it work with all versions of GraphQL.
- Refactor plugins to use `handleStreamOrSingleExecutionResult`.