### PR TITLE
fix: include the original context error in extensions in dev mode for error thrown during context creation

### DIFF
--- a/.changeset/unlucky-deers-leave.md
+++ b/.changeset/unlucky-deers-leave.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Ensure error thrown from the context factory is wrapped within a GraphQLError for proper formatting. Previously this caused an unexpected error to be swallowed completly when error masking is enabled.

--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -111,6 +111,9 @@ export const useMaskedErrors = (opts?: UseMaskedErrorsOpts): Plugin => {
         : undefined,
     onPluginInit(context) {
       context.registerContextErrorHandler(({ error, setError }) => {
+        if (error instanceof GraphQLError === false && error instanceof Error) {
+          error = new GraphQLError(error.message, undefined, undefined, undefined, undefined, error);
+        }
         setError(format(error, message, isDev));
       });
     },

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -219,6 +219,31 @@ describe('useMaskedErrors', () => {
       }
     }
   });
+  it('Should include the original context error in extensions in dev mode for error thrown during context creation.', async () => {
+    expect.assertions(1);
+    const testInstance = createTestkit(
+      [
+        useExtendContext((): {} => {
+          throw new Error('No context for you!');
+        }),
+        useMaskedErrors({ isDev: true }),
+      ],
+      schema
+    );
+    try {
+      await testInstance.execute(`query { secretWithExtensions }`);
+    } catch (err: any) {
+      expect(err.toJSON()).toEqual({
+        message: 'Unexpected error.',
+        extensions: {
+          originalError: {
+            message: 'No context for you!',
+            stack: expect.stringContaining('Error: No context for you!'),
+          },
+        },
+      });
+    }
+  });
   it('Should mask subscribe (sync/promise) subscription errors', async () => {
     const testInstance = createTestkit([useMaskedErrors()], schema);
     const result = await testInstance.execute(`subscription { instantError }`);

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -220,7 +220,7 @@ describe('useMaskedErrors', () => {
     }
   });
   it('Should include the original context error in extensions in dev mode for error thrown during context creation.', async () => {
-    expect.assertions(1);
+    expect.assertions(3);
     const testInstance = createTestkit(
       [
         useExtendContext((): {} => {
@@ -233,13 +233,12 @@ describe('useMaskedErrors', () => {
     try {
       await testInstance.execute(`query { secretWithExtensions }`);
     } catch (err: any) {
-      expect(err.toJSON()).toEqual({
-        message: 'Unexpected error.',
-        extensions: {
-          originalError: {
-            message: 'No context for you!',
-            stack: expect.stringContaining('Error: No context for you!'),
-          },
+      expect(err).toBeInstanceOf(GraphQLError);
+      expect(err.message).toEqual('Unexpected error.');
+      expect(err.extensions).toEqual({
+        originalError: {
+          message: 'No context for you!',
+          stack: expect.stringContaining('Error: No context for you!'),
         },
       });
     }


### PR DESCRIPTION
include the original context error in extensions in dev mode for error thrown during context creation

Previously, a non GraphQLError/EnvelopError was simply swallowed. By wrapping it inside a GraphQLError (,similar to what graphql-js is doing with Error thrown within resolvers,) we ensure that the error is properly handled within the format function.

See https://github.com/dotansimha/graphql-yoga/issues/1584#issuecomment-1212821510 for more context

_____

Discovered while investigating https://github.com/dotansimha/graphql-yoga/issues/1584