### PR TITLE
feat: firebase-auth plugin

### DIFF
--- a/packages/plugins/firebase-auth/README.md
+++ b/packages/plugins/firebase-auth/README.md
@@ -1,0 +1,3 @@
+## `@envelop/firebase-auth`
+
+TODO

--- a/packages/plugins/firebase-auth/README.md
+++ b/packages/plugins/firebase-auth/README.md
@@ -1,3 +1,72 @@
 ## `@envelop/firebase-auth`
 
-TODO
+This plugin validates JWT token created by Firebase Auth and injects the Firebase user profile into your GraphQL context, you can implement authentication in a simple way.
+
+## Getting Started
+
+1. Setup a firebase project and setup Auth on your web app. Checkout [Get Started with Firebase Authentication on Websites](https://firebase.google.com/docs/auth/web/start)
+2. When you sign up your user you can get a JWT token from Firebase Auth by calling `getIdToken()` on your user object. Pass that token as a header in your GraphQL request (for example: `Authorization: Bearer <TOKEN>`).
+3. Generate a private key for your Firebase project so your server can verify the token. Checkout [Add the Firebase Admin SDK to your server](https://firebase.google.com/docs/admin/setup)
+4. Add the plugin to your server and configure it.
+
+```ts
+import { envelop } from '@envelop/core';
+import { useFirebaseAuth } from '@envelop/firebase-auth';
+import admin from 'firebase-admin';
+import serviceAccount from "path/to/serviceAccountKey.json";
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    plugins: [
+      useFirebaseAuth({
+        firebaseApp: admin.initializeApp({ credential: admin.credential.cert(serviceAccount)}),
+      }),
+    ],
+});
+```
+
+5. Make sure to pass your request as part of the context building:
+
+```ts
+myHttpServer.on('request', async req => {
+  const { contextFactory } = getEnveloped({ req });
+  const contextValue = await contextFactory({ req }); // Make sure to pass it here
+});
+```
+
+6. You should be able to get user profile from the context.
+
+```ts
+const myResolvers = {
+  Query: {
+    me: (root, args, context, info) => {
+      const firebaseUser = context._firebaseAuth;
+    },
+  },
+};
+```
+
+### API Reference
+
+#### `firebaseApp`
+
+This is the firebase app instance that is passed to the plugin to validate the token.
+
+See https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp for all the options that you can pass.
+
+#### `headerName` + `tokenType`
+
+This plugin looks for `req` and `request` in the context, then look for `headers` and look for `authentication` header (you can customize it with `headerName`). Then, it validates that the token is of type `Bearer` (you can customize it with `tokenType` option).
+
+#### `extendContextField`
+
+The name of the field to inject to your `context`. When the user is valid, the decoded and verified payload of the JWT is injected.
+
+You can read more about the token structure here: e https://github.com/firebase/firebase-admin-node/blob/d96e61bad190a2e7bd68c35a55626f65c0506a7a/src/auth/index.ts#L503-L650
+
+By default, the `_firebaseAuth` value is used.
+
+### Examples
+
+Checkout https://github.com/saihaj/firebase-graphql-envelop [Create React App](https://create-react-app.dev) + [GraphQL EZ](https://www.graphql-ez.com) app using this plugin

--- a/packages/plugins/firebase-auth/package.json
+++ b/packages/plugins/firebase-auth/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@envelop/firebase-auth",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Saihajpreet Singh <saihajpreet.singh@gmail.com> (https://github.com/saihaj)",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/envelop.git",
+    "directory": "packages/plugins/firebase-auth"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "bob-the-bundler": "1.5.1",
+    "graphql": "15.5.3",
+    "typescript": "4.4.3"
+  },
+  "peerDependencies": {
+    "firebase-admin": "^9.0.0",
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/firebase-auth/src/index.ts
+++ b/packages/plugins/firebase-auth/src/index.ts
@@ -1,0 +1,60 @@
+/* eslint-disable dot-notation */
+/* eslint-disable no-console */
+import { Plugin } from '@envelop/types';
+import { app, auth } from 'firebase-admin';
+import { GraphQLError } from 'graphql';
+
+export type FirebaseAuthPluginOptions = {
+  firebaseApp: app.App;
+  tokenType?: string;
+  headerName?: string;
+  extendContextField?: '_firebaseAuth' | string;
+};
+
+type BuildContext<TOptions extends FirebaseAuthPluginOptions> = TOptions['extendContextField'] extends string
+  ? {
+      [TName in TOptions['extendContextField'] as TOptions['extendContextField']]: auth.DecodedIdToken;
+    }
+  : { _firebaseAuth: auth.DecodedIdToken };
+
+export const useFirebaseAuth = <TOptions extends FirebaseAuthPluginOptions>({
+  tokenType = 'Bearer',
+  headerName = 'authorization',
+  extendContextField = '_firebaseAuth',
+  firebaseApp,
+}: TOptions): Plugin<BuildContext<TOptions>> => {
+  return {
+    async onContextBuilding({ context, extendContext }) {
+      const req = context['req'] || context['request'] || {};
+      const headers = req.headers || context['headers'] || null;
+
+      if (!headers) {
+        console.warn('No headers found in request');
+      }
+
+      const authHeader = headers[headerName];
+      if (!authHeader) {
+        throw new Error(`No ${headerName} header found in request`);
+      }
+
+      const split = authHeader.split(' ');
+      if (split.length !== 2) {
+        throw new Error(`Invalid ${tokenType} value for ${headerName} header!`);
+      }
+
+      const [type, token] = split;
+      if (type !== tokenType) {
+        throw new Error(`Unsupported token type provided: ${type}!`);
+      }
+
+      try {
+        const verifiedToken = await firebaseApp.auth().verifyIdToken(token);
+        return extendContext({
+          [extendContextField]: verifiedToken,
+        } as BuildContext<TOptions>);
+      } catch (e) {
+        throw new GraphQLError('Invalid token');
+      }
+    },
+  };
+};

--- a/packages/plugins/firebase-auth/tests/use-firebase-auth.spec.ts
+++ b/packages/plugins/firebase-auth/tests/use-firebase-auth.spec.ts
@@ -1,0 +1,6 @@
+// TODO: Add tests
+describe('useFirebaseAuth', () => {
+  it('pass', () => {
+    expect(1).toBe(1);
+  });
+});


### PR DESCRIPTION
A simple plugin that allows to use [Firebase Auth](https://firebase.google.com/docs/auth) to authenticate users. 

**Flow for this plugin:**
Client logs in using client SDK -> Frontend will pass a JWT that is used to identify the user to a Firebase service -> this plugin extracts the headers for that JWT and verifies the identity -> if all good, firebase user object is added to context.

I made a demo here https://github.com/saihaj/firebase-graphql-envelop that only allows authenticated users. 

**To Do**
- [ ] Write tests?
- [x] Add readme with demo