### PR TITLE
Add `onMissingMatch` option to persisted operations plugin

### DIFF
--- a/.changeset/flat-zoos-float.md
+++ b/.changeset/flat-zoos-float.md
@@ -1,0 +1,5 @@
+---
+'@envelop/persisted-operations': minor
+---
+
+Add `onMissingMatch` option to allow custom handling of missing operation Ids in store/s

--- a/packages/plugins/persisted-operations/README.md
+++ b/packages/plugins/persisted-operations/README.md
@@ -103,6 +103,23 @@ const getEnveloped = envelop({
 const proxyFns = getEnveloped({ req });
 ```
 
+## Additional options
+
+### onlyPersisted
+
+You can pass `onlyPersisted: true` when you want to allow persisted operations only in your server. In this case the plugin will issue a GraphQL error when it does not receive an operation Id, or when the received operation id is not available in your store/s.
+
+### onMissingMatch
+
+You might want to perform some actions, such as logging custom events, when your operation Id is not matched in your store/s; in this case you can use the `onMissingMatch` callback function.  
+The function receives the context and operationId as arguments, so you can use it like so:
+
+```js
+onMissingMatch: (context, operationId) => {
+  myEventPool.add(`Missing match for operation "${operationId}" from agent "${context.req.headers['user-agent']}"`);
+};
+```
+
 ## With Relay
 
 If you are using Relay, you can leverage `relay-compiler` feature for hashing and and creating the store for you, during build.

--- a/packages/plugins/persisted-operations/src/plugin.ts
+++ b/packages/plugins/persisted-operations/src/plugin.ts
@@ -72,16 +72,15 @@ export const usePersistedOperations = (rawOptions: UsePersistedOperationsOptions
         return;
       }
 
-      if (options.onlyPersisted) {
-        if (options.onMissingMatch) options.onMissingMatch(context, operationId);
+      if (options.onMissingMatch) options.onMissingMatch(context, operationId);
 
+      if (options.onlyPersisted) {
         // we want to throw an error only when "onlyPersisted" is true, otherwise we let execution continue normally
         throw new GraphQLError(`Unable to match operation with id '${operationId}'`);
       }
 
       // if we reach this stage we could not retrieve a persisted operation and we didn't throw any error as onlyPersisted is false
       // hence we let operation continue assuming consumer is not passing an operation id, but a plain query string, with current request.
-      if (options.onMissingMatch) options.onMissingMatch(context, operationId);
     },
   };
 };

--- a/packages/plugins/persisted-operations/tests/persisted-operations.spec.ts
+++ b/packages/plugins/persisted-operations/tests/persisted-operations.spec.ts
@@ -200,4 +200,84 @@ describe('usePersistedOperations', () => {
     assertSingleExecutionValue(result);
     expect(result.data?.foo).toBe('test');
   });
+
+  it('Should execute `onMissingMatch` callback when operation Id is not matched and `onlyPersisted` is true', async () => {
+    const initialContext = { storeId: 'custom' };
+    const store = new Map();
+    const mockOnMissingMatch = jest.fn();
+    const testInstance = createTestkit(
+      [
+        usePersistedOperations({
+          onlyPersisted: true,
+          store,
+          onMissingMatch: mockOnMissingMatch,
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute('persisted_1', {}, initialContext);
+    assertSingleExecutionValue(result);
+    expect(mockOnMissingMatch).toHaveBeenCalledTimes(1);
+    expect(mockOnMissingMatch).toHaveBeenCalledWith(initialContext, 'persisted_1');
+  });
+
+  it('Should execute `onMissingMatch` callback when operation Id is not matched and `onlyPersisted` is false', async () => {
+    const initialContext = { storeId: 'custom' };
+    const store = new Map();
+    const mockOnMissingMatch = jest.fn();
+    const testInstance = createTestkit(
+      [
+        usePersistedOperations({
+          onlyPersisted: false,
+          store,
+          onMissingMatch: mockOnMissingMatch,
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute('persisted_1', {}, initialContext);
+    assertSingleExecutionValue(result);
+    expect(mockOnMissingMatch).toHaveBeenCalledTimes(1);
+    expect(mockOnMissingMatch).toHaveBeenCalledWith(initialContext, 'persisted_1');
+  });
+
+  it('Should not execute `onMissingMatch` callback when operation Id is matched and `onlyPersisted` is true', async () => {
+    const store = new Map([['persisted_1', `query { foo }`]]);
+    const mockOnMissingMatch = jest.fn();
+    const testInstance = createTestkit(
+      [
+        usePersistedOperations({
+          onlyPersisted: true,
+          store,
+          onMissingMatch: mockOnMissingMatch,
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute('persisted_1');
+    assertSingleExecutionValue(result);
+    expect(mockOnMissingMatch).not.toHaveBeenCalled();
+  });
+
+  it('Should not execute `onMissingMatch` callback when operation Id is matched and `onlyPersisted` is false', async () => {
+    const store = new Map([['persisted_1', `query { foo }`]]);
+    const mockOnMissingMatch = jest.fn();
+    const testInstance = createTestkit(
+      [
+        usePersistedOperations({
+          onlyPersisted: false,
+          store,
+          onMissingMatch: mockOnMissingMatch,
+        }),
+      ],
+      testSchema
+    );
+
+    const result = await testInstance.execute('persisted_1');
+    assertSingleExecutionValue(result);
+    expect(mockOnMissingMatch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Description

This PR adds a new option to the persisted operations plugin.
This is a callback to allow developers to handle events of missing operation Id/s in store/s.
With this callback, developers can log custom events so that missing matches are kept under control and analysed.

Keep in mind that a missing match is not necessarily an error.
It would be an error only when `onlyPersisted` is true, otherwise, a GraphQL server implementation might even involve a double-way communication so that if an operation Id is not found the client sends that to the server in a second request.

Hence the logging is relevant also in addition to errors handling scenarios.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
