### PR TITLE
enhance(response-cache) - Use WeakMap instead of context to store document node strings by default and pass all execution args to `getDocumentString`

### DIFF
--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -6,6 +6,55 @@
 
 Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with a "WeakMap" so the modification in the context is no longer needed.
 
-## More flexible `getDocumentStringFromContext`
+## Replace `getDocumentStringFromContext` with `getDocumentString`
 
-However, some users might provide document directly to the execution without parsing it via `parse`. So in that case, we added a second parameter to the `getDocumentStringFromContext` function which contains all execution arguments.
+However, some users might provide document directly to the execution without parsing it via `parse`. So in that case, we replaced the context parameter with the execution args including `document`, `variableValues` and `contextValue` to the new `getDocumentString`.
+
+Now a valid document string should be returned from the new `getDocumentString`.
+
+### Example with a custom document string caching
+
+```ts
+const myCache = new WeakMap<DocumentNode, string>();
+
+// Let's say you keep parse results in somewhere else like below
+function parseDocument(document: string): DocumentNode {
+  const parsedDocument = parse(document);
+  myCache.set(parsedDocument, document);
+  return parsedDocument;
+}
+
+// Then you can interact with your existing caching solution inside the response cache plugin like below
+useResponseCache({
+  getDocumentString(document: DocumentNode): string {
+    // You can also add a fallback to `graphql-js`'s print function
+    // to let the plugin works
+    const possibleDocumentStr = myCache.get(document);
+    if (!possibleDocumentStr) {
+      console.warn(`Something might be wrong with my cache setup`);
+      return print(document);
+    }
+    return possibleDocumentStr;
+  },
+});
+```
+
+### Migration from `getDocumentStringFromContext`
+
+So if you use `getDocumentStringFromContext` like below before;
+
+```ts
+function getDocumentStringFromContext(contextValue: any) {
+  return contextValue.myDocumentString;
+}
+```
+
+You have to change it to the following;
+
+```ts
+import { print } from 'graphql';
+function getDocumentString(executionArgs: ExecutionArgs) {
+  // We need to fallback to `graphql`'s print to return a value no matter what.
+  return executionArgs.contextValue.myDocumentString ?? print(executionArgs.document);
+}
+```

--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -6,7 +6,13 @@
 
 Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with a "WeakMap" so the modification in the context is no longer needed.
 
-## Replace `getDocumentStringFromContext` with `getDocumentString`
+# API Changes
+
+## NON-BREAKING CHANGE: `buildResponseCacheKey` also takes `contextValue` and more execution args
+
+Previously it wasn't possible to get `contextValue` from the `buildResponseCacheKey` function. Now you can get `contextValue`
+
+## BREAKING CHANGE: Replace `getDocumentStringFromContext` with `getDocumentString`
 
 However, some users might provide document directly to the execution without parsing it via `parse`. So in that case, we replaced the context parameter with the execution args including `document`, `variableValues` and `contextValue` to the new `getDocumentString`.
 

--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -2,4 +2,10 @@
 '@envelop/response-cache': patch
 ---
 
-Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with "WeakMap" so "getDocumentStringFromContext" is no longer needed and both "defaultGetDocumentStringFromContext" and getDocumentStringFromContext options are now deprecated and will be removed in the next major release.
+## Better document string storage by default
+
+Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with a "WeakMap" so the modification in the context is no longer needed.
+
+## More flexible `getDocumentStringFromContext`
+
+However, some users might provide document directly to the execution without parsing it via `parse`. So in that case, we added a second parameter to the `getDocumentStringFromContext` function which contains all execution arguments.

--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with "WeakMap" so "getDocumentStringFromContext" is no longer needed and both "defaultGetDocumentStringFromContext" and getDocumentStringFromContext options are now deprecated and will be removed in the next major release.

--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -6,12 +6,6 @@
 
 Previously non parsed operation document was stored in the context with a symbol to be used "documentString" in the later. But this can be solved with a "WeakMap" so the modification in the context is no longer needed.
 
-# API Changes
-
-## NON-BREAKING CHANGE: `buildResponseCacheKey` also takes `contextValue` and more execution args
-
-Previously it wasn't possible to get `contextValue` from the `buildResponseCacheKey` function. Now you can get `contextValue`
-
 ## BREAKING CHANGE: Replace `getDocumentStringFromContext` with `getDocumentString`
 
 However, some users might provide document directly to the execution without parsing it via `parse`. So in that case, we replaced the context parameter with the execution args including `document`, `variableValues` and `contextValue` to the new `getDocumentString`.

--- a/.changeset/shy-ears-divide.md
+++ b/.changeset/shy-ears-divide.md
@@ -1,5 +1,5 @@
 ---
-'@envelop/response-cache': patch
+'@envelop/response-cache': major
 ---
 
 ## Better document string storage by default

--- a/packages/plugins/response-cache/src/cache-document-str.ts
+++ b/packages/plugins/response-cache/src/cache-document-str.ts
@@ -1,0 +1,25 @@
+import { DocumentNode, ExecutionArgs, print } from 'graphql';
+import { Plugin } from '@envelop/core';
+
+const documentStringByDocument = new WeakMap<DocumentNode, string>();
+
+export function useCacheDocumentString(): Plugin {
+  return {
+    onParse({ params: { source } }) {
+      return function onParseEnd({ result }) {
+        if (result != null && !(result instanceof Error)) {
+          documentStringByDocument.set(result, source.toString());
+        }
+      };
+    },
+  };
+}
+
+export function defaultGetDocumentString(executionArgs: ExecutionArgs): string {
+  let documentString = documentStringByDocument.get(executionArgs.document);
+  if (documentString == null) {
+    documentString = print(executionArgs.document);
+    documentStringByDocument.set(executionArgs.document, documentString);
+  }
+  return documentString;
+}

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -253,10 +253,8 @@ export function useResponseCache({
         };
       }
 
