### PR TITLE
feat(response-cache): make the session property mandatory

### DIFF
--- a/.changeset/rare-peas-hope.md
+++ b/.changeset/rare-peas-hope.md
@@ -1,0 +1,39 @@
+---
+'@envelop/response-cache': major
+---
+
+**BREAKING** Require the user to provide a `session` function by default.
+
+Previously, using the response cache automatically used a global cache. For security reasons there is no longer a default value for the `session` config property. If you did not set the `session` function before and want a global cache that is shared by all users, you need to update your code to the following:
+
+```ts
+import { envelop } from '@envelop/core';
+import { useResponseCache } from '@envelop/response-cache';
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    useResponseCache({
+      // use global cache for all operations
+      session: () => null,
+    }),
+  ],
+});
+```
+
+Otherwise, you should return from your cache function a value that uniquely identifies the viewer.
+
+```ts
+import { envelop } from '@envelop/core';
+import { useResponseCache } from '@envelop/response-cache';
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    useResponseCache({
+      // return null as a fallback for caching the result globally
+      session: context => context.user?.id ?? null,
+    }),
+  ],
+});
+```

--- a/packages/plugins/graphql-middleware/test/graphql-middleware.spec.ts
+++ b/packages/plugins/graphql-middleware/test/graphql-middleware.spec.ts
@@ -19,6 +19,7 @@ describe('useGraphQlJit', () => {
     const testkit = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 2000,
           includeExtensionMetadata: true,
         }),

--- a/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
+++ b/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
@@ -73,7 +73,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -151,7 +151,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -246,7 +246,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -380,7 +380,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -493,7 +493,10 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache, includeExtensionMetadata: true })], schema);
+    const testInstance = createTestkit(
+      [useResponseCache({ session: () => null, cache, includeExtensionMetadata: true })],
+      schema
+    );
 
     const query = /* GraphQL */ `
       query test {
@@ -596,7 +599,10 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache, includeExtensionMetadata: true })], schema);
+    const testInstance = createTestkit(
+      [useResponseCache({ session: () => null, cache, includeExtensionMetadata: true })],
+      schema
+    );
 
     const result = await testInstance.execute(
       /* GraphQL */ `
@@ -673,7 +679,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test($limit: Int!) {
@@ -756,7 +762,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache, ttl: 100 })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache, ttl: 100 })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -942,7 +948,7 @@ describe('useResponseCache with Redis cache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ cache, ignoredTypes: ['Comment'] })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache, ignoredTypes: ['Comment'] })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -1031,6 +1037,7 @@ describe('useResponseCache with Redis cache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           cache,
           ttl: 500,
           ttlPerType: {
@@ -1121,6 +1128,7 @@ describe('useResponseCache with Redis cache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           cache,
           ttl: 500,
           ttlPerSchemaCoordinate: {

--- a/packages/plugins/response-cache/README.md
+++ b/packages/plugins/response-cache/README.md
@@ -44,7 +44,10 @@ import { useResponseCache } from '@envelop/response-cache';
 const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
-    useResponseCache(),
+    useResponseCache({
+      // use global cache for all operations
+      session: () => null,
+    }),
   ],
 });
 ```
@@ -61,11 +64,30 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useResponseCache({ cache }),
+    session: () => null, // use global cache for all operations
   ],
 });
 ```
 
 > Note: The in-memory LRU cache is not suitable for serverless deployments. Instead, consider the Redis cache provided by `@envelop/response-cache-redis`.
+
+### Cache based on session/user
+
+```ts
+import { envelop } from '@envelop/core';
+import { useResponseCache } from '@envelop/response-cache';
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    useResponseCache({
+      ttl: 2000,
+      // context is the GraphQL context used for execution
+      session: context => String(context.user?.id),
+    }),
+  ],
+});
+```
 
 ### Redis Cache
 
@@ -93,14 +115,17 @@ const redis = new Redis({
   password: '1234567890',
 });
 
-const redis = new Redis("rediss://:1234567890@my-redis-db.example.com:30652");
+const redis = new Redis('rediss://:1234567890@my-redis-db.example.com:30652');
 
 const cache = createRedisCache({ redis });
 
 const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
-    useResponseCache({ cache }),
+    useResponseCache({
+      cache,
+      session: () => null, // use global cache for all operations
+    }),
   ],
 });
 ```
@@ -120,6 +145,7 @@ const getEnveloped = envelop({
     // ... other plugins ...
     useResponseCache({
       ttl: 2000, // cached execution results become stale after 2 seconds
+      session: () => null, // use global cache for all operations
     }),
   ],
 });
@@ -167,24 +193,6 @@ const getEnveloped = envelop({
 });
 ```
 
-### Cache based on session/user
-
-```ts
-import { envelop } from '@envelop/core';
-import { useResponseCache } from '@envelop/response-cache';
-
-const getEnveloped = envelop({
-  plugins: [
-    // ... other plugins ...
-    useResponseCache({
-      ttl: 2000,
-      // context is the GraphQL context used for execution
-      session: context => String(context.user?.id),
-    }),
-  ],
-});
-```
-
 ### Disable cache based on session/user
 
 ```ts
@@ -198,6 +206,7 @@ const getEnveloped = envelop({
       ttl: 2000,
       // context is the GraphQL context used for execution
       enabled: context => context.user?.role !== 'admin',
+      session: () => null,
     }),
   ],
 });
@@ -231,6 +240,7 @@ const getEnveloped = envelop({
     // ... other plugins ...
     useResponseCache({
       shouldCacheResult = myCustomShouldCacheResult,
+      session: () => null,
     }),
   ],
 });
@@ -253,6 +263,7 @@ const getEnveloped = envelop({
       ttlPerSchemaCoordinate: {
         'Query.__schema': undefined, // cache infinitely
       },
+      session: () => null,
     }),
   ],
 });
@@ -271,6 +282,7 @@ const getEnveloped = envelop({
       ttlPerSchemaCoordinate: {
         'Query.__schema': 10_000, // cache for 10 seconds
       },
+      session: () => null,
     }),
   ],
 });
@@ -287,6 +299,7 @@ const getEnveloped = envelop({
     // ... other plugins ...
     useResponseCache({
       ttl: 2000, // cached execution results become stale after 2 seconds
+      session: () => null,
     }),
   ],
 });
@@ -305,6 +318,7 @@ const getEnveloped = envelop({
       ttl: 2000,
       // use the `_id` instead of `id` field.
       idFields: ['_id'],
+      session: () => null,
     }),
   ],
 });
@@ -323,6 +337,7 @@ const getEnveloped = envelop({
       ttl: 2000,
       // some might prefer invalidating based on a database write log
       invalidateViaMutation: false,
+      session: () => null,
     }),
   ],
 });
@@ -345,6 +360,7 @@ const getEnveloped = envelop({
       ttl: 2000,
       // we pass the cache instance to the request.
       cache,
+      session: () => null,
     }),
   ],
 });
@@ -379,6 +395,7 @@ const getEnveloped = envelop({
       ttl: 2000,
       // we pass the cache instance to the request.
       cache,
+      session: () => null,
     }),
   ],
 });
@@ -395,6 +412,7 @@ const getEnveloped = envelop({
     useResponseCache({
       ttl: 2000,
       includeExtensionMetadata: true,
+      session: () => null,
     }),
   ],
 });

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -74,6 +74,20 @@ export type UseResponseCacheParameter<C = any> = {
    * Return `null` or `undefined` to mark the session as public/global.
    * Creates a global session by default.
    * @param context GraphQL Context
+   *
+   * **Global Example:**
+   * ```ts
+   * useResponseCache({
+   *   session: () => null,
+   * });
+   * ```
+   *
+   * **User Specific with global fallback example:**
+   * ```ts
+   * useResponseCache({
+   *   session: (context) => context.user?.id ?? null,
+   * });
+   * ```
    */
   session(context: C): string | undefined | null;
   /**

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -40,7 +40,7 @@ export type BuildResponseCacheKeyFunction = (params: {
   /** The name of the GraphQL operation that should be executed from within the document. */
   operationName?: Maybe<string>;
   /** optional sessionId for make unique cache keys based on the session.  */
-  sessionId?: Maybe<string>;
+  sessionId: Maybe<string>;
 }) => Promise<string>;
 
 export type GetDocumentStringFunction = (executionArgs: ExecutionArgs) => string;
@@ -75,7 +75,7 @@ export type UseResponseCacheParameter<C = any> = {
    * Creates a global session by default.
    * @param context GraphQL Context
    */
-  session?(context: C): string | undefined | null;
+  session(context: C): string | undefined | null;
   /**
    * Specify whether the cache should be used based on the context.
    * By default any request uses the cache.
@@ -156,7 +156,7 @@ export const defaultShouldCacheResult: ShouldCacheResultFunction = (params): Boo
 export function useResponseCache({
   cache = createInMemoryCache(),
   ttl: globalTtl = Infinity,
-  session = () => null,
+  session,
   enabled,
   ignoredTypes = [],
   ttlPerType = {},
@@ -168,7 +168,7 @@ export function useResponseCache({
   shouldCacheResult = defaultShouldCacheResult,
   // eslint-disable-next-line dot-notation
   includeExtensionMetadata = typeof process !== 'undefined' ? process.env['NODE_ENV'] === 'development' : false,
-}: UseResponseCacheParameter = {}): Plugin {
+}: UseResponseCacheParameter): Plugin {
   const appliedTransform = Symbol('responseCache.appliedTransform');
   const ignoredTypesMap = new Set<string>(ignoredTypes);
 

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -22,6 +22,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 0,
           ttlPerType: {
             User: 200,
@@ -96,6 +97,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 0,
           ttlPerType: {
             User: 200,
@@ -170,7 +172,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({})], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -249,7 +251,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ includeExtensionMetadata: true })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, includeExtensionMetadata: true })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -353,7 +355,16 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ includeExtensionMetadata: true }), useGraphQlJit()], schema);
+    const testInstance = createTestkit(
+      [
+        useResponseCache({
+          session: () => null,
+          includeExtensionMetadata: true,
+        }),
+        useGraphQlJit(),
+      ],
+      schema
+    );
 
     const query = /* GraphQL */ `
       query test {
@@ -457,7 +468,7 @@ describe('useResponseCache', () => {
     });
 
     const cache = createInMemoryCache();
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -542,7 +553,7 @@ describe('useResponseCache', () => {
     });
 
     const cache = createInMemoryCache();
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -618,7 +629,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({})], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null })], schema);
 
     const query = /* GraphQL */ `
       query it($limit: Int!) {
@@ -691,14 +702,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit(
-      [
-        useResponseCache({
-          ttl: 100,
-        }),
-      ],
-      schema
-    );
+    const testInstance = createTestkit([useResponseCache({ session: () => null, ttl: 100 })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -871,14 +875,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit(
-      [
-        useResponseCache({
-          ignoredTypes: ['Comment'],
-        }),
-      ],
-      schema
-    );
+    const testInstance = createTestkit([useResponseCache({ session: () => null, ignoredTypes: ['Comment'] })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -951,6 +948,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 500,
           ttlPerType: {
             User: 200,
@@ -1034,6 +1032,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 500,
           ttlPerSchemaCoordinate: {
             'Query.users': 200,
@@ -1113,14 +1112,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit(
-      [
-        useResponseCache({
-          ttl: 0,
-        }),
-      ],
-      schema
-    );
+    const testInstance = createTestkit([useResponseCache({ session: () => null, ttl: 0 })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -1226,6 +1218,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 1,
           ttlPerSchemaCoordinate: {
             'Query.users': 200,
@@ -1343,6 +1336,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           ttl: 0,
           ttlPerType: {
             User: 200,
@@ -1421,7 +1415,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({})], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -1464,6 +1458,7 @@ describe('useResponseCache', () => {
     const testInstance = createTestkit(
       [
         useResponseCache({
+          session: () => null,
           // cache any query execution result
           shouldCacheResult: () => true,
         }),
@@ -1552,7 +1547,7 @@ describe('useResponseCache', () => {
       },
     });
 
-    const testInstance = createTestkit([useResponseCache({ includeExtensionMetadata: true })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, includeExtensionMetadata: true })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -1628,7 +1623,7 @@ describe('useResponseCache', () => {
     };
 
     const cache = createInMemoryCache();
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     // after each execution the introspectionCounter should be incremented by 1
     // as we never cache the introspection
@@ -1678,7 +1673,7 @@ describe('useResponseCache', () => {
 
     const cache = createInMemoryCache();
     const testInstance = createTestkit(
-      [useResponseCache({ cache, ttlPerSchemaCoordinate: { 'Query.__schema': undefined } })],
+      [useResponseCache({ session: () => null, cache, ttlPerSchemaCoordinate: { 'Query.__schema': undefined } })],
       schema
     );
 
@@ -1716,7 +1711,7 @@ describe('useResponseCache', () => {
     });
 
     const cache = createInMemoryCache();
-    const testInstance = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance = createTestkit([useResponseCache({ session: () => null, cache })], schema);
 
     const query = /* GraphQL */ `
       query test {
@@ -1730,7 +1725,7 @@ describe('useResponseCache', () => {
     await testInstance.execute(query);
     expect(usersResolverInvocationCount).toEqual(1);
 
-    const testInstance2 = createTestkit([useResponseCache({ cache })], schema);
+    const testInstance2 = createTestkit([useResponseCache({ session: () => null, cache })], schema);
     await testInstance2.execute(query);
     expect(usersResolverInvocationCount).toEqual(2);
   });
@@ -1746,7 +1741,7 @@ describe('useResponseCache', () => {
       `,
       resolvers: { Query: { foo: () => void mockFn() || 'hi' } },
     });
-    const testkit = createTestkit([useValidationCache(), useResponseCache(), useParserCache()], schema);
+    const testkit = createTestkit([useValidationCache(), useResponseCache({ session: () => null }), useParserCache()], schema);
 
     const document = /* GraphQL */ `
       query {
@@ -1788,7 +1783,7 @@ describe('useResponseCache', () => {
         useLogger({
           logFn: eventName => void logs.push(eventName),
         }),
-        useResponseCache({ ttlPerSchemaCoordinate: { 'Query.foo': Infinity } }),
+        useResponseCache({ session: () => null, ttlPerSchemaCoordinate: { 'Query.foo': Infinity } }),
       ],
       schema
     );


### PR DESCRIPTION
As discussed on slack we want to make users of the plugin aware that they should use the `session` property for configuring whether stuff should be cached based on the viewer or globally. The easiest way of doing this is to force the user to set it.

___

We already have a major for response-cache queued up, so this should trivial to merge.