### PR TITLE
Update Relay link

### DIFF
--- a/packages/plugins/persisted-operations/README.md
+++ b/packages/plugins/persisted-operations/README.md
@@ -58,4 +58,4 @@ Now, when running operations through your GraphQL server, you can use a key inst
 
 If you are using Relay, you can leverage `relay-compiler` feature for hashing and and creating the store for you, during build.
 
-You can [read more about this feature here](https://relay.dev/docs/v2.0.0/persisted-queries/). After building your hashes, you can use `queryMap.json` as your store.
+You can [read more about this feature here](https://relay.dev/docs/guides/persisted-queries/). After building your hashes, you can use `queryMap.json` as your store.


### PR DESCRIPTION
## Description

Updates Relay documentation link to the current version of the Relay persisted queries guide. This avoids linking users to a page with a "no longer actively maintained" warning.

## Type of change

- [x] Documentation change

## Checklist:

- [x] I have made corresponding changes to the documentation
