### PR TITLE
Masked error plugin: Configure custom message used to mask errors

### DIFF
--- a/.changeset/few-horses-exist.md
+++ b/.changeset/few-horses-exist.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': minor
+---
+
+Adds a custom message option used when masking errors

--- a/packages/core/docs/use-masked-errors.md
+++ b/packages/core/docs/use-masked-errors.md
@@ -36,3 +36,27 @@ const getEnveloped = envelop({
   plugins: [useSchema(schema), useMaskedErrors()],
 });
 ```
+
+You may customize the default error message `Unexpected error.` with your own `errorMessage`:
+
+```ts
+const getEnveloped = envelop({
+  plugins: [useSchema(schema), useMaskedErrors({ errorMessage: 'Something went wrong.' })],
+});
+```
+
+Or provide a custom formatter when masking the output:
+
+```ts
+export const customFormatError: FormatErrorHandler = (err: any) => {
+  if (err.originalError && err.originalError instanceof EnvelopError === false) {
+    return new GraphQLError('Sorry, something went wrong.');
+  }
+
+  return err;
+};
+
+const getEnveloped = envelop({
+  plugins: [useSchema(schema), useMaskedErrors({ formatError: customFormatError })],
+});
+```

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -1,44 +1,48 @@
 import { handleStreamOrSingleExecutionResult, Plugin } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
 
+export const DEFAULT_ERROR_MESSAGE = 'Unexpected error.';
+
 export class EnvelopError extends GraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
     super(message, undefined, undefined, undefined, undefined, undefined, extensions);
   }
 }
 
-export type FormatErrorHandler = (error: GraphQLError | unknown) => GraphQLError;
+export type FormatErrorHandler = (error: GraphQLError | unknown, message: string) => GraphQLError;
 
-export const formatError: FormatErrorHandler = err => {
+export const formatError: FormatErrorHandler = (err, message) => {
   if (err instanceof GraphQLError) {
     if (err.originalError && err.originalError instanceof EnvelopError === false) {
-      return new GraphQLError('Unexpected error.', err.nodes, err.source, err.positions, err.path, undefined);
+      return new GraphQLError(message, err.nodes, err.source, err.positions, err.path, undefined);
     }
     return err;
   }
-  return new GraphQLError('Unexpected error.');
+  return new GraphQLError(message);
 };
 
 export type UseMaskedErrorsOpts = {
   formatError?: FormatErrorHandler;
+  errorMessage?: string;
 };
 
 const makeHandleResult =
-  (format: FormatErrorHandler) =>
+  (format: FormatErrorHandler, message: string) =>
   ({ result, setResult }: { result: ExecutionResult; setResult: (result: ExecutionResult) => void }) => {
     if (result.errors != null) {
-      setResult({ ...result, errors: result.errors.map(error => format(error)) });
+      setResult({ ...result, errors: result.errors.map(error => format(error, message)) });
     }
   };
 
 export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
   const format = opts?.formatError ?? formatError;
-  const handleResult = makeHandleResult(format);
+  const message = opts?.errorMessage || DEFAULT_ERROR_MESSAGE;
+  const handleResult = makeHandleResult(format, message);
 
   return {
     onPluginInit(context) {
       context.registerContextErrorHandler(({ error, setError }) => {
-        setError(formatError(error));
+        setError(formatError(error, message));
       });
     },
     onExecute() {
@@ -54,7 +58,7 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
           return handleStreamOrSingleExecutionResult(payload, handleResult);
         },
         onSubscribeError({ error, setError }) {
-          setError(formatError(error));
+          setError(formatError(error, message));
         },
       };
     },

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -5,7 +5,7 @@ import {
   collectAsyncIteratorValues,
   createTestkit,
 } from '@envelop/testing';
-import { EnvelopError, useMaskedErrors } from '../../src/plugins/use-masked-errors';
+import { EnvelopError, useMaskedErrors, DEFAULT_ERROR_MESSAGE } from '../../src/plugins/use-masked-errors';
 import { useExtendContext } from '@envelop/core';
 
 describe('useMaskedErrors', () => {
@@ -92,7 +92,7 @@ describe('useMaskedErrors', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors).toHaveLength(1);
     const [error] = result.errors!;
-    expect(error.message).toEqual('Unexpected error.');
+    expect(error.message).toEqual(DEFAULT_ERROR_MESSAGE);
   });
 
   it('Should mask unexpected errors', async () => {
@@ -128,6 +128,23 @@ describe('useMaskedErrors', () => {
     });
   });
 
+  it('Should properly mask context creation errors with a custom error message', async () => {
+    expect.assertions(1);
+    const testInstance = createTestkit(
+      [
+        useExtendContext((): {} => {
+          throw new Error('No context for you!');
+        }),
+        useMaskedErrors({ errorMessage: 'My Custom Error Message.' }),
+      ],
+      schema
+    );
+    try {
+      await testInstance.execute(`query { secretWithExtensions }`);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: My Custom Error Message.]`);
+    }
+  });
   it('Should properly mask context creation errors', async () => {
     expect.assertions(1);
     const testInstance = createTestkit(
@@ -142,7 +159,7 @@ describe('useMaskedErrors', () => {
     try {
       await testInstance.execute(`query { secretWithExtensions }`);
     } catch (err) {
-      expect(err).toMatchInlineSnapshot(`[GraphQLError: Unexpected error.]`);
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: ${DEFAULT_ERROR_MESSAGE}]`);
     }
   });
 
@@ -170,7 +187,19 @@ describe('useMaskedErrors', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors).toMatchInlineSnapshot(`
 Array [
-  [GraphQLError: Unexpected error.],
+  [GraphQLError: ${DEFAULT_ERROR_MESSAGE}],
+]
+`);
+  });
+
+  it('Should mask subscribe (sync/promise) subscription errors with a custom error message', async () => {
+    const testInstance = createTestkit([useMaskedErrors({ errorMessage: 'My Custom subscription errror message.' })], schema);
+    const result = await testInstance.execute(`subscription { instantError }`);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: My Custom subscription errror message.],
 ]
 `);
   });
@@ -195,9 +224,22 @@ Array [
     try {
       await collectAsyncIteratorValues(resultStream);
     } catch (err) {
-      expect(err).toMatchInlineSnapshot(`[GraphQLError: Unexpected error.]`);
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: ${DEFAULT_ERROR_MESSAGE}]`);
     }
   });
+
+  it('Should mask subscribe (AsyncIterable) subscription errors with a custom error message', async () => {
+    expect.assertions(1);
+    const testInstance = createTestkit([useMaskedErrors({ errorMessage: 'My AsyncIterable Custom Error Message.' })], schema);
+    const resultStream = await testInstance.execute(`subscription { streamError }`);
+    assertStreamExecutionValue(resultStream);
+    try {
+      await collectAsyncIteratorValues(resultStream);
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(`[GraphQLError: My AsyncIterable Custom Error Message.]`);
+    }
+  });
+
   it('Should not mask subscribe (AsyncIterable) subscription envelop errors', async () => {
     const testInstance = createTestkit([useMaskedErrors()], schema);
     const resultStream = await testInstance.execute(`subscription { streamEnvelopError }`);
@@ -219,7 +261,21 @@ Array [
     expect(result.errors).toBeDefined();
     expect(result.errors).toMatchInlineSnapshot(`
 Array [
-  [GraphQLError: Unexpected error.],
+  [GraphQLError: ${DEFAULT_ERROR_MESSAGE}],
+]
+`);
+  });
+  it('Should mask resolve subscription errors with a custom error message', async () => {
+    const testInstance = createTestkit([useMaskedErrors({ errorMessage: 'Custom resolve subscription errors.' })], schema);
+    const resultStream = await testInstance.execute(`subscription { streamResolveError }`);
+    assertStreamExecutionValue(resultStream);
+    const allResults = await collectAsyncIteratorValues(resultStream);
+    expect(allResults).toHaveLength(1);
+    const [result] = allResults;
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Custom resolve subscription errors.],
 ]
 `);
   });

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -193,13 +193,13 @@ Array [
   });
 
   it('Should mask subscribe (sync/promise) subscription errors with a custom error message', async () => {
-    const testInstance = createTestkit([useMaskedErrors({ errorMessage: 'My Custom subscription errror message.' })], schema);
+    const testInstance = createTestkit([useMaskedErrors({ errorMessage: 'My Custom subscription error message.' })], schema);
     const result = await testInstance.execute(`subscription { instantError }`);
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors).toMatchInlineSnapshot(`
 Array [
-  [GraphQLError: My Custom subscription errror message.],
+  [GraphQLError: My Custom subscription error message.],
 ]
 `);
   });


### PR DESCRIPTION
## Description

When using the maskedErrors plugin with RedwoodJS, we noticed that when we encounter errors raised within Context Building -- for example when we fetch the authentication headers or try to resolve the currentUser as part of the authentication flow -- then the plugin's formatError is called. And therefore, we message returned is the default "Unexpected error.".

Note: the maskedError plugin is the last plugin added (that is our custom auth plugins are registered before maskedErrors -- in case perhaps that is the issue).

It would be nice if those messages were consistent -- that is either:

* always use the custom formatError
* allow maskedError to defined a custom error message and use that when formatting.

Fixes # https://github.com/dotansimha/envelop/issues/724

This PR adds a custom message config -- it does not aim to address the formatError used in context building.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## How Has This Been Tested?

- [ ] Adds tests for existing with "with a custom error message" scenario

**Test Environment**:

- OS:
- `@envelop/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Perhaps addressing why a custom formatError isn't used when errors happen in context building or init is better, but it is still useful to expose a custom message to use for flexible messaging.