### PR TITLE
fix spread using circular constraint

### DIFF
--- a/.changeset/large-deers-arrive.md
+++ b/.changeset/large-deers-arrive.md
@@ -1,0 +1,5 @@
+---
+'@envelop/types': patch
+---
+
+update spread typing to not be circular

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -11,7 +11,7 @@ export type SpreadTwo<L, R> = Id<
     SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
 >;
 
-export type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R] ? SpreadTwo<L, Spread<R>> : {};
+export type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R] ? SpreadTwo<L, R> : {};
 
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 


### PR DESCRIPTION
## Description
Update Spread typing in typings/utils.d.ts to not be circular

Fixes #1120

## Type of change
Typings

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
test+build

**Test Environment**:

- OS: mac
- `@envelop/...`: main
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
