### PR TITLE
fix(docs): isAsyncIterable type-guard example

### DIFF
--- a/website/docs/plugins/lifecycle.mdx
+++ b/website/docs/plugins/lifecycle.mdx
@@ -198,9 +198,8 @@ const myPlugin = (): Plugin => {
     onExecute({ args }) {
       return {
         onExecuteDone: ({ result, setResult }) => {
-          if (isAsyncIterable(result)) {
-            // Here you can access result, and modify it with setResult if needed
-          }
+          if (!isAsyncIterable(result)) return
+          // Here you can access result, and modify it with setResult if needed
         },
       };
     },


### PR DESCRIPTION
## Description

Fixes the example using `isAsyncIterable` type-guard in the `onExecute` section of the plugin lifecycle documentation page.

## Type of change

- [x] Documentation update
