### PR TITLE
Ensure useOpenTelemetry ends spans after execution

### DIFF
--- a/.changeset/fluffy-peas-yawn.md
+++ b/.changeset/fluffy-peas-yawn.md
@@ -1,0 +1,5 @@
+---
+'@envelop/opentelemetry': patch
+---
+
+Ensure plug-in correctly ends spans after execution.

--- a/packages/plugins/opentelemetry/src/index.ts
+++ b/packages/plugins/opentelemetry/src/index.ts
@@ -122,7 +122,7 @@ export const useOpenTelemetry = (
         };
       }
 
-      return {};
+      return resultCbs;
     },
   };
 };

--- a/packages/plugins/opentelemetry/test/use-open-telemetry.spec.ts
+++ b/packages/plugins/opentelemetry/test/use-open-telemetry.spec.ts
@@ -1,0 +1,74 @@
+import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
+import { BasicTracerProvider, SimpleSpanProcessor, InMemorySpanExporter } from '@opentelemetry/tracing';
+import { buildSchema } from 'graphql';
+import { useOpenTelemetry } from '../src';
+
+function createTraceProvider(exporter: InMemorySpanExporter) {
+  const provider = new BasicTracerProvider();
+  const processor = new SimpleSpanProcessor(exporter);
+  provider.addSpanProcessor(processor);
+  provider.register();
+  return provider;
+}
+
+describe('useOpenTelemetry', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    type Query {
+      ping: String
+    }
+  `);
+  const query = /* GraphQL */ `
+    query {
+      ping
+    }
+  `;
+
+  const useTestOpenTelemetry = (exporter?: InMemorySpanExporter, options?: any) =>
+    useOpenTelemetry(
+      {
+        resolvers: false,
+        result: false,
+        variables: false,
+        ...(options ?? {}),
+      },
+      exporter ? createTraceProvider(exporter) : undefined
+    );
+
+  it('Should override execute function', async () => {
+    const onExecuteSpy = jest.fn();
+    const testInstance = createTestkit(
+      [
+        useTestOpenTelemetry(),
+        {
+          onExecute: onExecuteSpy,
+        },
+      ],
+      schema
+    );
+
+    const result = await testInstance.execute(query);
+    assertSingleExecutionValue(result);
+    expect(onExecuteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should add execution span', async () => {
+    const exporter = new InMemorySpanExporter();
+    const testInstance = createTestkit([useTestOpenTelemetry(exporter)], schema);
+
+    await testInstance.execute(query);
+    const actual = exporter.getFinishedSpans();
+    expect(actual.length).toBe(1);
+    expect(actual[0].name).toBe('Anonymous Operation');
+  });
+
+  it('Should add resolver span if requested', async () => {
+    const exporter = new InMemorySpanExporter();
+    const testInstance = createTestkit([useTestOpenTelemetry(exporter, { resolvers: true })], schema);
+
+    await testInstance.execute(query);
+    const actual = exporter.getFinishedSpans();
+    expect(actual.length).toBe(2);
+    expect(actual[0].name).toBe('Query.ping');
+    expect(actual[1].name).toBe('Anonymous Operation');
+  });
+});


### PR DESCRIPTION
## Description

Ensure useOpenTelemetry ends spans after execution.

Fixes #1192.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests to verify this behaviour only have been added as part of the PR.

**Test Environment**:

- OS: Linux codespaces_8fc9e5 5.4.0-1064-azure
- `@envelop/opentelemetry`: 2.0.0
- NodeJS: v14.17.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
