### PR TITLE
Introduce `extractOperationName` to set a custom operation name

### DIFF
--- a/.changeset/pink-drinks-matter.md
+++ b/.changeset/pink-drinks-matter.md
@@ -1,0 +1,22 @@
+---
+'@envelop/newrelic': major
+---
+
+Set a custom operation name through a function that reads from context
+
+## 🚀 Breaking Change:
+
+In order to set a custom operation name, you can no longer use the `operationNameProperty` option.  
+You will, instead, be able to use the new function `extractOperationName` which receives the context and so allows for greater customisation by accessing nested properties or context extensions from other Envelop plugins.
+
+```ts
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    useNewRelic({
+      ...
+      extractOperationName: (context) => context.request.body.customOperationName
+    }),
+  ],
+});
+```

--- a/packages/plugins/newrelic/README.md
+++ b/packages/plugins/newrelic/README.md
@@ -45,7 +45,7 @@ const getEnveloped = envelop({
       includeResolverArgs: false, // default `false`. When set to `true`, includes all the arguments passed to resolvers with their values
       rootFieldsNaming: true, // default `false`. When set to `true` append the names of operation root fields to the transaction name
       skipError: error => { ... return true; }, // a function that allows you to skip reporting a given error to NewRelic. By default custom `EnvelopError`s will be skipped
-      operationNameProperty: 'id', // default empty. When passed will check for the property name passed, within the document object. Will eventually use its value as operation name. Useful for custom document properties (e.g. queryId/hash)
+      extractOperationName: (context) => context.request.body.customOperationName, // Allows to set a custom operation name to be used as transaction name and attribute
     }),
   ],
 });


### PR DESCRIPTION
## Description

The NewRelic plugin currently allows setting a custom Operation Name by passing a string as a property name to check within the document.

This PR replaces that functionality with a new function that receives the context and so allows setting an Operation Name by accessing values available in context.

The Operation Name is used by the plugin to identify a transaction in NewRelic and will also be logged as an attribute to each transaction, so the ability to customise it will help identify transactions when browsing through the logs.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules