### PR TITLE
fix: handle introspection types per field

### DIFF
--- a/.changeset/lucky-carrots-confess.md
+++ b/.changeset/lucky-carrots-confess.md
@@ -1,0 +1,6 @@
+---
+'@envelop/extended-validation': patch
+'@envelop/operation-field-permissions': patch
+---
+
+Fix handling of introspection queries and disallow authorization bypassing. Previously, it was possible to bypass authorization by adding `\_\_schema` to query

--- a/packages/plugins/extended-validation/src/plugin.ts
+++ b/packages/plugins/extended-validation/src/plugin.ts
@@ -48,10 +48,6 @@ export const useExtendedValidation = (options: {
       const visitor = visitInParallel(rules.map(rule => rule(validationContext, args)));
       visit(args.document, visitWithTypeInfo(typeInfo, visitor));
 
-      for (const rule of rules) {
-        rule(validationContext, args);
-      }
-
       if (errors.length > 0) {
         let result: ExecutionResult = {
           data: null,

--- a/packages/plugins/operation-field-permissions/src/index.ts
+++ b/packages/plugins/operation-field-permissions/src/index.ts
@@ -87,20 +87,18 @@ const OperationScopeRule =
 
         const parentType = context.getParentType();
         if (parentType) {
-          const wrappedType = getWrappedType(parentType);
-
-          if (isIntrospectionType(wrappedType)) {
+          if (isIntrospectionType(parentType)) {
             return false;
           }
 
-          if (isObjectType(wrappedType)) {
-            handleField(node, wrappedType);
-          } else if (isUnionType(wrappedType)) {
-            for (const objectType of wrappedType.getTypes()) {
+          if (isObjectType(parentType)) {
+            handleField(node, parentType);
+          } else if (isUnionType(parentType)) {
+            for (const objectType of parentType.getTypes()) {
               handleField(node, objectType);
             }
-          } else if (isInterfaceType(wrappedType)) {
-            for (const objectType of executionArgs.schema.getImplementations(wrappedType).objects) {
+          } else if (isInterfaceType(parentType)) {
+            for (const objectType of executionArgs.schema.getImplementations(parentType).objects) {
               handleField(node, objectType);
             }
           }

--- a/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
+++ b/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
@@ -57,6 +57,32 @@ describe('useOperationPermissions', () => {
     expect(result.errors).toBeUndefined();
   });
 
+  it('should not skip for extended introspection query', async () => {
+    const kit = createTestkit(
+      [
+        useOperationFieldPermissions({
+          getPermissions: () => 'boop',
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(/* GraphQL */ `
+      query {
+        __schema {
+          __typename
+        }
+        greetings
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Insufficient permissions for selecting 'Query.greetings'.],
+]
+`);
+  });
+
   it('allow everything', async () => {
     const kit = createTestkit(
       [


### PR DESCRIPTION
## Description

Perform authorization for queries that contain `__schema` query.
Skip authorization for Introspection Types and nested fields.

Fixes #892 

## Type of change

- Bug fix (non-breaking change which fixes an issue)