### PR TITLE
feat: error masking for context (variant using onPluginInit) and subscribe

### DIFF
--- a/.changeset/chilled-lions-hug.md
+++ b/.changeset/chilled-lions-hug.md
@@ -1,0 +1,19 @@
+---
+'@envelop/core': minor
+'@envelop/types': minor
+---
+
+Add API for registering a context creation error handler.
+
+```ts
+export const useMyHook = (): Plugin => {
+  return {
+    onPluginInit(context) {
+      context.registerContextErrorHandler(({ error, setError }) => {
+        console.error('Error occurred during context creation.', error);
+        setError(new Error('Something went wrong :('));
+      });
+    },
+  };
+};
+```

--- a/.changeset/curly-carpets-unite.md
+++ b/.changeset/curly-carpets-unite.md
@@ -1,0 +1,20 @@
+---
+'@envelop/core': minor
+---
+
+`useMaskedErrors` now masks errors thrown during context creation (calling `contextFactory`).
+
+It might be possible that you need to load some data during context creation from a remote source that could be unavailable and thus yield in an error being thrown. `useMaskedErrors` now handles such scenarios and prevents leaking such information to clients.
+
+✅ context error will be masked
+
+```ts
+const getEnveloped = envelop({
+  plugins: [
+    useExtendContext(() => {
+      throw new Error('Oooooops.');
+    }),
+    useMaskedErrors(),
+  ],
+});
+```

--- a/.changeset/twelve-ghosts-invite.md
+++ b/.changeset/twelve-ghosts-invite.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': minor
+---
+
+useMaskedErrors now also handles subscription errors

--- a/.changeset/twelve-ghosts-invite.md
+++ b/.changeset/twelve-ghosts-invite.md
@@ -2,4 +2,4 @@
 '@envelop/core': minor
 ---
 
-useMaskedErrors now also handles subscription errors
+useMaskedErrors now also handles errors that are occurring during subscriptions.

--- a/.changeset/twenty-sloths-film.md
+++ b/.changeset/twenty-sloths-film.md
@@ -1,0 +1,5 @@
+---
+'@envelop/testing': patch
+---
+
+Do not swallow/map errors thrown from contextFactory

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -53,6 +53,9 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
         onSubscribeResult(payload) {
           return handleStreamOrSingleExecutionResult(payload, handleResult);
         },
+        onSubscribeError({ error, setError }) {
+          setError(formatError(error));
+        },
       };
     },
   };

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -7,14 +7,16 @@ export class EnvelopError extends GraphQLError {
   }
 }
 
-export type FormatErrorHandler = (error: GraphQLError) => GraphQLError;
+export type FormatErrorHandler = (error: GraphQLError | unknown) => GraphQLError;
 
 export const formatError: FormatErrorHandler = err => {
-  if (err.originalError && err.originalError instanceof EnvelopError === false) {
-    return new GraphQLError('Unexpected error.', err.nodes, err.source, err.positions, err.path, undefined);
+  if (err instanceof GraphQLError) {
+    if (err.originalError && err.originalError instanceof EnvelopError === false) {
+      return new GraphQLError('Unexpected error.', err.nodes, err.source, err.positions, err.path, undefined);
+    }
+    return err;
   }
-
-  return err;
+  return new GraphQLError('Unexpected error.');
 };
 
 export type UseMaskedErrorsOpts = {
@@ -34,6 +36,11 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
   const handleResult = makeHandleResult(format);
 
   return {
+    onPluginInit(context) {
+      context.registerContextErrorHandler(({ error, setError }) => {
+        setError(formatError(error));
+      });
+    },
     onExecute() {
       return {
         onExecuteDone(payload) {

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -48,5 +48,12 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
         },
       };
     },
+    onSubscribe() {
+      return {
+        onSubscribeResult(payload) {
+          return handleStreamOrSingleExecutionResult(payload, handleResult);
+        },
+      };
+    },
   };
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -121,3 +121,14 @@ export async function* finalAsyncIterator<TInput>(
     onFinal();
   }
 }
+
+export async function* errorAsyncIterator<TInput>(
+  asyncIterable: AsyncIterableIterator<TInput>,
+  onError: (err: unknown) => void
+): AsyncIterableIterator<TInput> {
+  try {
+    yield* asyncIterable;
+  } catch (err: unknown) {
+    onError(err);
+  }
+}

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -188,28 +188,25 @@ Array [
   });
 
   it('Should mask subscribe (AsyncIterable) subscription errors', async () => {
+    expect.assertions(1);
     const testInstance = createTestkit([useMaskedErrors()], schema);
     const resultStream = await testInstance.execute(`subscription { streamError }`);
     assertStreamExecutionValue(resultStream);
-    const allResults = await collectAsyncIteratorValues(resultStream);
-    expect(allResults).toHaveLength(1);
-    const [result] = allResults;
-    expect(result.errors).toBeDefined();
-    expect(result.errors).toMatchInlineSnapshot();
+    try {
+      await collectAsyncIteratorValues(resultStream);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: Unexpected error.]`);
+    }
   });
   it('Should not mask subscribe (AsyncIterable) subscription envelop errors', async () => {
     const testInstance = createTestkit([useMaskedErrors()], schema);
     const resultStream = await testInstance.execute(`subscription { streamEnvelopError }`);
     assertStreamExecutionValue(resultStream);
-    const allResults = await collectAsyncIteratorValues(resultStream);
-    expect(allResults).toHaveLength(1);
-    const [result] = allResults;
-    expect(result.errors).toBeDefined();
-    expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Noop],
-]
-`);
+    try {
+      await collectAsyncIteratorValues(resultStream);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: Noop]`);
+    }
   });
 
   it('Should mask resolve subscription errors', async () => {

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -1,5 +1,10 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
+import {
+  assertSingleExecutionValue,
+  assertStreamExecutionValue,
+  collectAsyncIteratorValues,
+  createTestkit,
+} from '@envelop/testing';
 import { EnvelopError, useMaskedErrors } from '../../src/plugins/use-masked-errors';
 import { useExtendContext } from '@envelop/core';
 
@@ -10,6 +15,14 @@ describe('useMaskedErrors', () => {
         secret: String!
         secretEnvelop: String!
         secretWithExtensions: String!
+      }
+      type Subscription {
+        instantError: String
+        streamError: String
+        streamResolveError: String
+        instantEnvelopError: String
+        streamEnvelopError: String
+        streamResolveEnvelopError: String
       }
     `,
     resolvers: {
@@ -25,6 +38,48 @@ describe('useMaskedErrors', () => {
             code: 'Foo',
             message: 'Bar',
           });
+        },
+      },
+      Subscription: {
+        instantError: {
+          subscribe: async function () {
+            throw new Error('Noop');
+          },
+          resolve: _ => _,
+        },
+        streamError: {
+          subscribe: async function* () {
+            throw new Error('Noop');
+          },
+          resolve: _ => _,
+        },
+        streamResolveError: {
+          subscribe: async function* () {
+            yield '1';
+          },
+          resolve: _ => {
+            throw new Error('Noop');
+          },
+        },
+        instantEnvelopError: {
+          subscribe: async function () {
+            throw new EnvelopError('Noop');
+          },
+          resolve: _ => _,
+        },
+        streamEnvelopError: {
+          subscribe: async function* () {
+            throw new EnvelopError('Noop');
+          },
+          resolve: _ => _,
+        },
+        streamResolveEnvelopError: {
+          subscribe: async function* () {
+            yield '1';
+          },
+          resolve: _ => {
+            throw new EnvelopError('Noop');
+          },
         },
       },
     },
