### PR TITLE
fix and test ESM

### DIFF
--- a/.changeset/serious-actors-arrive.md
+++ b/.changeset/serious-actors-arrive.md
@@ -1,0 +1,9 @@
+---
+'@envelop/auth0': patch
+'@envelop/execute-subscription-event': patch
+'@envelop/extended-validation': patch
+'@envelop/fragment-arguments': patch
+'@envelop/newrelic': patch
+---
+
+fix ESM

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,3 +51,5 @@ jobs:
         run: yarn test:ci --logHeapUsage
         env:
           CI: true
+      - name: Check ESM
+        run: node ./scripts/test-esm.mjs

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "ts-jest": "27.0.5",
     "rimraf": "3.0.2",
     "typescript": "4.4.3",
-    "jest": "27.2.0"
+    "jest": "27.2.0",
+    "chalk": "4.1.2",
+    "globby": "11.0.4"
   },
   "resolutions": {
     "@changesets/git": "1.1.2",

--- a/packages/plugins/auth0/src/index.ts
+++ b/packages/plugins/auth0/src/index.ts
@@ -2,8 +2,10 @@
 /* eslint-disable dot-notation */
 import { Plugin } from '@envelop/types';
 import * as JwksRsa from 'jwks-rsa';
-import { decode, verify, VerifyOptions, DecodeOptions } from 'jsonwebtoken';
+import jwtPkg, { VerifyOptions, DecodeOptions } from 'jsonwebtoken';
 import { GraphQLError } from 'graphql';
+
+const { decode, verify } = jwtPkg;
 
 export type Auth0PluginOptions = {
   domain: string;

--- a/packages/plugins/execute-subscription-event/src/subscribe.ts
+++ b/packages/plugins/execute-subscription-event/src/subscribe.ts
@@ -2,7 +2,7 @@ import { createSourceEventStream } from 'graphql';
 
 import { ExecuteFunction, makeSubscribe, SubscribeFunction } from '@envelop/core';
 import { isAsyncIterable } from '@envelop/types';
-import mapAsyncIterator from 'graphql/subscription/mapAsyncIterator';
+import mapAsyncIterator from 'graphql/subscription/mapAsyncIterator.js';
 
 /**
  * This is a almost identical port from graphql-js subscribe.

--- a/packages/plugins/extended-validation/src/rules/one-of.ts
+++ b/packages/plugins/extended-validation/src/rules/one-of.ts
@@ -1,5 +1,5 @@
 import { ArgumentNode, GraphQLError, GraphQLInputObjectType, GraphQLInputType, isListType, ValidationContext } from 'graphql';
-import { getArgumentValues } from 'graphql/execution/values';
+import { getArgumentValues } from 'graphql/execution/values.js';
 import { ExtendedValidationRule, getDirectiveFromAstNode, unwrapType } from '../common';
 
 export const ONE_OF_DIRECTIVE_SDL = /* GraphQL */ `

--- a/packages/plugins/fragment-arguments/src/extended-parser.ts
+++ b/packages/plugins/fragment-arguments/src/extended-parser.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { Parser } from 'graphql/language/parser';
+import { Parser } from 'graphql/language/parser.js';
 import { TokenKind, Kind } from 'graphql';
 
 export class FragmentArgumentCompatibleParser extends Parser {

--- a/packages/plugins/newrelic/src/index.ts
+++ b/packages/plugins/newrelic/src/index.ts
@@ -1,7 +1,9 @@
-import { shim as instrumentationApi } from 'newrelic';
+import newRelic from 'newrelic';
 import { Plugin, OnResolverCalledHook, isAsyncIterable } from '@envelop/types';
 import { print, FieldNode, Kind, OperationDefinitionNode } from 'graphql';
 import { Path } from 'graphql/jsutils/Path';
+
+const { shim: instrumentationApi } = newRelic;
 
 enum AttributeName {
   COMPONENT_NAME = 'Envelop_NewRelic_Plugin',

--- a/scripts/test-esm.mjs
+++ b/scripts/test-esm.mjs
@@ -1,0 +1,51 @@
+import globby from 'globby';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+
+process.env.NEW_RELIC_APP_NAME = 'TEST';
+
+async function main() {
+  const mjsFiles = await globby(['../packages/*/dist/*.mjs', '../packages/plugins/*/dist/*.mjs'], {
+    cwd: dirname(fileURLToPath(import.meta.url)),
+  });
+
+  const ok = [];
+  const fail = [];
+
+  let i = 0;
+  await Promise.all(
+    mjsFiles.map(mjsFile => {
+      const mjsPath = `./${mjsFile}`;
+      return import(mjsPath)
+        .then(() => {
+          ok.push(mjsPath);
+        })
+        .catch(err => {
+          const color = i++ % 2 === 0 ? chalk.magenta : chalk.red;
+          console.error(color('\n\n-----\n' + i + '\n'));
+          console.error(mjsPath, err);
+          console.error(color('\n-----\n\n'));
+          fail.push(mjsPath);
+        });
+    })
+  );
+  ok.length && console.log(chalk.blue(`${ok.length} OK: ${ok.join(' | ')}`));
+  fail.length && console.error(chalk.red(`${fail.length} Fail: ${fail.join(' | ')}`));
+
+  if (fail.length) {
+    console.error('\nFAILED');
+    process.exit(1);
+  } else if (ok.length) {
+    console.error('\nOK');
+    process.exit(0);
+  } else {
+    console.error('No files analyzed!');
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,6 +4263,14 @@ chalk@4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"


### PR DESCRIPTION
While trying to use [useExtendedValidation](https://www.envelop.dev/plugins/use-extended-validation) I got the error ` Cannot find module '...graphql/execution/values'` and then I realized that this kind of issue was in more places and the `test-esm.mjs` script that is in place for codegen & tools, was not in Envelop, because of this error it's not possible to use the fixed packages in ESM projects