-      const documentString = getDocumentString(ctx.args);
-
       const operationId = await buildResponseCacheKey({
-        documentString,
+        documentString: getDocumentString(ctx.args),
         variableValues: ctx.args.variableValues,
         operationName: ctx.args.operationName,
         sessionId: session(ctx.args.contextValue),

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -32,14 +32,16 @@ type Context = {
 /**
  * Function for building the response cache key based on the input parameters
  */
-export type BuildResponseCacheKeyFunction = (
-  params: {
-    /** Raw document string as sent from the client. */
-    documentString: string;
-    /** optional sessionId for make unique cache keys based on the session.  */
-    sessionId?: Maybe<string>;
-  } & ExecutionArgs
-) => Promise<string>;
+export type BuildResponseCacheKeyFunction = (params: {
+  /** Raw document string as sent from the client. */
+  documentString: string;
+  /** Variable values as sent form the client. */
+  variableValues: ExecutionArgs['variableValues'];
+  /** The name of the GraphQL operation that should be executed from within the document. */
+  operationName?: Maybe<string>;
+  /** optional sessionId for make unique cache keys based on the session.  */
+  sessionId?: Maybe<string>;
+}) => Promise<string>;
 
 export type GetDocumentStringFunction = (executionArgs: ExecutionArgs) => string;
 
@@ -253,8 +255,9 @@ export function useResponseCache({
 
       const operationId = await buildResponseCacheKey({
         documentString: getDocumentString(ctx.args),
+        variableValues: ctx.args.variableValues,
+        operationName: ctx.args.operationName,
         sessionId: session(ctx.args.contextValue),
-        ...ctx.args,
       });
 
       if ((enabled?.(ctx.args.contextValue) ?? true) === true) {

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -32,16 +32,14 @@ type Context = {
 /**
  * Function for building the response cache key based on the input parameters
  */
-export type BuildResponseCacheKeyFunction = (params: {
-  /** Raw document string as sent from the client. */
-  documentString: string;
-  /** Variable values as sent form the client. */
-  variableValues: ExecutionArgs['variableValues'];
-  /** The name of the GraphQL operation that should be executed from within the document. */
-  operationName?: Maybe<string>;
-  /** optional sessionId for make unique cache keys based on the session.  */
-  sessionId?: Maybe<string>;
-}) => Promise<string>;
+export type BuildResponseCacheKeyFunction = (
+  params: {
+    /** Raw document string as sent from the client. */
+    documentString: string;
+    /** optional sessionId for make unique cache keys based on the session.  */
+    sessionId?: Maybe<string>;
+  } & ExecutionArgs
+) => Promise<string>;
 
 export type GetDocumentStringFunction = (executionArgs: ExecutionArgs) => string;
 
@@ -255,9 +253,8 @@ export function useResponseCache({
 
       const operationId = await buildResponseCacheKey({
         documentString: getDocumentString(ctx.args),
-        variableValues: ctx.args.variableValues,
-        operationName: ctx.args.operationName,
         sessionId: session(ctx.args.contextValue),
+        ...ctx.args,
       });
 
       if ((enabled?.(ctx.args.contextValue) ?? true) === true) {

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -10,6 +10,7 @@ import {
   defaultFieldResolver,
   ExecutionArgs,
   ExecutionResult,
+  print,
 } from 'graphql';
 import jsonStableStringify from 'fast-json-stable-stringify';
 import type { Cache, CacheEntityRecord } from './cache.js';
@@ -105,6 +106,8 @@ export type UseResponseCacheParameter<C = any> = {
    * By default, the useResponseCache plugin hooks into onParse and writes the original operation string to the context.
    * If you are hard overriding parse you need to set this function, otherwise responses will not be cached or served from the cache.
    * Defaults to `defaultGetDocumentStringFromContext`
+   *
+   * @deprecated No longer being used in the next major version.
    */
   getDocumentStringFromContext?: GetDocumentStringFromContextFunction;
   /**
@@ -152,8 +155,20 @@ export const defaultShouldCacheResult: ShouldCacheResultFunction = (params): Boo
   return true;
 };
 
+// @deprecated This will be removed in the next major
 export const defaultGetDocumentStringFromContext: GetDocumentStringFromContextFunction = context =>
   context[rawDocumentStringSymbol as any] as any;
+
+const documentStringByDocument = new WeakMap<DocumentNode, string>();
+
+function getDocumentStringFromDocument(documentNode: DocumentNode) {
+  let documentString = documentStringByDocument.get(documentNode);
+  if (!documentString) {
+    documentString = print(documentNode);
+    documentStringByDocument.set(documentNode, documentString);
+  }
+  return documentString;
+}
 
 export function useResponseCache({
   cache = createInMemoryCache(),
@@ -166,7 +181,7 @@ export function useResponseCache({
   idFields = ['id'],
   invalidateViaMutation = true,
   buildResponseCacheKey = defaultBuildResponseCacheKey,
-  getDocumentStringFromContext = defaultGetDocumentStringFromContext,
+  getDocumentStringFromContext,
   shouldCacheResult = defaultShouldCacheResult,
   // eslint-disable-next-line dot-notation
   includeExtensionMetadata = typeof process !== 'undefined' ? process.env['NODE_ENV'] === 'development' : false,
@@ -191,15 +206,10 @@ export function useResponseCache({
       };
       replaceSchema(patchedSchema);
     },
-    onParse(parseCtx) {
-      return function onParseEnd(ctx) {
-        if (ctx.result && 'kind' in ctx.result) {
-          const source = parseCtx.params.source;
-
-          const rawDocumentString = typeof source === 'string' ? source : source.body;
-          ctx.extendContext({
-            [rawDocumentStringSymbol]: rawDocumentString,
-          });
+    onParse({ params: { source } }) {
+      return function onParseEnd({ result }) {
+        if (result != null && !(result instanceof Error)) {
+          documentStringByDocument.set(result, source.toString());
         }
       };
     },
@@ -248,110 +258,103 @@ export function useResponseCache({
           },
         };
       }
-      const documentString = getDocumentStringFromContext(ctx.args.contextValue);
-      if (documentString != null) {
-        const operationId = await buildResponseCacheKey({
-          documentString,
-          variableValues: ctx.args.variableValues,
-          operationName: ctx.args.operationName,
-          sessionId: session(ctx.args.contextValue),
-        });
+      const documentString =
+        getDocumentStringFromContext?.(ctx.args.contextValue) ?? getDocumentStringFromDocument(ctx.args.document);
+      const operationId = await buildResponseCacheKey({
+        documentString,
+        variableValues: ctx.args.variableValues,
+        operationName: ctx.args.operationName,
+        sessionId: session(ctx.args.contextValue),
+      });
 
-        if ((enabled?.(ctx.args.contextValue) ?? true) === true) {
-          const cachedResponse = await cache.get(operationId);
+      if ((enabled?.(ctx.args.contextValue) ?? true) === true) {
+        const cachedResponse = await cache.get(operationId);
 
-          if (cachedResponse != null) {
-            if (includeExtensionMetadata) {
-              ctx.setResultAndStopExecution({
-                ...cachedResponse,
-                extensions: {
-                  responseCache: {
-                    hit: true,
-                  },
+        if (cachedResponse != null) {
+          if (includeExtensionMetadata) {
+            ctx.setResultAndStopExecution({
+              ...cachedResponse,
+              extensions: {
+                responseCache: {
+                  hit: true,
                 },
-              });
-            } else {
-              ctx.setResultAndStopExecution(cachedResponse);
-            }
+              },
+            });
+          } else {
+            ctx.setResultAndStopExecution(cachedResponse);
+          }
+          return;
+        }
+      }
+
+      if (ttlPerSchemaCoordinate) {
+        const typeInfo = new TypeInfo(ctx.args.schema);
+        visit(
+          ctx.args.document,
+          visitWithTypeInfo(typeInfo, {
+            Field(fieldNode) {
+              const parentType = typeInfo.getParentType();
+              if (parentType) {
+                const schemaCoordinate = `${parentType.name}.${fieldNode.name.value}`;
+                const maybeTtl = ttlPerSchemaCoordinate[schemaCoordinate];
+                if (maybeTtl !== undefined) {
+                  context.currentTtl = calculateTtl(maybeTtl, context.currentTtl);
+                }
+              }
+            },
+          })
+        );
+      }
+
+      return {
+        onExecuteDone({ result, setResult }) {
+          if (isAsyncIterable(result)) {
+            // eslint-disable-next-line no-console
+            console.warn('[useResponseCache] AsyncIterable returned from execute is currently unsupported.');
             return;
           }
-        }
 
-        if (ttlPerSchemaCoordinate) {
-          const typeInfo = new TypeInfo(ctx.args.schema);
-          visit(
-            ctx.args.document,
-            visitWithTypeInfo(typeInfo, {
-              Field(fieldNode) {
-                const parentType = typeInfo.getParentType();
-                if (parentType) {
-                  const schemaCoordinate = `${parentType.name}.${fieldNode.name.value}`;
-                  const maybeTtl = ttlPerSchemaCoordinate[schemaCoordinate];
-                  if (maybeTtl !== undefined) {
-                    context.currentTtl = calculateTtl(maybeTtl, context.currentTtl);
-                  }
-                }
-              },
-            })
-          );
-        }
+          if (context.skip) {
+            return;
+          }
 
-        return {
-          onExecuteDone({ result, setResult }) {
-            if (isAsyncIterable(result)) {
-              // eslint-disable-next-line no-console
-              console.warn('[useResponseCache] AsyncIterable returned from execute is currently unsupported.');
-              return;
-            }
+          if (!shouldCacheResult({ result })) {
+            return;
+          }
 
-            if (context.skip) {
-              return;
-            }
+          // we only use the global ttl if no currentTtl has been determined.
+          const finalTtl = context.currentTtl ?? globalTtl;
 
-            if (!shouldCacheResult({ result })) {
-              return;
-            }
-
-            // we only use the global ttl if no currentTtl has been determined.
-            const finalTtl = context.currentTtl ?? globalTtl;
-
-            if (finalTtl === 0) {
-              if (includeExtensionMetadata) {
-                setResult({
-                  ...result,
-                  extensions: {
-                    responseCache: {
-                      hit: false,
-                      didCache: false,
-                    },
-                  },
-                });
-              }
-              return;
-            }
-
-            cache.set(operationId, result, identifier.values(), finalTtl);
+          if (finalTtl === 0) {
             if (includeExtensionMetadata) {
               setResult({
                 ...result,
                 extensions: {
                   responseCache: {
                     hit: false,
-                    didCache: true,
-                    ttl: finalTtl,
+                    didCache: false,
                   },
                 },
               });
             }
-          },
-        };
-      }
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[useResponseCache] Failed extracting document string from the context. The response will not be cached or served from the cache. ` +
-          `If you are overriding the 'parse' behavior make sure to pass a custom 'getDocumentStringFromContext' function for getting the document string, which is required for building the response cache key.`
-      );
-      return undefined;
+            return;
+          }
+
+          cache.set(operationId, result, identifier.values(), finalTtl);
+          if (includeExtensionMetadata) {
+            setResult({
+              ...result,
+              extensions: {
+                responseCache: {
+                  hit: false,
+                  didCache: true,
+                  ttl: finalTtl,
+                },
+              },
+            });
+          }
+        },
+      };
     },
   };
 }


### PR DESCRIPTION
Currently the document string is added during parse and extracted later during execution. Actually WeakMap can be used here to remove the need of the context.

But still some users of Envelop (e.g. Mesh SDK) don't use Envelop's scoped `parse` function so it is a bit overhead to put printed document node into the context specifically for response cache plugin in order to take from `getDocumentStringFromContext`. In Mesh for example, we have its own `print` and parse` caching so it can give the cached document string by the document node object.

And even if it is not stored and user doesn't provide its own logic , we should still allow the plugin work as is by printing the document node 

I avoided introducing breaking changes but @n1ru4l if you are fine with that, it'd better to make the following breaking changes;

Rename `getDocumentStringFromContext` to `getDocumentString` and remove `context` paramter in favor of all execution parameters (document, variables, context and so on).

Update:
Ok I did some breaking changes by renaming `getDocumentStringFromContext` to `getDocumentString`, also a returned value is required from `getDocumentString` which can be easily fallbacked to graphql-js's print function.