### PR TITLE
Adds `skip` option to Sentry plugin

### DIFF
--- a/.changeset/tame-countries-knock.md
+++ b/.changeset/tame-countries-knock.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': minor
+---
+
+Adds "skip" to indicate whether or not to skip the entire Sentry flow for given GraphQL operation

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -62,8 +62,8 @@ export type SentryPluginOptions = {
 };
 
 export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
-  function pick<K extends keyof SentryPluginOptions>(key: K, defaultValue?: SentryPluginOptions[K]): SentryPluginOptions[K] {
-    return prioritize(options[key], defaultValue);
+  function pick<K extends keyof SentryPluginOptions>(key: K, defaultValue: NonNullable<SentryPluginOptions[K]>) {
+    return options[key] ?? defaultValue;
   }
 
   const startTransaction = pick('startTransaction', true);
@@ -72,7 +72,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeRawResult = pick('includeRawResult', false);
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
-  const skip = pick('skip', () => false)!;
+  const skip = pick('skip', () => false);
 
   return {
     onExecute({ args }) {
@@ -235,16 +235,3 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
     },
   };
 };
-
-/**
- * Sets a priority for provided values from left (highest) to right (lowest)
- */
-function prioritize<T>(...values: T[]): T {
-  const picked = values.find(val => typeof val !== 'undefined');
-
-  if (typeof picked === 'undefined') {
-    return values[values.length - 1];
-  }
-
-  return picked;
-}


### PR DESCRIPTION
Adds "skip" to indicate whether or not to skip the entire Sentry flow for given GraphQL operation.

```typescript
skip?: (args: ExecutionArgs) => boolean;
```