### PR TITLE
fix: await execute before calling "onEnd"

### DIFF
--- a/.changeset/twelve-vans-protect.md
+++ b/.changeset/twelve-vans-protect.md
@@ -1,0 +1,5 @@
+---
+'@envelop/execute-subscription-event': patch
+---
+
+fix: await execute before calling "onEnd"

--- a/packages/plugins/execute-subscription-event/src/index.ts
+++ b/packages/plugins/execute-subscription-event/src/index.ts
@@ -28,7 +28,7 @@ export const useExtendContextValuePerExecuteSubscriptionEvent = <TContextValue =
       const executeNew = makeExecute(async executionArgs => {
         const context = await createContext({ args });
         try {
-          return execute({
+          return await execute({
             ...executionArgs,
             contextValue: { ...executionArgs.contextValue, ...context?.contextPartial },
           });


### PR DESCRIPTION
Right now the `"onEnd"` always gets called right away after execute is called but not after it ends.