### PR TITLE
fix: use correct extensions type

### DIFF
--- a/.changeset/twelve-ghosts-shout.md
+++ b/.changeset/twelve-ghosts-shout.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+use the correct `GraphQLErrorExtensions` interface for the `extensions` constructor option on `EnvelopError`.

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -1,11 +1,11 @@
 import { Plugin } from '@envelop/types';
-import { ExecutionResult, GraphQLError } from 'graphql';
+import { ExecutionResult, GraphQLError, GraphQLErrorExtensions } from 'graphql';
 import { handleStreamOrSingleExecutionResult } from '../utils';
 
 export const DEFAULT_ERROR_MESSAGE = 'Unexpected error.';
 
 export class EnvelopError extends GraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
+  constructor(message: string, extensions?: GraphQLErrorExtensions) {
     super(message, undefined, undefined, undefined, undefined, undefined, extensions);
   }
 }


### PR DESCRIPTION
## Description

use the correct `GraphQLErrorExtensions` interface for the `extensions` constructor option on `EnvelopError`.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
