### PR TITLE
fix(response-cache): include operationName into cache key + stable json stringify variable values

### DIFF
--- a/.changeset/yellow-spiders-stare.md
+++ b/.changeset/yellow-spiders-stare.md
@@ -1,0 +1,7 @@
+---
+'@envelop/response-cache': patch
+---
+
+Include operationName for building the cache key hash. Previously, sending the same operation document with a different operationName value could result in the wrong response being served from the cache.
+
+Use `fast-json-stable-stringify` for stringifying the variableValues. This will ensure that the cache is hit more often as the variable value serialization is now more stable.

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -37,7 +37,8 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "lru-cache": "^6.0.0"
+    "lru-cache": "^6.0.0",
+    "fast-json-stable-stringify": "^2.1.0"
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0"


### PR DESCRIPTION
See changeset for an overview of the changes