### PR TITLE
useParserCache - Remove unnecessary cache.get() calls

### DIFF
--- a/.changeset/metal-bears-beg.md
+++ b/.changeset/metal-bears-beg.md
@@ -1,0 +1,5 @@
+---
+'@envelop/parser-cache': patch
+---
+
+Refactor to call document and error caches only once per request.

--- a/packages/plugins/graphql-jit/src/index.ts
+++ b/packages/plugins/graphql-jit/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { DefaultContext, Plugin } from '@envelop/types';
+import { Plugin } from '@envelop/types';
 import { GraphQLError, DocumentNode, Source, ExecutionArgs } from 'graphql';
 import { compileQuery, isCompiledQuery, CompilerOptions } from 'graphql-jit';
 import lru from 'tiny-lru';

--- a/packages/plugins/parser-cache/src/index.ts
+++ b/packages/plugins/parser-cache/src/index.ts
@@ -22,18 +22,16 @@ export const useParserCache = (pluginOptions: ParserCacheOptions = {}): Plugin =
       const { source } = params;
       const key = source instanceof Source ? source.body : source;
 
-      if (errorCache.get(key)) {
-        const error = errorCache.get(key);
+      const cachedError = errorCache.get(key);
 
-        throw error;
+      if (cachedError !== undefined) {
+        throw cachedError;
       }
 
-      if (documentCache.get(key)) {
-        const document = documentCache.get(key);
+      const cachedDocument = documentCache.get(key);
 
-        if (document) {
-          setParsedDocument(document);
-        }
+      if (cachedDocument !== undefined) {
+        setParsedDocument(cachedDocument);
       }
 
       return ({ result }) => {


### PR DESCRIPTION
## Description

Changing `useParserCache` to call `errorCache` and `documentCache` only once per perquest.

Fixes https://github.com/dotansimha/envelop/issues/720

Also removed the unnecessary import of `DefaultContext` in `packages/plugins/graphql-jit/src/index.ts` as `yarn lint` highlighted that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `packages/plugins/parser-cache/test/parser-cache.spec.ts`

**Test Environment**:

- OS: macOS 11.1
- `@envelop/...`: latest
- NodeJS: v14.15.4

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
