### PR TITLE
useValidationCache -  Read cache only once

### DIFF
--- a/.changeset/four-tables-protect.md
+++ b/.changeset/four-tables-protect.md
@@ -1,0 +1,5 @@
+---
+'@envelop/validation-cache': patch
+---
+
+Read from cache only once per request.

--- a/packages/plugins/validation-cache/src/index.ts
+++ b/packages/plugins/validation-cache/src/index.ts
@@ -21,13 +21,10 @@ export const useValidationCache = (pluginOptions: ValidationCacheOptions = {}): 
     },
     onValidate({ params, setResult }) {
       const key = print(params.documentAST);
+      const cachedResult = resultCache.get(key);
 
-      if (resultCache.get(key)) {
-        const errors = resultCache.get(key);
-
-        if (errors) {
-          setResult(errors);
-        }
+      if (cachedResult !== undefined) {
+        setResult(cachedResult);
       }
 
       return ({ result }) => {


### PR DESCRIPTION
## Description

Related https://github.com/dotansimha/envelop/issues/738

Calling `cache.get()` only once per request.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `packages/plugins/validation-cache/test/validation-cache.spec.ts`

**Test Environment**:

- OS: macOS 11.1
- `@envelop/...`: latest
- NodeJS: v14.15.4

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
