### PR TITLE
style: Disable linter checks in benchmark utils

### DIFF
--- a/benchmark/utils.js
+++ b/benchmark/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /// @ts-check
 import http from 'k6/http';
 
@@ -18,6 +19,7 @@ export function graphql({ query, operationName, variables }) {
     {
       headers: {
         'Content-Type': 'application/json',
+        // eslint-disable-next-line no-undef
         'X-Test-Scenario': __ENV.MODE,
       },
     }


### PR DESCRIPTION
## Description

Fixes # https://github.com/dotansimha/envelop/issues/969

There were a few lint warnings surfaced in VS Code when using the benchmark utils.

See  https://github.com/dotansimha/envelop/issues/969 for screenshots.

## Type of change

* Added instructions to disable/ignore the lint warnings

## Screenshots/Sandbox (if appropriate/relevant):

See before:  https://github.com/dotansimha/envelop/issues/969 for screenshots.

And after:

![image](https://user-images.githubusercontent.com/1051633/141489116-e23403a7-ba10-47de-a3bc-81ecb6327dd7.png)


## How Has This Been Tested?

Ran:

* yarn build
* yarn test
* yarn lint

**Test Environment**:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
