### PR TITLE
feat: add async iterable handler and map indexes in error path

### DIFF
--- a/.changeset/tall-rats-tell.md
+++ b/.changeset/tall-rats-tell.md
@@ -1,0 +1,6 @@
+---
+"@envelop/sentry": patch
+---
+
+Handle errors in async iterables, defer and stream queries.
+Better grouping of errors in lists by mapping the index number to a constant: `$index`


### PR DESCRIPTION
## Description

Context is found in the below issues.

Fixes #1329
Fixes #1330 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Could argue that this is breaking, as it changes grouping behaviour in Sentry.

## How Has This Been Tested?

Ran the plugin on my own graphql server and observed that it correctly reports errors generated in deferred queries.
Observed before the change that these errors were ignored, and that the warning was written to log.

**Test Environment**:

- OS: Mac OSX
- "@envelop/core": "2.0.0"
- "@envelop/sentry": "3.1.0"
- "@sentry/node": "6.18.2"
- "@sentry/tracing": "6.18.2"
- NodeJS: v16.2.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - There are no tests for this plugin.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
