### PR TITLE
Fix memory leak

### DIFF
--- a/.changeset/mean-actors-exist.md
+++ b/.changeset/mean-actors-exist.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+fix potential memory leak when using `onEndHandler` and `onNextHandler`

--- a/.changeset/mean-actors-exist.md
+++ b/.changeset/mean-actors-exist.md
@@ -2,4 +2,6 @@
 '@envelop/core': patch
 ---
 
-fix potential memory leak when using `onEndHandler` and `onNextHandler`
+fix potential memory leak when using `onEnd` and `onNext` stream handlers for hooking into `subscribe` and `execute`.
+
+This has been caused by AsyncGenerators being blocked until the next value is published. Now disposed result streams (AsyncIterables) will properly cleanup the underlying stream source.


### PR DESCRIPTION
The previous implementation did not properly proxy the `.return` and `.throw` calls, which could lead to consumed event sources not being cleaned up properly.