### PR TITLE
useGraphQlJit: Add option to pass in custom cache instance

### DIFF
--- a/.changeset/wild-foxes-jog.md
+++ b/.changeset/wild-foxes-jog.md
@@ -1,0 +1,5 @@
+---
+'@envelop/graphql-jit': minor
+---
+
+Add option to pass in an existing cache instance to useGraphQlJit plugin.

--- a/packages/plugins/graphql-jit/README.md
+++ b/packages/plugins/graphql-jit/README.md
@@ -52,6 +52,31 @@ const getEnveloped = envelop({
 });
 ```
 
+## Configuring JIT cache
+
+You can configure the JIT cache with the following options:
+
+```ts
+import { envelop } from '@envelop/core';
+import { useGraphQlJit } from '@envelop/graphql-jit';
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    useGraphQlJit(
+      {
+        // your compiler options here
+      },
+      {
+        max: 1000, // Number of items to keep in cache (defaults to 1000)
+        ttl: 3600000, // Time to live for items in cache (defaults to 3600000 - one hour)
+        cache: lru(), // Pass in a custom cache instance, by default a new LRU cache is created which uses the default `max` and `ttl` settings
+      }
+    ),
+  ],
+});
+```
+
 ## Notes
 
 You can find more details here: https://github.com/zalando-incubator/graphql-jit

--- a/packages/plugins/graphql-jit/src/index.ts
+++ b/packages/plugins/graphql-jit/src/index.ts
@@ -7,6 +7,16 @@ import lru from 'tiny-lru';
 const DEFAULT_MAX = 1000;
 const DEFAULT_TTL = 3600000;
 
+type JITCacheEntry = {
+  query: CompiledQuery['query'];
+  subscribe?: CompiledQuery['subscribe'];
+};
+
+export interface JITCache {
+  get(key: string): JITCacheEntry | undefined;
+  set(key: string, value: JITCacheEntry): void;
+}
+
 export const useGraphQlJit = (
   compilerOptions: Partial<CompilerOptions> = {},
   pluginOptions: {
@@ -28,17 +38,17 @@ export const useGraphQlJit = (
      * @default 3600000
      */
     ttl?: number;
+    /**
+     * Custom cache instance
+     */
+    cache?: JITCache;
   } = {}
 ): Plugin => {
   const max = typeof pluginOptions.max === 'number' ? pluginOptions.max : DEFAULT_MAX;
   const ttl = typeof pluginOptions.ttl === 'number' ? pluginOptions.ttl : DEFAULT_TTL;
 
   const documentSourceMap = new WeakMap<DocumentNode, string>();
-  type JITCacheEntry = {
-    query: CompiledQuery['query'];
-    subscribe?: CompiledQuery['subscribe'];
-  };
-  const jitCache = lru<JITCacheEntry>(max, ttl);
+  const jitCache = typeof pluginOptions.cache !== 'undefined' ? pluginOptions.cache : lru<JITCacheEntry>(max, ttl);
 
   function getCacheEntry<T>(args: TypedExecutionArgs<T>): JITCacheEntry {
     let cacheEntry: JITCacheEntry | undefined;


### PR DESCRIPTION
## Description

Hey again! Following up on my previous changes [here](https://github.com/dotansimha/envelop/pull/741) I would like to do a similar thing with the graphql-jit plugin as well.

Fixes https://github.com/dotansimha/envelop/issues/1317

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `packages/plugins/graphql-jit/test/graphql-jit.spec.ts`

**Test Environment**:

- OS: macOS 12.2.1
- `@envelop/...`: latest
- NodeJS: v16.14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
