### PR TITLE
Track deprecated arguments in @envelop/prometheus

### DIFF
--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -114,6 +114,19 @@ export function extractDeprecatedFields(node: ASTNode, typeInfo: TypeInfo): Depr
   visit(
     node,
     visitWithTypeInfo(typeInfo, {
+      Argument: () => {
+        const argument = typeInfo.getArgument();
+        const field = typeInfo.getFieldDef();
+        if (field && argument && (argument.deprecationReason != null || (argument as any).isDeprecated)) {
+          found.push({
+            fieldName: argument.name,
+            // the GraphQLArgument type doesn't contain context regarding the mutation the argument was passed to
+            // however, when visiting an argument, typeInfo.getFieldDef returns the mutation
+            typeName: field.name, // this is the mutation name
+          });
+        }
+      },
+
       Field: () => {
         const field = typeInfo.getFieldDef();
 

--- a/packages/plugins/prometheus/test/prom.spec.ts
+++ b/packages/plugins/prometheus/test/prom.spec.ts
@@ -515,37 +515,6 @@ describe('Prom Metrics plugin', () => {
       expect(await metricCount('graphql_envelop_deprecated_field')).toBe(1);
     });
 
-    it.skip('Should track deprecated fields in mutation input', async () => {
-      const { execute, metricCount, metricString } = prepare({
-        errors: true,
-        execute: true,
-        parse: true,
-        validate: true,
-        contextBuilding: true,
-        deprecatedFields: true,
-        resolvers: true,
-      });
-      const result = await execute(
-        /* GraphQL */ `
-          mutation MutationWithDeprecatedFields($nonDeprecatedInput: MutationInput!) {
-            mutationWithDeprecatedFields(nonDeprecatedInput: $nonDeprecatedInput) {
-              payloadField
-            }
-          }
-        `,
-        {
-          nonDeprecatedInput: { deprecatedField: 'deprecatedField', regularField: 'regularField' },
-        }
-      );
-      assertSingleExecutionValue(result);
-
-      expect(result.errors).toBeUndefined();
-      expect(await metricCount('graphql_envelop_deprecated_field')).toBe(1);
-
-      const m = await metricString('graphql_envelop_deprecated_field');
-      // TODO assert the field logged is correct
-    });
-
     it('Should track deprecated arguments in mutation', async () => {
       const { execute, metricCount, allMetrics, metricString } = prepare({
         errors: true,

--- a/packages/plugins/prometheus/test/prom.spec.ts
+++ b/packages/plugins/prometheus/test/prom.spec.ts
@@ -27,10 +27,7 @@ describe('Prom Metrics plugin', () => {
         payloadField: String
       }
       type Mutation {
-        mutationWithDeprecatedFields(
-          nonDeprecatedInput: MutationInput
-          deprecatedInput: String @deprecated(reason: "old")
-        ): MutationPayload
+        mutationWithDeprecatedFields(deprecatedInput: String @deprecated(reason: "old")): MutationPayload
       }
     `,
     resolvers: {


### PR DESCRIPTION
## Description

Add support for tracking deprecated arguments in `@envelop/prometheus`. I could not add support for input fields since my assumption is that we can't catch those at parse time, which doesn't work with the given set-up.

Fixes #1476 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test `Should track deprecated arguments in mutation` has been added to `packages/plugins/prometheus/test/prom.spec.ts`
- [ ] Skipped test `Should track deprecated fields in mutation input` has been added to `packages/plugins/prometheus/test/prom.spec.ts`

**Test Environment**:

- OS:
- `@envelop/...`: !6.4.2
- NodeJS: v14.18.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

As explained in the description, I cover only one of the two problems. I can either try to cover both cases but would need some guidance on where to hook to see what parameters are passed to the mutation. Or I can remove the skipped test and stick with arguments for now, which is already an improvement, and work on the inputs in a follow-up PR.
