### PR TITLE
Fix interoperability between the plugin and Sentry Integrations

### DIFF
--- a/.changeset/friendly-moons-grin.md
+++ b/.changeset/friendly-moons-grin.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': patch
+---
+
+Fix interoperability between the plugin and Sentry Integrations

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -236,6 +236,8 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
         }
       }
 
+      Sentry.configureScope(scope => scope.setSpan(rootSpan));
+
       rootSpan.setData('document', document);
 
       if (options.configureScope) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,16 +5030,17 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bob-the-bundler@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/bob-the-bundler/-/bob-the-bundler-3.0.4.tgz#9ab19c8d8d9cff3eaf106e5f10bafe946bdaf0a9"
-  integrity sha512-Lx1Xf6OWdXpUCUSQTdgbBfgg9K8GIjMtibDKS5TEd0LFv3PAOeIGgY9VxyUVylWJeqawHl5ztD2MfNBZYooIiQ==
+bob-the-bundler@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bob-the-bundler/-/bob-the-bundler-2.0.0.tgz#a0b5971e557d15f53c942e559a979542786677fc"
+  integrity sha512-3/qnKDSlUc/65hDgJLK/t7P2eWYKJF8Siz3Cu5mJRgMvtvYnbhKc5lbJyda/Y1sox1fnePHfBn+mFd/L/Z9KtA==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     "@rollup/plugin-node-resolve" "^13.3.0"
     "@vercel/ncc" "^0.34.0"
     builtins "^5.0.1"
     consola "^2.15.3"
+    cosmiconfig "^7.0.1"
     cross-spawn "^7.0.3"
     dependency-graph "^0.11.0"
     fs-extra "^10.1.0"


### PR DESCRIPTION
For some reason spans created by `Sentry.Integrations` are not included in a transaction when `Sentry.configureScope(s => s.setSpan(spanCreatedByUseSentry))` is not called.

Context: https://github.com/n1ru4l/envelop/discussions/1448