### PR TITLE
Fixes issues with generic-auth plugin and missing `directiveNode` 

### DIFF
--- a/.changeset/smart-poets-pull.md
+++ b/.changeset/smart-poets-pull.md
@@ -1,0 +1,6 @@
+---
+'@envelop/generic-auth': minor
+---
+
+- Rename resolveUserFn to resolveUser
+- Fix issue with inaccessible directiveNode

--- a/.changeset/smart-poets-pull.md
+++ b/.changeset/smart-poets-pull.md
@@ -1,6 +1,5 @@
 ---
-'@envelop/generic-auth': minor
+'@envelop/generic-auth': patch
 ---
 
-- Rename resolveUserFn to resolveUser
-- Fix issue with inaccessible directiveNode
+Fix issue with inaccessible directiveNode

--- a/packages/plugins/generic-auth/CHANGELOG.md
+++ b/packages/plugins/generic-auth/CHANGELOG.md
@@ -1,10 +1,9 @@
 # @envelop/generic-auth
 
-## 1.1.0
+## 1.0.1
 
-### Minor Changes
+### Patch Changes
 
-- Rename resolveUserFn to resolveUser
 - Fix issue with inaccessible directiveNode
 
 ## 1.0.0

--- a/packages/plugins/generic-auth/CHANGELOG.md
+++ b/packages/plugins/generic-auth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @envelop/generic-auth
 
+## 1.1.0
+
+### Minor Changes
+
+- Rename resolveUserFn to resolveUser
+- Fix issue with inaccessible directiveNode
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -20,7 +20,7 @@ yarn add @envelop/generic-auth
 
 Then, define your authentication methods:
 
-1. Resolve your user from the request by implementing `resolveUser` function:
+1. Resolve your user from the request by implementing `resolveUserFn`:
 
 Use this method to only extract the user from the context, with any custom code, for example:
 
@@ -31,7 +31,7 @@ type UserType = {
   id: string;
 };
 
