### PR TITLE
feat: Allow userland code to specify type of currentContext #1101

### DIFF
--- a/.changeset/fresh-gifts-serve.md
+++ b/.changeset/fresh-gifts-serve.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Allow userland code to specify type of currentContext in ContextFactoryFn

--- a/packages/core/src/plugins/use-extend-context.ts
+++ b/packages/core/src/plugins/use-extend-context.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@envelop/types';
 
-export type ContextFactoryFn<TResult = unknown> = (currentContext: unknown) => TResult | Promise<TResult>;
+export type ContextFactoryFn<TResult = unknown, TCurrent = unknown> = (currentContext: TCurrent) => TResult | Promise<TResult>;
 
 type UnwrapAsync<T> = T extends Promise<infer U> ? U : T;
 


### PR DESCRIPTION
## Description

Allow userland code to get better typings from `currentContext` when defining context factory functions.

Fixes #1101 

With this change we will be able to do this:

![Screenshot 2021-12-15 at 09 54 11](https://user-images.githubusercontent.com/2785359/146154687-40c3f2f9-63e2-4c0f-9468-0695067ab3ea.png)

Which means our server library did a better job at abstracting the underlying envelop machinery. The userland service only need to worry about their types (`Clients` and `FactoryContext`) while also being provided things already available in the context.

(The `MergedContext` type is not important, but is used for `contextType` in codegen)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

