### PR TITLE
feat(usePayloadFormatter): add second argument with execution arguments

### DIFF
--- a/.changeset/tame-beds-think.md
+++ b/.changeset/tame-beds-think.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': minor
+---
+
+feat(usePayloadFormatter): add second argument with execution arguments

--- a/packages/core/docs/use-payload-formatter.md
+++ b/packages/core/docs/use-payload-formatter.md
@@ -2,13 +2,15 @@
 
 Allow you to format/modify execution result payload before returning it to your consumer.
 
+The second argument `executionArgs` provides additional information for your formatter. It consists of contextValue, variableValues, document, operationName, and other properties.
+
 ```ts
 import { envelop, usePayloadFormatter } from '@envelop/core';
 import { buildSchema } from 'graphql';
 
 const getEnveloped = envelop({
   plugins: [
-    usePayloadFormatter(result => {
+    usePayloadFormatter((result, executionArgs) => {
       // Return a modified result here,
       // Or `false`y value to keep it as-is.
     }),

--- a/packages/core/src/plugins/use-payload-formatter.ts
+++ b/packages/core/src/plugins/use-payload-formatter.ts
@@ -1,13 +1,24 @@
-import { Plugin } from '@envelop/types';
+import { Plugin, TypedExecutionArgs } from '@envelop/types';
 import { handleStreamOrSingleExecutionResult } from '../utils';
 import { ExecutionResult } from 'graphql';
 
-export type FormatterFunction = (result: ExecutionResult<any, any>) => false | ExecutionResult<any, any>;
+export type FormatterFunction = (
+  result: ExecutionResult<any, any>,
+  args: TypedExecutionArgs<any>
+) => false | ExecutionResult<any, any>;
 
 const makeHandleResult =
   (formatter: FormatterFunction) =>
-  ({ result, setResult }: { result: ExecutionResult; setResult: (result: ExecutionResult) => void }) => {
-    const modified = formatter(result);
+  ({
+    args,
+    result,
+    setResult,
+  }: {
+    args: TypedExecutionArgs<any>;
+    result: ExecutionResult;
+    setResult: (result: ExecutionResult) => void;
+  }) => {
+    const modified = formatter(result, args);
     if (modified !== false) {
       setResult(modified);
     }

--- a/website/docs/core.md
+++ b/website/docs/core.md
@@ -111,13 +111,15 @@ const getEnveloped = envelop({
 
 Allow you to format/modify the execution result payload before returning it to your consumer.
 
+The second argument `executionArgs` provides additional information for your formatter. It consists of contextValue, variableValues, document, operationName, and other properties.
+
 ```ts
 import { envelop, usePayloadFormatter } from '@envelop/core';
 import { buildSchema } from 'graphql';
 
 const getEnveloped = envelop({
   plugins: [
-    usePayloadFormatter(result => {
+    usePayloadFormatter((result, executionArgs) => {
       // Return a modified result here,
       // Or `false`y value to keep it as-is.
     }),


### PR DESCRIPTION
feat(core): add second argument with execution argument to `usePayloadFormatter` which provides additional metadata to formatter

## Description

Formatter does not have any request context. This PR adds executionArgs which allows to get graphql context and get `req` object from it.

In my case, I want to add an extension property to the payload with request-id in it.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
