### PR TITLE
useSentry: patch for defaultSkipError, which should return true if the error is an EnvelopError instance.

### DIFF
--- a/.changeset/empty-glasses-grow.md
+++ b/.changeset/empty-glasses-grow.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': patch
+---
+
+Patch for defaultSkipError, which should return true if the error is an EnvelopError instance.

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -72,7 +72,7 @@ export type SentryPluginOptions = {
 };
 
 export function defaultSkipError(error: Error): boolean {
-  return !(error instanceof EnvelopError);
+  return error instanceof EnvelopError;
 }
 
 export const useSentry = (options: SentryPluginOptions = {}): Plugin => {


### PR DESCRIPTION
Patch for `defaultSkipError`, which should return `true` if the error is an `EnvelopError` instance.