@@ -107,5 +162,83 @@ describe('useMaskedErrors', () => {
     } catch (err) {
       expect(err).toMatchInlineSnapshot(`[GraphQLError: No context for you!]`);
     }
+  });
+  it('Should mask subscribe (sync/promise) subscription errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const result = await testInstance.execute(`subscription { instantError }`);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Unexpected error.],
+]
+`);
+  });
+
+  it('Should not mask subscribe (sync/promise) subscription envelop errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const result = await testInstance.execute(`subscription { instantEnvelopError }`);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Noop],
+]
+`);
+  });
+
+  it('Should mask subscribe (AsyncIterable) subscription errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const resultStream = await testInstance.execute(`subscription { streamError }`);
+    assertStreamExecutionValue(resultStream);
+    const allResults = await collectAsyncIteratorValues(resultStream);
+    expect(allResults).toHaveLength(1);
+    const [result] = allResults;
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot();
+  });
+  it('Should not mask subscribe (AsyncIterable) subscription envelop errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const resultStream = await testInstance.execute(`subscription { streamEnvelopError }`);
+    assertStreamExecutionValue(resultStream);
+    const allResults = await collectAsyncIteratorValues(resultStream);
+    expect(allResults).toHaveLength(1);
+    const [result] = allResults;
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Noop],
+]
+`);
+  });
+
+  it('Should mask resolve subscription errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const resultStream = await testInstance.execute(`subscription { streamResolveError }`);
+    assertStreamExecutionValue(resultStream);
+    const allResults = await collectAsyncIteratorValues(resultStream);
+    expect(allResults).toHaveLength(1);
+    const [result] = allResults;
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Unexpected error.],
+]
+`);
+  });
+
+  it('Should not mask resolve subscription envelop errors', async () => {
+    const testInstance = createTestkit([useMaskedErrors()], schema);
+    const resultStream = await testInstance.execute(`subscription { streamResolveEnvelopError }`);
+    assertStreamExecutionValue(resultStream);
+    const allResults = await collectAsyncIteratorValues(resultStream);
+    expect(allResults).toHaveLength(1);
+    const [result] = allResults;
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Noop],
+]
+`);
   });
 });

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -1,6 +1,7 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { EnvelopError, useMaskedErrors } from '../../src/plugins/use-masked-errors';
+import { useExtendContext } from '@envelop/core';
 
 describe('useMaskedErrors', () => {
   const schema = makeExecutableSchema({
@@ -70,5 +71,41 @@ describe('useMaskedErrors', () => {
       code: 'Foo',
       message: 'Bar',
     });
+  });
+
+  it('Should properly mask context creation errors', async () => {
+    expect.assertions(1);
+    const testInstance = createTestkit(
+      [
+        useExtendContext((): {} => {
+          throw new Error('No context for you!');
+        }),
+        useMaskedErrors(),
+      ],
+      schema
+    );
+    try {
+      await testInstance.execute(`query { secretWithExtensions }`);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: Unexpected error.]`);
+    }
+  });
+
+  it('Should not mask expected context creation errors', async () => {
+    expect.assertions(1);
+    const testInstance = createTestkit(
+      [
+        useExtendContext((): {} => {
+          throw new EnvelopError('No context for you!');
+        }),
+        useMaskedErrors(),
+      ],
+      schema
+    );
+    try {
+      await testInstance.execute(`query { secretWithExtensions }`);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: No context for you!]`);
+    }
   });
 });

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -47,6 +47,7 @@ describe('useGenericAuth', () => {
     });
 
     it('Should prevent execution when user is not authenticated correctly', async () => {
+      expect.assertions(1);
       const testInstance = createTestkit(
         [
           useGenericAuth({
@@ -57,11 +58,11 @@ describe('useGenericAuth', () => {
         schema
       );
 
-      const result = await testInstance.execute(`query { test }`);
-      assertSingleExecutionValue(result);
-      expect(result.errors!.length).toBe(1);
-      expect(result.errors![0].message).toBe('Unauthenticated!');
-      expect(result.errors![0].path).toBeUndefined();
+      try {
+        await testInstance.execute(`query { test }`);
+      } catch (err) {
+        expect(err).toMatchInlineSnapshot(`[GraphQLError: Unauthenticated!]`);
+      }
     });
 
     it('Should inject currentUser into the context when the user is valid', async () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -165,29 +165,21 @@ export function createTestkit(pluginsOrEnvelop: GetEnvelopedFn<any> | Plugin<any
         };
       }
 
-      let contextValue: any;
-
-      try {
-        contextValue = await proxy.contextFactory({
-          request: {
-            headers: {},
-            method: 'POST',
-            query: '',
-            body: {
-              query: print(document),
-              variables: variableValues,
-            },
+      const contextValue = await proxy.contextFactory({
+        request: {
+          headers: {},
+          method: 'POST',
+          query: '',
+          body: {
+            query: print(document),
+            variables: variableValues,
           },
-          document,
-          operation: print(document),
-          variables: variableValues,
-          ...initialContext,
-        });
-      } catch (err: unknown) {
-        return {
-          errors: [toGraphQLErrorOrThrow(err)],
-        };
-      }
+        },
+        document,
+        operation: print(document),
+        variables: variableValues,
+        ...initialContext,
+      });
 
       if (mainOperation.operation === 'subscription') {
         return proxy.subscribe({

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -482,11 +482,22 @@ export type OnSubscribeResultResult = {
  */
 export type SubscribeResultHook = (options: OnSubscribeResultEventPayload) => void | OnSubscribeResultResult;
 
+export type SubscribeErrorHookPayload = {
+  error: unknown;
+  setError: (err: unknown) => void;
+};
+
+export type SubscribeErrorHook = (payload: SubscribeErrorHookPayload) => void;
+
 export type OnSubscribeHookResult<ContextType> = {
   /**
    * Invoked with the result returned from subscribe.
    */
   onSubscribeResult?: SubscribeResultHook;
+  /**
+   * Invoked if the source stream returned from subscribe throws an error.
+   */
+  onSubscribeError?: SubscribeErrorHook;
   /**
    * Invoked before each resolver has been invoked during the execution phase.
    */

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -37,6 +37,17 @@ export type OnSchemaChangeEventPayload = { schema: GraphQLSchema; replaceSchema:
  */
 export type OnSchemaChangeHook = (options: OnSchemaChangeEventPayload) => void;
 
+export type OnContextErrorHandlerPayload = {
+  /** The error or thing that got rejected or thrown */
+  error: unknown;
+  /** Overwrite the error or thing that got rejected or thrown. */
+  setError: (err: unknown) => void;
+};
+
+export type OnContextErrorHandler = (options: OnContextErrorHandlerPayload) => PromiseOrValue<void>;
+
+export type RegisterContextErrorHandler = (handler: OnContextErrorHandler) => void;
+
 /**
  * Payload forwarded to the onPluginInit hook.
  */
@@ -53,6 +64,10 @@ export type OnPluginInitEventPayload = {
    * Set the GraphQL schema.
    */
   setSchema: SetSchemaFn;
+  /**
+   * Register an error handler used for context creation.
+   */
+  registerContextErrorHandler: RegisterContextErrorHandler;
 };
 
 /**


### PR DESCRIPTION
Alternative for https://github.com/dotansimha/envelop/pull/616

- Mask errors thrown within `contextFactory`
- Mask errors occurring during `subscribe`