### PR TITLE
useErrorHandler: pass in the context to the error handlers

### DIFF
--- a/.changeset/ten-terms-join.md
+++ b/.changeset/ten-terms-join.md
@@ -3,4 +3,4 @@
 '@envelop/types': minor
 ---
 
-useErrorHandler: Pass in the context to the error handler callbacks.
+useErrorHandler: Pass in the execution arguments to the error handler callbacks.

--- a/.changeset/ten-terms-join.md
+++ b/.changeset/ten-terms-join.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': minor
+'@envelop/types': minor
+---
+
+useErrorHandler: Pass in the context to the error handler callbacks.

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ dist
 .bob
 temp
 .idea
+.history

--- a/packages/core/docs/use-error-handler.md
+++ b/packages/core/docs/use-error-handler.md
@@ -8,7 +8,7 @@ import { buildSchema } from 'graphql';
 
 const getEnveloped = envelop({
   plugins: [
-    useErrorHandler((errors, context) => {
+    useErrorHandler((errors, args) => {
       // This callback is called once, containing all GraphQLError emitted during execution phase
     }),
     // ... other plugins ...

--- a/packages/core/docs/use-error-handler.md
+++ b/packages/core/docs/use-error-handler.md
@@ -8,7 +8,7 @@ import { buildSchema } from 'graphql';
 
 const getEnveloped = envelop({
   plugins: [
-    useErrorHandler(error => {
+    useErrorHandler((error, context) => {
       // This callback is called per each GraphQLError emitted during execution phase
     }),
     // ... other plugins ...

--- a/packages/core/docs/use-error-handler.md
+++ b/packages/core/docs/use-error-handler.md
@@ -1,6 +1,6 @@
 #### `useErrorHandler`
 
-This plugin triggers a custom function every time execution encounter an error.
+This plugin triggers a custom function when execution encounters an error.
 
 ```ts
 import { envelop, useErrorHandler } from '@envelop/core';
@@ -8,12 +8,10 @@ import { buildSchema } from 'graphql';
 
 const getEnveloped = envelop({
   plugins: [
-    useErrorHandler((error, context) => {
-      // This callback is called per each GraphQLError emitted during execution phase
+    useErrorHandler((errors, context) => {
+      // This callback is called once, containing all GraphQLError emitted during execution phase
     }),
     // ... other plugins ...
   ],
 });
 ```
-
-> Note: every error is being triggered on it's own. So an execution results will multiple error will yield multiple calls.

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -460,6 +460,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
 
         for (const afterCb of afterCalls) {
           const hookResult = afterCb({
+            context,
             result,
             setResult: newResult => {
               result = newResult;

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -345,6 +345,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
 
     for (const afterCb of afterCalls) {
       const hookResult = afterCb({
+        context,
         result,
         setResult: newResult => {
           result = newResult;
@@ -363,7 +364,11 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
     if (onNextHandler.length && isAsyncIterable(result)) {
       result = mapAsyncIterator(result, async result => {
         for (const onNext of onNextHandler) {
-          await onNext({ result, setResult: newResult => (result = newResult) });
+          await onNext({
+            context,
+            result,
+            setResult: newResult => (result = newResult),
+          });
         }
         return result;
       });
@@ -479,7 +484,11 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
         if (onNextHandler.length && isAsyncIterable(result)) {
           result = mapAsyncIterator(result, async result => {
             for (const onNext of onNextHandler) {
-              await onNext({ result, setResult: newResult => (result = newResult) });
+              await onNext({
+                context,
+                result,
+                setResult: newResult => (result = newResult),
+              });
             }
             return result;
           });

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -345,7 +345,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
 
     for (const afterCb of afterCalls) {
       const hookResult = afterCb({
-        context,
+        args,
         result,
         setResult: newResult => {
           result = newResult;
@@ -365,7 +365,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
       result = mapAsyncIterator(result, async result => {
         for (const onNext of onNextHandler) {
           await onNext({
-            context,
+            args,
             result,
             setResult: newResult => (result = newResult),
           });
@@ -465,7 +465,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
 
         for (const afterCb of afterCalls) {
           const hookResult = afterCb({
-            context,
+            args,
             result,
             setResult: newResult => {
               result = newResult;
@@ -485,7 +485,7 @@ export function createEnvelopOrchestrator<PluginsContext = any>(plugins: Plugin[
           result = mapAsyncIterator(result, async result => {
             for (const onNext of onNextHandler) {
               await onNext({
-                context,
+                args,
                 result,
                 setResult: newResult => (result = newResult),
               });

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -1,18 +1,18 @@
-import { Plugin, handleStreamOrSingleExecutionResult, DefaultContext } from '@envelop/types';
+import { Plugin, handleStreamOrSingleExecutionResult, DefaultContext, TypedExecutionArgs } from '@envelop/types';
 import { ExecutionResult, GraphQLError } from 'graphql';
 
 export type ErrorHandler = (errors: readonly GraphQLError[], context: Readonly<DefaultContext>) => void;
 
 type ErrorHandlerCallback<ContextType> = {
-  context: Readonly<ContextType>;
   result: ExecutionResult;
+  args: TypedExecutionArgs<ContextType>;
 };
 
 const makeHandleResult =
   <ContextType>(errorHandler: ErrorHandler) =>
-  ({ context, result }: ErrorHandlerCallback<ContextType>) => {
+  ({ result, args }: ErrorHandlerCallback<ContextType>) => {
     if (result.errors?.length) {
-      errorHandler(result.errors, context);
+      errorHandler(result.errors, args);
     }
   };
 

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -16,7 +16,7 @@ const makeHandleResult =
     }
   };
 
-export const useErrorHandler = <ContextType>(errorHandler: ErrorHandler): Plugin<ContextType> => ({
+export const useErrorHandler = <ContextType = DefaultContext>(errorHandler: ErrorHandler): Plugin<ContextType> => ({
   onExecute() {
     const handleResult = makeHandleResult<ContextType>(errorHandler);
     return {

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -16,7 +16,7 @@ const makeHandleResult =
     }
   };
 
-export const useErrorHandler = <ContextType = DefaultContext>(errorHandler: ErrorHandler): Plugin<ContextType> => ({
+export const useErrorHandler = <ContextType>(errorHandler: ErrorHandler): Plugin<ContextType> => ({
   onExecute() {
     const handleResult = makeHandleResult<ContextType>(errorHandler);
     return {

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -31,6 +31,7 @@ describe('execute', () => {
     expect(spiedPlugin.spies.afterResolver).toHaveBeenCalledTimes(3);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledTimes(1);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledWith({
+      context: expect.any(Object),
       setResult: expect.any(Function),
       result: {
         data: {

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -31,7 +31,7 @@ describe('execute', () => {
     expect(spiedPlugin.spies.afterResolver).toHaveBeenCalledTimes(3);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledTimes(1);
     expect(spiedPlugin.spies.afterExecute).toHaveBeenCalledWith({
-      context: expect.any(Object),
+      args: expect.any(Object),
       setResult: expect.any(Function),
       result: {
         data: {

--- a/packages/core/test/plugins/use-error-handler.spec.ts
+++ b/packages/core/test/plugins/use-error-handler.spec.ts
@@ -26,6 +26,13 @@ describe('useErrorHandler', () => {
     const testInstance = createTestkit([useErrorHandler(mockHandler)], schema);
     await testInstance.execute(`query { foo }`, {}, { foo: 'bar' });
 
-    expect(mockHandler).toHaveBeenCalledWith([testError], expect.objectContaining({ foo: 'bar' }));
+    expect(mockHandler).toHaveBeenCalledWith(
+      [testError],
+      expect.objectContaining({
+        contextValue: expect.objectContaining({
+          foo: 'bar',
+        }),
+      })
+    );
   });
 });

--- a/packages/core/test/plugins/use-error-handler.spec.ts
+++ b/packages/core/test/plugins/use-error-handler.spec.ts
@@ -1,0 +1,31 @@
+import { useErrorHandler } from '../../src/plugins/use-error-handler';
+import { createTestkit } from '@envelop/testing';
+import { buildSchema } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('useErrorHandler', () => {
+  const testError = new Error('Foobar');
+
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        foo: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo: () => {
+          throw testError;
+        },
+      },
+    },
+  });
+
+  it('should invoke error handler when error happens during execution', async () => {
+    const mockHandler = jest.fn();
+    const testInstance = createTestkit([useErrorHandler(mockHandler)], schema);
+    await testInstance.execute(`query { foo }`, {}, { foo: 'bar' });
+
+    expect(mockHandler).toHaveBeenCalledWith([testError], expect.objectContaining({ foo: 'bar' }));
+  });
+});

--- a/packages/types/src/async-utils.ts
+++ b/packages/types/src/async-utils.ts
@@ -32,7 +32,7 @@ export function handleStreamOrSingleExecutionResult<ContextType = DefaultContext
     return { onNext: fn };
   } else {
     fn({
-      context: payload.context,
+      args: payload.args,
       result: payload.result,
       setResult: payload.setResult,
     });

--- a/packages/types/src/async-utils.ts
+++ b/packages/types/src/async-utils.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { OnExecuteDoneEventPayload, OnExecuteDoneHookResult, OnExecuteDoneHookResultOnNextHook } from '@envelop/core';
+import {
+  DefaultContext,
+  OnExecuteDoneEventPayload,
+  OnExecuteDoneHookResult,
+  OnExecuteDoneHookResultOnNextHook,
+} from '@envelop/core';
 import { ExecutionResult } from 'graphql';
 
 /**
@@ -19,14 +24,15 @@ export function isAsyncIterable(maybeAsyncIterable: any): maybeAsyncIterable is 
  * @param fn The handler to be executed on each result
  * @returns a subscription for streamed results, or undefined in case of an non-async
  */
-export function handleStreamOrSingleExecutionResult(
-  payload: OnExecuteDoneEventPayload,
-  fn: OnExecuteDoneHookResultOnNextHook
-): void | OnExecuteDoneHookResult {
+export function handleStreamOrSingleExecutionResult<ContextType = DefaultContext>(
+  payload: OnExecuteDoneEventPayload<ContextType>,
+  fn: OnExecuteDoneHookResultOnNextHook<ContextType>
+): void | OnExecuteDoneHookResult<ContextType> {
   if (isAsyncIterable(payload.result)) {
     return { onNext: fn };
   } else {
     fn({
+      context: payload.context,
       result: payload.result,
       setResult: payload.setResult,
     });

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -295,7 +295,7 @@ export type OnResolverCalledHook<
 /**
  * Execution arguments with inferred context value type.
  */
-export type TypedExecutionArgs<ContextType> = Omit<ExecutionArgs, 'contextValue'> & { contextValue?: ContextType };
+export type TypedExecutionArgs<ContextType> = Omit<ExecutionArgs, 'contextValue'> & { contextValue: ContextType };
 
 /**
  * Payload that is passed to the onExecute hook.
@@ -344,7 +344,7 @@ export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
 /**
  * Hook that is invoked for each value a AsyncIterable returned from execute publishes.
  */
-export type OnExecuteDoneHookResultOnNextHook<ContextType = DefaultContext> = (
+export type OnExecuteDoneHookResultOnNextHook<ContextType> = (
   payload: OnExecuteDoneHookResultOnNextHookPayload<ContextType>
 ) => void | Promise<void>;
 
@@ -370,7 +370,7 @@ export type OnExecuteDoneHookResult<ContextType> = {
 /**
  * Payload with which the onExecuteDone hook is invoked.
  */
-export type OnExecuteDoneEventPayload<ContextType = DefaultContext> = {
+export type OnExecuteDoneEventPayload<ContextType> = {
   /**
    * The execution arguments.
    */
@@ -390,7 +390,7 @@ export type OnExecuteDoneEventPayload<ContextType = DefaultContext> = {
  * Hook that is invoked after the execute function has been invoked.
  * Allows returning a OnExecuteDoneHookResult for hooking into stream values if execute returned an AsyncIterable.
  */
-export type OnExecuteDoneHook<ContextType = DefaultContext> = (
+export type OnExecuteDoneHook<ContextType> = (
   options: OnExecuteDoneEventPayload<ContextType>
 ) => void | OnExecuteDoneHookResult<ContextType>;
 
@@ -445,7 +445,7 @@ export type OnSubscribeEventPayload<ContextType> = {
 /**
  * Payload with which the onSubscribeResult hook is invoked.
  */
-export type OnSubscribeResultEventPayload<ContextType = DefaultContext> = {
+export type OnSubscribeResultEventPayload<ContextType> = {
   /**
    * The execution arguments.
    */
@@ -460,7 +460,7 @@ export type OnSubscribeResultEventPayload<ContextType = DefaultContext> = {
   setResult: (newResult: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => void;
 };
 
-export type OnSubscribeResultResultOnNextHookPayload<ContextType = DefaultContext> = {
+export type OnSubscribeResultResultOnNextHookPayload<ContextType> = {
   /**
    * The execution arguments.
    */
@@ -478,18 +478,20 @@ export type OnSubscribeResultResultOnNextHookPayload<ContextType = DefaultContex
 /**
  * Hook invoked for each value published by the AsyncIterable returned from subscribe.
  */
-export type OnSubscribeResultResultOnNextHook = (payload: OnSubscribeResultResultOnNextHookPayload) => void | Promise<void>;
+export type OnSubscribeResultResultOnNextHook<ContextType> = (
+  payload: OnSubscribeResultResultOnNextHookPayload<ContextType>
+) => void | Promise<void>;
 
 /**
  * Hook invoked after the AsyncIterable returned from subscribe completes.
  */
 export type OnSubscribeResultResultOnEndHook = () => void;
 
-export type OnSubscribeResultResult = {
+export type OnSubscribeResultResult<ContextType> = {
   /**
    * Invoked for each value published by the AsyncIterable returned from subscribe.
    */
-  onNext?: OnSubscribeResultResultOnNextHook;
+  onNext?: OnSubscribeResultResultOnNextHook<ContextType>;
   /**
    * Invoked after the AsyncIterable returned from subscribe completes.
    */
@@ -500,7 +502,9 @@ export type OnSubscribeResultResult = {
  * Hook that is invoked with the result of the subscribe call.
  * Return a OnSubscribeResultResult for hooking into the AsyncIterable returned from subscribe.
  */
-export type SubscribeResultHook = (options: OnSubscribeResultEventPayload) => void | OnSubscribeResultResult;
+export type SubscribeResultHook<ContextType> = (
+  options: OnSubscribeResultEventPayload<ContextType>
+) => void | OnSubscribeResultResult<ContextType>;
 
 export type SubscribeErrorHookPayload = {
   error: unknown;
@@ -509,11 +513,11 @@ export type SubscribeErrorHookPayload = {
 
 export type SubscribeErrorHook = (payload: SubscribeErrorHookPayload) => void;
 
-export type OnSubscribeHookResult<ContextType = DefaultContext> = {
+export type OnSubscribeHookResult<ContextType> = {
   /**
    * Invoked with the result returned from subscribe.
    */
-  onSubscribeResult?: SubscribeResultHook;
+  onSubscribeResult?: SubscribeResultHook<ContextType>;
   /**
    * Invoked if the source stream returned from subscribe throws an error.
    */

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -344,7 +344,7 @@ export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
 /**
  * Hook that is invoked for each value a AsyncIterable returned from execute publishes.
  */
-export type OnExecuteDoneHookResultOnNextHook<ContextType> = (
+export type OnExecuteDoneHookResultOnNextHook<ContextType = DefaultContext> = (
   payload: OnExecuteDoneHookResultOnNextHookPayload<ContextType>
 ) => void | Promise<void>;
 
@@ -370,7 +370,7 @@ export type OnExecuteDoneHookResult<ContextType> = {
 /**
  * Payload with which the onExecuteDone hook is invoked.
  */
-export type OnExecuteDoneEventPayload<ContextType> = {
+export type OnExecuteDoneEventPayload<ContextType = DefaultContext> = {
   /**
    * The context object.
    */
@@ -390,7 +390,7 @@ export type OnExecuteDoneEventPayload<ContextType> = {
  * Hook that is invoked after the execute function has been invoked.
  * Allows returning a OnExecuteDoneHookResult for hooking into stream values if execute returned an AsyncIterable.
  */
-export type OnExecuteDoneHook<ContextType> = (
+export type OnExecuteDoneHook<ContextType = DefaultContext> = (
   options: OnExecuteDoneEventPayload<ContextType>
 ) => void | OnExecuteDoneHookResult<ContextType>;
 
@@ -445,7 +445,11 @@ export type OnSubscribeEventPayload<ContextType> = {
 /**
  * Payload with which the onSubscribeResult hook is invoked.
  */
-export type OnSubscribeResultEventPayload = {
+export type OnSubscribeResultEventPayload<ContextType = DefaultContext> = {
+  /**
+   * The context object.
+   */
+  context: Readonly<ContextType>;
   /**
    * The current execution result.
    */
@@ -456,7 +460,11 @@ export type OnSubscribeResultEventPayload = {
   setResult: (newResult: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => void;
 };
 
-export type OnSubscribeResultResultOnNextHookPayload = {
+export type OnSubscribeResultResultOnNextHookPayload<ContextType = DefaultContext> = {
+  /**
+   * The context object.
+   */
+  context: Readonly<ContextType>;
   /**
    * The current execution result.
    */
@@ -501,7 +509,7 @@ export type SubscribeErrorHookPayload = {
 
 export type SubscribeErrorHook = (payload: SubscribeErrorHookPayload) => void;
 
-export type OnSubscribeHookResult<ContextType> = {
+export type OnSubscribeHookResult<ContextType = DefaultContext> = {
   /**
    * Invoked with the result returned from subscribe.
    */

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -295,7 +295,7 @@ export type OnResolverCalledHook<
 /**
  * Execution arguments with inferred context value type.
  */
-export type TypedExecutionArgs<ContextType> = Omit<ExecutionArgs, 'contextValue'> & { contextValue: ContextType };
+export type TypedExecutionArgs<ContextType> = Omit<ExecutionArgs, 'contextValue'> & { contextValue?: ContextType };
 
 /**
  * Payload that is passed to the onExecute hook.
@@ -328,9 +328,9 @@ export type OnExecuteEventPayload<ContextType> = {
  */
 export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
   /**
-   * The context object.
+   * The execution arguments.
    */
-  context: Readonly<ContextType>;
+  args: TypedExecutionArgs<ContextType>;
   /**
    * The execution result.
    */
@@ -372,9 +372,9 @@ export type OnExecuteDoneHookResult<ContextType> = {
  */
 export type OnExecuteDoneEventPayload<ContextType = DefaultContext> = {
   /**
-   * The context object.
+   * The execution arguments.
    */
-  context: Readonly<ContextType>;
+  args: TypedExecutionArgs<ContextType>;
   /**
    * The execution result returned from the execute function.
    * Can return an AsyncIterable if a graphql.js that has defer/stream implemented is used.
@@ -447,9 +447,9 @@ export type OnSubscribeEventPayload<ContextType> = {
  */
 export type OnSubscribeResultEventPayload<ContextType = DefaultContext> = {
   /**
-   * The context object.
+   * The execution arguments.
    */
-  context: Readonly<ContextType>;
+  args: TypedExecutionArgs<ContextType>;
   /**
    * The current execution result.
    */
@@ -462,9 +462,9 @@ export type OnSubscribeResultEventPayload<ContextType = DefaultContext> = {
 
 export type OnSubscribeResultResultOnNextHookPayload<ContextType = DefaultContext> = {
   /**
-   * The context object.
+   * The execution arguments.
    */
-  context: Readonly<ContextType>;
+  args: TypedExecutionArgs<ContextType>;
   /**
    * The current execution result.
    */

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -326,7 +326,11 @@ export type OnExecuteEventPayload<ContextType> = {
 /**
  * Payload that is passed to the onExecuteDone hook.
  */
-export type OnExecuteDoneHookResultOnNextHookPayload = {
+export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
+  /**
+   * The context object.
+   */
+  context: Readonly<ContextType>;
   /**
    * The execution result.
    */
@@ -340,7 +344,9 @@ export type OnExecuteDoneHookResultOnNextHookPayload = {
 /**
  * Hook that is invoked for each value a AsyncIterable returned from execute publishes.
  */
-export type OnExecuteDoneHookResultOnNextHook = (payload: OnExecuteDoneHookResultOnNextHookPayload) => void | Promise<void>;
+export type OnExecuteDoneHookResultOnNextHook<ContextType> = (
+  payload: OnExecuteDoneHookResultOnNextHookPayload<ContextType>
+) => void | Promise<void>;
 
 /**
  * Hook that is invoked after a AsyncIterable returned from execute completes.
@@ -350,11 +356,11 @@ export type OnExecuteDoneHookResultOnEndHook = () => void;
 /**
  * Hook for hooking into AsyncIterables returned from execute.
  */
-export type OnExecuteDoneHookResult = {
+export type OnExecuteDoneHookResult<ContextType> = {
   /**
    * Hook that is invoked for each value a AsyncIterable returned from execute publishes.
    */
-  onNext?: OnExecuteDoneHookResultOnNextHook;
+  onNext?: OnExecuteDoneHookResultOnNextHook<ContextType>;
   /**
    * Hook that is invoked after a AsyncIterable returned from execute completes.
    */
@@ -364,7 +370,11 @@ export type OnExecuteDoneHookResult = {
 /**
  * Payload with which the onExecuteDone hook is invoked.
  */
-export type OnExecuteDoneEventPayload = {
+export type OnExecuteDoneEventPayload<ContextType> = {
+  /**
+   * The context object.
+   */
+  context: Readonly<ContextType>;
   /**
    * The execution result returned from the execute function.
    * Can return an AsyncIterable if a graphql.js that has defer/stream implemented is used.
@@ -380,7 +390,9 @@ export type OnExecuteDoneEventPayload = {
  * Hook that is invoked after the execute function has been invoked.
  * Allows returning a OnExecuteDoneHookResult for hooking into stream values if execute returned an AsyncIterable.
  */
-export type OnExecuteDoneHook = (options: OnExecuteDoneEventPayload) => void | OnExecuteDoneHookResult;
+export type OnExecuteDoneHook<ContextType> = (
+  options: OnExecuteDoneEventPayload<ContextType>
+) => void | OnExecuteDoneHookResult<ContextType>;
 
 /**
  * Result returned from the onExecute hook result for hooking into subsequent phases.
@@ -389,7 +401,7 @@ export type OnExecuteHookResult<ContextType> = {
   /**
    * Invoked with the execution result returned from execute.
    */
-  onExecuteDone?: OnExecuteDoneHook;
+  onExecuteDone?: OnExecuteDoneHook<ContextType>;
   /**
    * Invoked before each resolver has been invoked during the execution phase.
    */


### PR DESCRIPTION
## Description

Related https://github.com/dotansimha/envelop/issues/744

For detailed error reporting it would be really useful to access the context in the error handlers.

I'm not 100% convienced this is the best approach as I had to do lot of juggling with `ContextType`. If there is a better solution I'm happy to update the PR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [x] `packages/core/src/plugins/use-error-handler.ts` - There were no tests for this plugin so I implemented a basic one to demonstrate how the plugin should work.

**Test Environment**:

- OS: macOS 11.1
- `@envelop/...`: latest
- NodeJS: v14.15.4

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

