### PR TITLE
feat(sentry): expose sentry event id in error extensions

### DIFF
--- a/.changeset/swift-rings-compare.md
+++ b/.changeset/swift-rings-compare.md
@@ -1,0 +1,5 @@
+---
+"@envelop/sentry": minor
+---
+
+Expose sentry event id in error extensions

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -62,3 +62,4 @@ const getEnveloped = envelop({
 - `operationName` - Produces a "op" (operation) of created Span.
 - `skip` (default: none) - Produces a "op" (operation) of created Span.
 - `skipError` (default: ignored `EnvelopError`) - Indicates whether or not to skip Sentry exception reporting for a given error. By default, this plugin skips all `EnvelopError` errors and does not report it to Sentry.
+- `eventIdKey` (default: `'sentryEventId'`) - The key in the error's extensions field used to expose the generated Sentry event id. Set to `null` to disable.

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -43,10 +43,10 @@ export type SentryPluginOptions = {
    */
   includeExecuteVariables?: boolean;
   /**
-   * The key of the event id in the error's extension
+   * The key of the event id in the error's extension. `null` to disable.
    * @default sentryEventId
    */
-  eventIdKey?: string;
+  eventIdKey?: string | null;
   /**
    * Adds custom tags to every Transaction.
    */
@@ -104,9 +104,13 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const renameTransaction = pick('renameTransaction', false);
   const skipOperation = pick('skip', () => false);
   const skipError = pick('skipError', defaultSkipError);
-  const eventIdKey = pick('eventIdKey', 'sentryEventId');
 
   function addEventId(err: GraphQLError, eventId: string): GraphQLError {
+    if (options.eventIdKey === null) {
+      return err;
+    }
+    const eventIdKey = options.eventIdKey ?? 'sentryEventId';
+
     return new GraphQLError(err.message, {
       ...err,
       extensions: {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -111,12 +111,9 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
     }
     const eventIdKey = options.eventIdKey ?? 'sentryEventId';
 
-    return new GraphQLError(err.message, {
-      ...err,
-      extensions: {
-        ...err.extensions,
-        [eventIdKey]: eventId,
-      },
+    return new GraphQLError(err.message, err.nodes, err.source, err.positions, err.path, undefined, {
+      ...err.extensions,
+      [eventIdKey]: eventId,
     });
   }
 
@@ -204,6 +201,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
         });
 
         if (!span) {
+          // eslint-disable-next-line no-console
           console.warn(
             [
               `Flag "startTransaction" is enabled but Sentry failed to find a transaction.`,


### PR DESCRIPTION
## Description
We expose the Sentry event id in error extensions so that the client can refer to it for error tracing.

Fixes #1340 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the plugin on my own graphql server. Currently using the event ids in our Relay client.

**Test Environment**:

- OS: Mac OSX
- "@envelop/core": "2.0.0"
- "@envelop/sentry": "3.1.0"
- "@sentry/node": "6.18.2"
- "@sentry/tracing": "6.18.2"
- NodeJS: v16.2.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

