### PR TITLE
style: Correct subscription typo in useTiming log

### DIFF
--- a/.changeset/kind-jeans-check.md
+++ b/.changeset/kind-jeans-check.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+useTiming: Fix a typo in onSubscriptionMeasurement

--- a/packages/core/src/plugins/use-timing.ts
+++ b/packages/core/src/plugins/use-timing.ts
@@ -21,7 +21,7 @@ export type TimingPluginOptions = {
 const DEFAULT_OPTIONS: TimingPluginOptions = {
   onExecutionMeasurement: (args, timing) => console.log(`Operation execution "${args.operationName}" done in ${timing.ms}ms`),
   onSubscriptionMeasurement: (args, timing) =>
-    console.log(`Operation subsctiption "${args.operationName}" done in ${timing.ms}ms`),
+    console.log(`Operation subscription "${args.operationName}" done in ${timing.ms}ms`),
   onParsingMeasurement: (source: Source | string, timing: ResultTiming) =>
     console.log(`Parsing "${source}" done in ${timing.ms}ms`),
   onValidationMeasurement: (document: DocumentNode, timing: ResultTiming) =>


### PR DESCRIPTION
## Description

In the useTiming plugin, there is a typo in console log for "subsctiption".

Fixes https://github.com/dotansimha/envelop/issues/967

## Type of change

Spelling correction for "subscription" in the useTiming plugin,

  onSubscriptionMeasurement: (args, timing) =>
    console.log(`Operation subsctiption "${args.operationName}" done in ${timing.ms}ms`), 

## How Has This Been Tested?

Ran `yarn build & yarn test`
