### PR TITLE
fix(masked-errors): Use the custom error formatter for the errors thrown when building the context and the subscription

### DIFF
--- a/.changeset/fluffy-lions-marry.md
+++ b/.changeset/fluffy-lions-marry.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Use the custom error formatter for the errors thrown when building the context and the subscription

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -111,7 +111,7 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
         : undefined,
     onPluginInit(context) {
       context.registerContextErrorHandler(({ error, setError }) => {
-        setError(formatError(error, message, isDev));
+        setError(format(error, message, isDev));
       });
     },
     onExecute() {
@@ -127,7 +127,7 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
           return handleStreamOrSingleExecutionResult(payload, handleResult);
         },
         onSubscribeError({ error, setError }) {
-          setError(formatError(error, message, isDev));
+          setError(format(error, message, isDev));
         },
       };
     },


### PR DESCRIPTION
See the changeset.