### PR TITLE
Corrects onResolverCalled vs onResolversCalled in v2.0.0 @envelop/core CHANGELOG

### DIFF
--- a/.changeset/tricky-singers-brush.md
+++ b/.changeset/tricky-singers-brush.md
@@ -1,1 +1,0 @@
-Updates v2 core CHANGELOG

--- a/.changeset/tricky-singers-brush.md
+++ b/.changeset/tricky-singers-brush.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+'@envelop/types': patch
+---
+
+Updates v2 core CHANGELOG

--- a/.changeset/tricky-singers-brush.md
+++ b/.changeset/tricky-singers-brush.md
@@ -1,6 +1,1 @@
----
-'@envelop/core': patch
-'@envelop/types': patch
----
-
 Updates v2 core CHANGELOG

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- aac65ef: Move `onResolversCalled` from within `OnExecuteHookResult` and `OnSubscribeHookResult` to the `Plugin` type.
+- aac65ef: Move `onResolverCalled` from within `OnExecuteHookResult` and `OnSubscribeHookResult` to the `Plugin` type.
 
   ```diff
   import type { Plugin } from "@envelop/core";
@@ -12,19 +12,19 @@
   const plugin: Plugin = {
     onExecute() {
   -    return {
-  -      onResolversCalled() {}
+  -      onResolverCalled() {}
   -    }
   -  }
   +  },
-  +  onResolversCalled() {},
+  +  onResolverCalled() {},
   }
   ```
 
-  We highly recommend avoiding to use any plugins that use `onResolversCalled` within your production environment as it has severe impact on the performance of the individual resolver functions within your schema.
+  We highly recommend avoiding to use any plugins that use `onResolverCalled` within your production environment as it has severe impact on the performance of the individual resolver functions within your schema.
 
-  The schema resolver functions are now ONLY wrapped if any plugin in your envelop setup uses the `onResolversCalled` hook.
+  The schema resolver functions are now ONLY wrapped if any plugin in your envelop setup uses the `onResolverCalled` hook.
 
-  If you need any shared state between `onExecute` and `onResolversCalled` you can share it by extending the context object.
+  If you need any shared state between `onExecute` and `onResolverCalled` you can share it by extending the context object.
 
   ```ts
   import type { Plugin } from '@envelop/core';
@@ -35,7 +35,7 @@
     onExecute({ extendContext }) {
       extendContext({ [sharedStateSymbol]: { value: 1 } });
     },
-    onResolversCalled({ context }) {
+    onResolverCalled({ context }) {
       const sharedState = context[sharedStateSymbol];
       // logs 1
       console.log(sharedState.value);

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- aac65ef: Move `onResolversCalled` from within `OnExecuteHookResult` and `OnSubscribeHookResult` to the `Plugin` type.
+- aac65ef: Move `onResolverCalled` from within `OnExecuteHookResult` and `OnSubscribeHookResult` to the `Plugin` type.
 
   ```diff
   import type { Plugin } from "@envelop/core";
@@ -12,19 +12,19 @@
   const plugin: Plugin = {
     onExecute() {
   -    return {
-  -      onResolversCalled() {}
+  -      onResolverCalled() {}
   -    }
   -  }
   +  },
-  +  onResolversCalled() {},
+  +  onResolverCalled() {},
   }
   ```
 
-  We highly recommend avoiding to use any plugins that use `onResolversCalled` within your production environment as it has severe impact on the performance of the individual resolver functions within your schema.
+  We highly recommend avoiding to use any plugins that use `onResolverCalled` within your production environment as it has severe impact on the performance of the individual resolver functions within your schema.
 
-  The schema resolver functions are now ONLY wrapped if any plugin in your envelop setup uses the `onResolversCalled` hook.
+  The schema resolver functions are now ONLY wrapped if any plugin in your envelop setup uses the `onResolverCalled` hook.
 
-  If you need any shared state between `onExecute` and `onResolversCalled` you can share it by extending the context object.
+  If you need any shared state between `onExecute` and `onResolverCalled` you can share it by extending the context object.
 
   ```ts
   import type { Plugin } from '@envelop/core';
@@ -35,7 +35,7 @@
     onExecute({ extendContext }) {
       extendContext({ [sharedStateSymbol]: { value: 1 } });
     },
-    onResolversCalled({ context }) {
+    onResolverCalled({ context }) {
       const sharedState = context[sharedStateSymbol];
       // logs 1
       console.log(sharedState.value);


### PR DESCRIPTION
## Description

The CHANGELOG for envelop/core included a reference to `onResolversCalled()` but in fact the change is to use the singular (and previously also named) `onResolverCalled()`.

Fixes https://github.com/dotansimha/envelop/issues/1249

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

None. This is a CHANGELOG typo correction.

See docs at https://www.envelop.dev/docs/plugins/lifecycle#onresolvercalledapi

![image](https://user-images.githubusercontent.com/1051633/152563554-d93bda0d-c686-4c37-8725-ca8aacac18c7.png)


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [-] I have commented on my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules

