### PR TITLE
ensure that root query only contains introspection fields

### DIFF
--- a/packages/core/src/plugins/use-immediate-introspection.ts
+++ b/packages/core/src/plugins/use-immediate-introspection.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from '@envelop/types';
-import { Kind, OperationDefinitionNode, OperationTypeNode } from 'graphql';
+import { Kind, OperationDefinitionNode } from 'graphql';
 
 const fastIntroSpectionSymbol = Symbol('fastIntrospection');
 
@@ -16,7 +16,7 @@ export const useImmediateIntrospection = (): Plugin<{
       setValidationFn((schema, node, ...args) => {
         const operations = node.definitions.filter((n): n is OperationDefinitionNode => n.kind === Kind.OPERATION_DEFINITION);
 
-        if (operations.some(operation => operation.operation !== OperationTypeNode.QUERY)) {
+        if (operations.some(operation => operation.operation !== 'query')) {
           return validateFn(schema, node, ...args);
         }
 

--- a/packages/core/test/plugins/use-immediate-introspection.spec.ts
+++ b/packages/core/test/plugins/use-immediate-introspection.spec.ts
@@ -2,6 +2,7 @@ import { createTestkit } from '@envelop/testing';
 import { useImmediateIntrospection } from '../../src/plugins/use-immediate-introspection';
 import { useExtendContext } from '../../src/plugins/use-extend-context';
 import { schema } from '../common';
+import { getIntrospectionQuery } from 'graphql';
 
 describe('useImmediateIntrospection', () => {
   it('skips context building for introspection only operation', async () => {
@@ -52,5 +53,13 @@ describe('useImmediateIntrospection', () => {
       }
       throw err;
     }
+  });
+  it('skips context building for graphql introspection query', async () => {
+    const testInstance = createTestkit(
+      [useImmediateIntrospection(), useExtendContext<() => Promise<{}>>(() => Promise.reject('This should not reject'))],
+      schema
+    );
+
+    await testInstance.execute(getIntrospectionQuery());
   });
 });


### PR DESCRIPTION
## Description

`useImmediateIntrospection` fails when using `getIntrospectionQuery` from `graphql-js`.
This fixes it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