-const resolveUser: ResolveUserFn<UserType> = async context => {
+const resolveUserFn: ResolveUserFn<UserType> = async context => {
   // Here you can implement any custom sync/async code, and use the context built so far in Envelop and the HTTP request
   // to find the current user.
   // Common practice is to use a JWT token here, validate it, and use the payload as-is, or fetch the user from an external services.
@@ -78,12 +78,12 @@ To setup this mode, use the following config:
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUser: ResolveUserFn<UserType> = async context => {
+const resolveUserFn: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {
@@ -108,12 +108,12 @@ This mode uses the plugin to inject the authenticated user into the `context`, a
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUser: ResolveUserFn<UserType> = async context => {
+const resolveUserFn: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {
@@ -153,12 +153,12 @@ This mode is similar to option #2, but it uses `@auth` SDL directive to automati
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUser: ResolveUserFn<UserType> = async context => {
+const resolveUserFn: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -78,7 +78,7 @@ To setup this mode, use the following config:
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
@@ -94,7 +94,7 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useGenericAuth({
-      resolveUser,
+      resolveUserFn,
       validateUser,
       mode: 'protect-all',
     }),
@@ -108,7 +108,7 @@ This mode uses the plugin to inject the authenticated user into the `context`, a
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
@@ -124,7 +124,7 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useGenericAuth({
-      resolveUser,
+      resolveUserFn,
       validateUser,
       mode: 'resolve-only',
     }),
@@ -153,7 +153,7 @@ This mode is similar to option #2, but it uses `@auth` SDL directive to automati
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
@@ -169,7 +169,7 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useGenericAuth({
-      resolveUser,
+      resolveUserFn,
       validateUser,
       mode: 'protect-auth-directive',
     }),

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -234,7 +234,7 @@ const validateUser: ValidateUserFn<UserType> = async (user, context, { root, arg
     throw new Error(`Unauthenticated!`);
   }
 
-  const valueNode = authDirectiveNode.arguments.find(arg => arg.name.value === 'role').value as EnumValueNode;
+  const valueNode = directiveNode.arguments.find(arg => arg.name.value === 'role').value as EnumValueNode;
   const role = valueNode.value;
 
   if (role !== user.role) {

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -20,7 +20,7 @@ yarn add @envelop/generic-auth
 
 Then, define your authentication methods:
 
-1. Resolve your user from the request by implementing `resolveUserFn`:
+1. Resolve your user from the request by implementing `resolveUser` function:
 
 Use this method to only extract the user from the context, with any custom code, for example:
 
@@ -31,7 +31,7 @@ type UserType = {
   id: string;
 };
 
-const resolveUserFn: ResolveUserFn<UserType> = async context => {
+const resolveUser: ResolveUserFn<UserType> = async context => {
   // Here you can implement any custom sync/async code, and use the context built so far in Envelop and the HTTP request
   // to find the current user.
   // Common practice is to use a JWT token here, validate it, and use the payload as-is, or fetch the user from an external services.
@@ -78,12 +78,12 @@ To setup this mode, use the following config:
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUserFn: ResolveUserFn<UserType> = async context => {
+const resolveUser: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {
@@ -108,12 +108,12 @@ This mode uses the plugin to inject the authenticated user into the `context`, a
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUserFn: ResolveUserFn<UserType> = async context => {
+const resolveUser: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {
@@ -153,12 +153,12 @@ This mode is similar to option #2, but it uses `@auth` SDL directive to automati
 
 ```ts
 import { envelop } from '@envelop/core';
-import { useGenericAuth, resolveUser, ValidateUserFn } from '@envelop/generic-auth';
+import { useGenericAuth, ResolveUserFn, ValidateUserFn } from '@envelop/generic-auth';
 
 type UserType = {
   id: string;
 };
-const resolveUserFn: ResolveUserFn<UserType> = async context => {
+const resolveUser: ResolveUserFn<UserType> = async context => {
   /* ... */
 };
 const validateUser: ValidateUserFn<UserType> = async (user, context) => {

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -27,7 +27,7 @@ export type GenericAuthPluginOptions<UserType extends {} = {}, ContextType exten
    * Common practice is to use a JWT token here, validate it, and use the payload as-is, or fetch the user from an external services.
    * Make sure to either return `null` or the user object.
    */
-  resolveUser: ResolveUserFn<UserType, ContextType>;
+  resolveUserFn: ResolveUserFn<UserType, ContextType>;
   /**
    * Here you can implement any custom to check if the user is valid and have access to the server.
    * This method is being triggered in different flows, besed on the mode you chose to implement.
@@ -84,7 +84,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   if (options.mode === 'protect-all') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUser(context as unknown as ContextType);
+        const user = await options.resolveUserFn(context as unknown as ContextType);
         await validateUser(user!, context as unknown as ContextType);
 
         extendContext({
@@ -95,7 +95,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   } else if (options.mode === 'resolve-only') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUser(context as unknown as ContextType);
+        const user = await options.resolveUserFn(context as unknown as ContextType);
 
         extendContext({
           [fieldName]: user,
@@ -106,7 +106,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   } else if (options.mode === 'protect-auth-directive') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUser(context as unknown as ContextType);
+        const user = await options.resolveUserFn(context as unknown as ContextType);
 
         extendContext({
           [fieldName]: user,

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -110,7 +110,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
 
         extendContext({
           [fieldName]: user,
-          validateUser: () => validateUser(user!, context as unknown as ContextType),
+          validateUser,
         } as unknown as ContextType);
       },
       onExecute() {

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -27,7 +27,7 @@ export type GenericAuthPluginOptions<UserType extends {} = {}, ContextType exten
    * Common practice is to use a JWT token here, validate it, and use the payload as-is, or fetch the user from an external services.
    * Make sure to either return `null` or the user object.
    */
-  resolveUserFn: ResolveUserFn<UserType, ContextType>;
+  resolveUser: ResolveUserFn<UserType, ContextType>;
   /**
    * Here you can implement any custom to check if the user is valid and have access to the server.
    * This method is being triggered in different flows, besed on the mode you chose to implement.
@@ -84,7 +84,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   if (options.mode === 'protect-all') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUserFn(context as unknown as ContextType);
+        const user = await options.resolveUser(context as unknown as ContextType);
         await validateUser(user!, context as unknown as ContextType);
 
         extendContext({
@@ -95,7 +95,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   } else if (options.mode === 'resolve-only') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUserFn(context as unknown as ContextType);
+        const user = await options.resolveUser(context as unknown as ContextType);
 
         extendContext({
           [fieldName]: user,
@@ -106,7 +106,7 @@ export const useGenericAuth = <UserType extends {} = {}, ContextType extends Def
   } else if (options.mode === 'protect-auth-directive') {
     return {
       async onContextBuilding({ context, extendContext }) {
-        const user = await options.resolveUserFn(context as unknown as ContextType);
+        const user = await options.resolveUser(context as unknown as ContextType);
 
         extendContext({
           [fieldName]: user,

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -34,7 +34,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-all',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
         ],
         schema
@@ -51,7 +51,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-all',
-            resolveUserFn: invalidresolveUserFn,
+            resolveUser: invalidresolveUserFn,
           }),
         ],
         schema
@@ -70,7 +70,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -103,7 +103,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
         ],
         schema
@@ -120,7 +120,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: invalidresolveUserFn,
+            resolveUser: invalidresolveUserFn,
           }),
         ],
         schema
@@ -138,7 +138,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -170,7 +170,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: invalidresolveUserFn,
+            resolveUser: invalidresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -199,7 +199,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -246,7 +246,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -263,7 +263,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUserFn: validresolveUserFn,
+            resolveUser: validresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -280,7 +280,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUserFn: invalidresolveUserFn,
+            resolveUser: invalidresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -297,7 +297,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUserFn: invalidresolveUserFn,
+            resolveUser: invalidresolveUserFn,
           }),
         ],
         schemaWithDirective

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -375,7 +375,7 @@ describe('useGenericAuth', () => {
           [
             useGenericAuth({
               mode: 'protect-auth-directive',
-              resolveUser: invalidRoleResolveUserFn,
+              resolveUserFn: invalidRoleResolveUserFn,
               validateUser: validateUserFn,
             }),
           ],
@@ -394,7 +394,7 @@ describe('useGenericAuth', () => {
           [
             useGenericAuth({
               mode: 'protect-auth-directive',
-              resolveUser: validRoleResolveUserFn,
+              resolveUserFn: validRoleResolveUserFn,
               validateUser: validateUserFn,
             }),
           ],

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -35,7 +35,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-all',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
         ],
         schema
@@ -52,7 +52,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-all',
-            resolveUser: invalidresolveUserFn,
+            resolveUserFn: invalidresolveUserFn,
           }),
         ],
         schema
@@ -71,7 +71,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -104,7 +104,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
         ],
         schema
@@ -121,7 +121,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: invalidresolveUserFn,
+            resolveUserFn: invalidresolveUserFn,
           }),
         ],
         schema
@@ -139,7 +139,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -171,7 +171,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: invalidresolveUserFn,
+            resolveUserFn: invalidresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -200,7 +200,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'resolve-only',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
           {
             onExecute: spyFn,
@@ -247,7 +247,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -264,7 +264,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUser: validresolveUserFn,
+            resolveUserFn: validresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -281,7 +281,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUser: invalidresolveUserFn,
+            resolveUserFn: invalidresolveUserFn,
           }),
         ],
         schemaWithDirective
@@ -298,7 +298,7 @@ describe('useGenericAuth', () => {
         [
           useGenericAuth({
             mode: 'protect-auth-directive',
-            resolveUser: invalidresolveUserFn,
+            resolveUserFn: invalidresolveUserFn,
           }),
         ],
         schemaWithDirective


### PR DESCRIPTION
## Description

Fixes #614 

1. Fixed the conflicts between documentation and implementation.
- Renamed resolveUserFn to resolveUser (this would be a breaking change)
- Fixed Documentation

2. Fixed: directiveNode is not passed to validateUser onExecute.
- Pass directiveNode correctly to validateUser when run it on onExecute
- Added test code for role-aware authentication
- Fixed Documentation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test code for role-aware authentication
- [x] Tested on my personal project https://github.com/taneba/fullstack-graphql-app/blob/main/backend/src/getEnveloped.ts

"@envelop/generic-auth": "^1.0.0"
"@envelop/core": "^1.0.3"

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

1 test failed but this is the same in main branch so I left it as it is.