### PR TITLE
fix: do not mask the operation permissions error message

### DIFF
--- a/.changeset/ninety-elephants-argue.md
+++ b/.changeset/ninety-elephants-argue.md
@@ -1,0 +1,5 @@
+---
+'@envelop/operation-field-permissions': patch
+---
+
+use EnvelopError instead of GraphQLError for preventing the error message from being masked

--- a/packages/plugins/operation-field-permissions/src/index.ts
+++ b/packages/plugins/operation-field-permissions/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin, useExtendContext } from '@envelop/core';
+import { EnvelopError, Plugin, useExtendContext } from '@envelop/core';
 import { ExtendedValidationRule, useExtendedValidation } from '@envelop/extended-validation';
 import {
   GraphQLError,
@@ -64,7 +64,12 @@ const OperationScopeRule =
         !permissionContext.wildcardTypes.has(objectType.name) &&
         !permissionContext.schemaCoordinates.has(schemaCoordinate)
       ) {
-        context.reportError(new GraphQLError(options.formatError(schemaCoordinate), [node]));
+        // TODO: EnvelopError was a bad idea ;)
+        // We should use GraphQLError once the object constructor lands in stable GraphQL.js
+        // and useMaskedErrors supports it.
+        const error = new EnvelopError(options.formatError(schemaCoordinate));
+        (error as any).nodes = [node];
+        context.reportError(error);
       }
     };
 

--- a/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
+++ b/packages/plugins/operation-field-permissions/test/use-operation-permissions.spec.ts
@@ -2,6 +2,7 @@ import { useOperationFieldPermissions } from '../src';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { getIntrospectionQuery } from 'graphql';
+import { useMaskedErrors } from '@envelop/core';
 
 const schema = makeExecutableSchema({
   typeDefs: [
@@ -77,10 +78,10 @@ describe('useOperationPermissions', () => {
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Insufficient permissions for selecting 'Query.greetings'.],
-]
-`);
+      Array [
+        [GraphQLError: Insufficient permissions for selecting 'Query.greetings'.],
+      ]
+    `);
   });
 
   it('allow everything', async () => {
@@ -111,12 +112,12 @@ Array [
     const result = await kit.execute(query);
     assertSingleExecutionValue(result);
     expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Insufficient permissions for selecting 'Query.foo'.],
-  [GraphQLError: Insufficient permissions for selecting 'Query.user'.],
-  [GraphQLError: Insufficient permissions for selecting 'User.id'.],
-]
-`);
+      Array [
+        [GraphQLError: Insufficient permissions for selecting 'Query.foo'.],
+        [GraphQLError: Insufficient permissions for selecting 'Query.user'.],
+        [GraphQLError: Insufficient permissions for selecting 'User.id'.],
+      ]
+    `);
   });
   it('allow wildcard for types', async () => {
     const kit = createTestkit(
@@ -131,10 +132,10 @@ Array [
     const result = await kit.execute(query);
     assertSingleExecutionValue(result);
     expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Insufficient permissions for selecting 'User.id'.],
-]
-`);
+      Array [
+        [GraphQLError: Insufficient permissions for selecting 'User.id'.],
+      ]
+    `);
   });
   it('allow selecting specific fields', async () => {
     const kit = createTestkit(
@@ -169,12 +170,12 @@ Array [
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Insufficient permissions for selecting 'Query.postOrUser'.],
-  [GraphQLError: Insufficient permissions for selecting 'Post.__typename'.],
-  [GraphQLError: Insufficient permissions for selecting 'User.__typename'.],
-]
-`);
+      Array [
+        [GraphQLError: Insufficient permissions for selecting 'Query.postOrUser'.],
+        [GraphQLError: Insufficient permissions for selecting 'Post.__typename'.],
+        [GraphQLError: Insufficient permissions for selecting 'User.__typename'.],
+      ]
+    `);
   });
 
   it('interface errors', async () => {
@@ -196,11 +197,52 @@ Array [
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toMatchInlineSnapshot(`
-Array [
-  [GraphQLError: Insufficient permissions for selecting 'Query.node'.],
-  [GraphQLError: Insufficient permissions for selecting 'User.__typename'.],
-  [GraphQLError: Insufficient permissions for selecting 'Post.__typename'.],
-]
-`);
+      Array [
+        [GraphQLError: Insufficient permissions for selecting 'Query.node'.],
+        [GraphQLError: Insufficient permissions for selecting 'User.__typename'.],
+        [GraphQLError: Insufficient permissions for selecting 'Post.__typename'.],
+      ]
+    `);
+  });
+
+  it('includes the node location', async () => {
+    const kit = createTestkit(
+      [
+        useOperationFieldPermissions({
+          getPermissions: () => new Set([]),
+        }),
+      ],
+      schema
+    );
+
+    const result = await kit.execute(/* GraphQL */ `
+      query {
+        __typename
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    const [error] = result.errors!;
+    expect(error.nodes).toBeDefined();
+  });
+
+  it('is not masked by the masked errors plugin', async () => {
+    const kit = createTestkit(
+      [
+        useOperationFieldPermissions({
+          getPermissions: () => new Set([]),
+        }),
+        useMaskedErrors(),
+      ],
+      schema
+    );
+    const result = await kit.execute(/* GraphQL */ `
+      query {
+        __typename
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0].message).toEqual("Insufficient permissions for selecting 'Query.__typename'.");
   });
 });


### PR DESCRIPTION
The operation permissions plugin error message should not be masked by the masked error plugin.