### PR TITLE
[sentry plugin] Adds an error before using the rootSpan if it's not been set up

### DIFF
--- a/.changeset/twenty-vans-grab.md
+++ b/.changeset/twenty-vans-grab.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': patch
+---
+
+Create a more friendly error message in case the Sentry SDK is not properly configured.

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -191,6 +191,14 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
           op,
           tags,
         });
+
+        if (!rootSpan) {
+          const error = [
+            `Could not create the root Sentry transaction for the GraphQL operation "${transactionName}".`,
+            `It's very likely that this is because you have not included the Sentry tracing SDK in your app's runtime before handling the request.`,
+          ];
+          throw new Error(error.join('\n'));
+        }
       } else {
         const scope = Sentry.getCurrentHub().getScope();
         const parentSpan = scope?.getSpan();


### PR DESCRIPTION
## Description

:wave: It is possible to set up Sentry so that `rootSpan = Sentry.startTransaction` returns null. This is always a user-side sentry setup issue, but because it will crash the plugin I wasn't seeing any logs about what was going on. https://github.com/getsentry/sentry-javascript/issues/4731

Fixes (no issue, didn't seem worth it for a more explicit log)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Too small to warrant, but I did run this code in my app's node_modules first

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
