### PR TITLE
useSentry: `skipError` option

### DIFF
--- a/.changeset/silent-mugs-pay.md
+++ b/.changeset/silent-mugs-pay.md
@@ -1,0 +1,7 @@
+---
+'@envelop/sentry': minor
+---
+
+Adds a new `skipError` option, which allows users to skip certain errors.
+
+It's useful in the case where a user has defined custom error types, such as `ValidationError` which may be used to validate resolver arguments.

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -41,7 +41,24 @@ const getEnveloped = envelop({
       includeResolverArgs: false, // set to `true` in order to include the args passed to resolvers
       includeExecuteVariables: false, // set to `true` in order to include the operation variables values
       appendTags: (args) => { return { ... }} // if you wish to add custom "tags" to the Sentry transaction created per operation
+      configureScope: (args, scope) => { return { ... }} // if you wish to modify the Sentry scope
+      skip: (executionArgs) => { return { ... }} // if you wish to modify the skip specific operations
     }),
   ],
 });
 ```
+
+### Configuration
+
+- `startTransaction` (default: `true`) - Starts a new transaction for every GraphQL Operation. When disabled, an already existing Transaction will be used.
+- `renameTransaction` (default: `false`) - Creates a Span for every resolve function.
+- `trackResolvers` (default: `true`) - Wraps resolvers with tracing functionality, and creates a Span for every resolve function.
+- `includeRawResult` (default: `false`) - Adds result of each resolver and operation to Span's data (available under "result")
+- `includeResolverArgs` (default: `false`) - Adds arguments of each resolver to Span's tag called "args"
+- `includeExecuteVariables` (default: `false`) - Adds operation's variables to a Scope (only in case of errors)
+- `appendTags` - See example above. Allow you to manipulate the tags reports on the Sentry transaction.
+- `configureScope` - See example above. Allow you to manipulate the tags reports on the Sentry transaction.
+- `transactionName` (default: operation name) - Produces a name of Transaction (only when "renameTransaction" or "startTransaction" are enabled) and description of created Span.
+- `operationName` - Produces a "op" (operation) of created Span.
+- `skip` (default: none) - Produces a "op" (operation) of created Span.
+- `skipError` (default: ignored `EnvelopError`) - Indicates whether or not to skip Sentry exception reporting for a given error. By default, this plugin skips all `EnvelopError` errors and does not report it to Sentry.

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -60,13 +60,13 @@ export type SentryPluginOptions = {
    */
   operationName?: (args: ExecutionArgs) => string;
   /**
-   * Indicates whether or not to ignore the entire Sentry flow for given GraphQL operation
+   * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
    */
-  ignoreOperation?: (args: ExecutionArgs) => boolean;
+  skipOperation?: (args: ExecutionArgs) => boolean;
   /**
-   * Indicates whether or not to ignore Sentry exception reporting for a given error,
+   * Indicates whether or not to skip Sentry exception reporting for a given error,
    */
-  ignoreError?: (args: Error) => boolean;
+  skipError?: (args: Error) => boolean;
 };
 
 export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
@@ -80,12 +80,12 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeRawResult = pick('includeRawResult', false);
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
-  const ignoreOperation = pick('ignoreOperation', () => false);
-  const ignoreError = pick('ignoreError', () => false);
+  const skipOperation = pick('skipOperation', () => false);
+  const skipError = pick('skipError', () => false);
 
   return {
     onExecute({ args }) {
-      if (ignoreOperation(args)) {
+      if (skipOperation(args)) {
         return;
       }
 
@@ -168,7 +168,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
                   childSpan.setData('result', result);
                 }
 
-                if (result instanceof Error && !(result instanceof EnvelopError) && !ignoreError(result)) {
+                if (result instanceof Error && !(result instanceof EnvelopError) && !skipError(result)) {
                   const errorPath = responsePathAsArray(info.path).join(' > ');
 
                   Sentry.captureException(result, {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -64,7 +64,7 @@ export type SentryPluginOptions = {
    */
   skipOperation?: (args: ExecutionArgs) => boolean;
   /**
-   * Indicates whether or not to skip Sentry exception reporting for a given error,
+   * Indicates whether or not to skip Sentry exception reporting for a given error.
    */
   skipError?: (args: Error) => boolean;
 };

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -62,7 +62,7 @@ export type SentryPluginOptions = {
   /**
    * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
    */
-  skip?: (args: ExecutionArgs) => boolean;
+  skipOperation?: (args: ExecutionArgs) => boolean;
   /**
    * Indicates whether or not to skip the entire Sentry flow for given error
    */
@@ -80,12 +80,12 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeRawResult = pick('includeRawResult', false);
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
-  const skip = pick('skip', () => false);
+  const skipOperation = pick('skipOperation', () => false);
   const skipError = pick('skipError', () => false);
 
   return {
     onExecute({ args }) {
-      if (skip(args)) {
+      if (skipOperation(args)) {
         return;
       }
 

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -62,7 +62,7 @@ export type SentryPluginOptions = {
   /**
    * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
    */
-  skipOperation?: (args: ExecutionArgs) => boolean;
+  skip?: (args: ExecutionArgs) => boolean;
   /**
    * Indicates whether or not to skip Sentry exception reporting for a given error.
    */
@@ -84,7 +84,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeRawResult = pick('includeRawResult', false);
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
-  const skipOperation = pick('skipOperation', () => false);
+  const skipOperation = pick('skip', () => false);
   const skipError = pick('skipError', defaultSkipError);
 
   return {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -63,6 +63,10 @@ export type SentryPluginOptions = {
    * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
    */
   skip?: (args: ExecutionArgs) => boolean;
+  /**
+   * Indicates whether or not to skip the entire Sentry flow for given error
+   */
+  skipError?: (args: Error) => boolean;
 };
 
 export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
@@ -77,6 +81,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
   const skip = pick('skip', () => false);
+  const skipError = pick('skipError', () => false);
 
   return {
     onExecute({ args }) {
@@ -163,7 +168,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
                   childSpan.setData('result', result);
                 }
 
-                if (result instanceof Error && !(result instanceof EnvelopError)) {
+                if (result instanceof Error && !(result instanceof EnvelopError) && !skipError(result)) {
                   const errorPath = responsePathAsArray(info.path).join(' > ');
 
                   Sentry.captureException(result, {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -60,11 +60,13 @@ export type SentryPluginOptions = {
    */
   operationName?: (args: ExecutionArgs) => string;
   /**
-   * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
+   * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation.
+   * By default, no operations are skipped.
    */
   skip?: (args: ExecutionArgs) => boolean;
   /**
    * Indicates whether or not to skip Sentry exception reporting for a given error.
+   * By default, this plugin skips all `EnvelopError` errors and does not report it to Sentry.
    */
   skipError?: (args: Error) => boolean;
 };

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -60,13 +60,13 @@ export type SentryPluginOptions = {
    */
   operationName?: (args: ExecutionArgs) => string;
   /**
-   * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation
+   * Indicates whether or not to ignore the entire Sentry flow for given GraphQL operation
    */
-  skipOperation?: (args: ExecutionArgs) => boolean;
+  ignoreOperation?: (args: ExecutionArgs) => boolean;
   /**
-   * Indicates whether or not to skip the entire Sentry flow for given error
+   * Indicates whether or not to ignore the entire Sentry flow for given error
    */
-  skipError?: (args: Error) => boolean;
+  ignoreError?: (args: Error) => boolean;
 };
 
 export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
@@ -80,12 +80,12 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const includeRawResult = pick('includeRawResult', false);
   const includeExecuteVariables = pick('includeExecuteVariables', false);
   const renameTransaction = pick('renameTransaction', false);
-  const skipOperation = pick('skipOperation', () => false);
-  const skipError = pick('skipError', () => false);
+  const ignoreOperation = pick('ignoreOperation', () => false);
+  const ignoreError = pick('ignoreError', () => false);
 
   return {
     onExecute({ args }) {
-      if (skipOperation(args)) {
+      if (ignoreOperation(args)) {
         return;
       }
 
@@ -168,7 +168,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
                   childSpan.setData('result', result);
                 }
 
-                if (result instanceof Error && !(result instanceof EnvelopError) && !skipError(result)) {
+                if (result instanceof Error && !(result instanceof EnvelopError) && !ignoreError(result)) {
                   const errorPath = responsePathAsArray(info.path).join(' > ');
 
                   Sentry.captureException(result, {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -64,7 +64,7 @@ export type SentryPluginOptions = {
    */
   ignoreOperation?: (args: ExecutionArgs) => boolean;
   /**
-   * Indicates whether or not to ignore the entire Sentry flow for given error
+   * Indicates whether or not to ignore Sentry exception reporting for a given error,
    */
   ignoreError?: (args: Error) => boolean;
 };


### PR DESCRIPTION
Adds a new `skipError` option, which allows users to skip certain errors. It's useful in the case where a user has defined custom error types, such as `ValidationError` which may be used to validate resolver arguments.

I've also renamed `skip` to `skipOperation`, this is a breaking change.

Fixes #925 
