### PR TITLE
Reworks intro sentence in Securing GraphQL API Documentation

### DIFF
--- a/website/docs/guides/securing-your-graphql-api.md
+++ b/website/docs/guides/securing-your-graphql-api.md
@@ -5,7 +5,7 @@ sidebar_label: Securing your GraphQL API
 
 # Securing your GraphQL API
 
-Building a secure GraphQL API is hard by design of to the because "Graph" part withing GraphQL.
+Building a secure GraphQL API is hard by design because of the "Graph" nature of GraphQL.
 Libraries for making different aspects of a GraphQL server secure have existed since the early days of GraphQL.
 However, combining those tools is often cumbersome and results in messy code.
 With envelop securing your server is now as easy as pie!


### PR DESCRIPTION
## Description

In the Securing your GraphQL API [documentation](https://www.envelop.dev/docs/guides/securing-your-graphql-api) the introductory sentence is difficult to read:

> Building a secure GraphQL API is hard by design of to the because "Graph" part withing GraphQL. 

This PR rewords the sentence.

Fixes # https://github.com/dotansimha/envelop/issues/510

## Type of change

Documentation change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

<img width="984" alt="image" src="https://user-images.githubusercontent.com/1051633/127689023-08f898f2-f8a4-44fb-b7b1-e29ddb9cc54f.png">


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

None. Documentation change, Was not sure how to locally build website.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

## Further comments

This rewording is open for suggestions. 

I think the idea here to to say that graphs are hard to secure because of the many ways graphs can be composed and where do you apply the authentication or at what level does something authorize or how deep do you let the graph get?

Graphs are complex structures and also also super flexible so it's hard to guard against and predict how it will be used -- and thus hard to secure.