### PR TITLE
fix(dependencies): add tslib as dependency

### DIFF
--- a/.changeset/itchy-days-roll.md
+++ b/.changeset/itchy-days-roll.md
@@ -1,0 +1,57 @@
+---
+'@envelop/core': minor
+'@envelop/apollo-datasources': minor
+'@envelop/apollo-federation': minor
+'@envelop/apollo-server-errors': minor
+'@envelop/apollo-tracing': minor
+'@envelop/auth0': minor
+'@envelop/dataloader': minor
+'@envelop/depth-limit': minor
+'@envelop/disable-introspection': minor
+'@envelop/execute-subscription-event': minor
+'@envelop/extended-validation': minor
+'@envelop/filter-operation-type': minor
+'@envelop/fragment-arguments': minor
+'@envelop/generic-auth': minor
+'@envelop/graphql-jit': minor
+'@envelop/graphql-middleware': minor
+'@envelop/graphql-modules': minor
+'@envelop/live-query': minor
+'@envelop/newrelic': minor
+'@envelop/opentelemetry': minor
+'@envelop/operation-field-permissions': minor
+'@envelop/parser-cache': minor
+'@envelop/persisted-operations': minor
+'@envelop/preload-assets': minor
+'@envelop/prometheus': minor
+'@envelop/rate-limiter': minor
+'@envelop/resource-limitations': minor
+'@envelop/response-cache': minor
+'@envelop/response-cache-redis': minor
+'@envelop/sentry': minor
+'@envelop/statsd': minor
+'@envelop/validation-cache': minor
+'@envelop/testing': minor
+'@envelop/types': minor
+---
+
+Adding tslib to package dependencies
+
+Projects that currently are using yarn Berry with PnP or any strict dependency
+resolver, that requires that all dependencies are specified on
+package.json otherwise it would endue in an error if not treated correct
+
+Since https://www.typescriptlang.org/tsconfig#importHelpers is currently
+being used, tslib should be exported as a dependency to external runners
+get the proper import.
+
+Change on each package:
+
+```json
+// package.json
+{
+  "dependencies": {
+    "tslib": "^2.4.0"
+  }
+}
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "@envelop/types": "2.3.1"
+    "@envelop/types": "2.3.1",
+    "tslib": "2.4.0"
   },
   "devDependencies": {
     "@graphql-tools/utils": "8.8.0",

--- a/packages/plugins/apollo-datasources/package.json
+++ b/packages/plugins/apollo-datasources/package.json
@@ -53,6 +53,9 @@
     "graphql": "16.3.0",
     "typescript": "4.7.4"
   },
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "peerDependencies": {
     "@envelop/core": "^2.5.0",
     "apollo-datasource": "^3",

--- a/packages/plugins/apollo-federation/package.json
+++ b/packages/plugins/apollo-federation/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "apollo-server-caching": "^3.1.0",
-    "apollo-server-types": "^3.2.0"
+    "apollo-server-types": "^3.2.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/apollo-server-errors/package.json
+++ b/packages/plugins/apollo-server-errors/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "apollo-server-errors": "^3.3.1"
+    "apollo-server-errors": "^3.3.1",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "apollo-server-core": "3.5.0",

--- a/packages/plugins/apollo-tracing/package.json
+++ b/packages/plugins/apollo-tracing/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "apollo-tracing": "^0.15.0"
+    "apollo-tracing": "^0.15.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@graphql-tools/schema": "8.5.0",

--- a/packages/plugins/auth0/package.json
+++ b/packages/plugins/auth0/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
-    "jwks-rsa": "^2.0.1"
+    "jwks-rsa": "^2.0.1",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.5.8",

--- a/packages/plugins/dataloader/package.json
+++ b/packages/plugins/dataloader/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "dataloader": "2.0.0",
     "reflect-metadata": "0.1.13",

--- a/packages/plugins/depth-limit/package.json
+++ b/packages/plugins/depth-limit/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "graphql-depth-limit": "^1.1.0"
+    "graphql-depth-limit": "^1.1.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@envelop/core": "^2.5.0",

--- a/packages/plugins/disable-introspection/package.json
+++ b/packages/plugins/disable-introspection/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql": "16.3.0",
     "typescript": "4.7.4"

--- a/packages/plugins/execute-subscription-event/package.json
+++ b/packages/plugins/execute-subscription-event/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@n1ru4l/push-pull-async-iterable-iterator": "3.2.0",
     "graphql": "16.3.0",

--- a/packages/plugins/extended-validation/package.json
+++ b/packages/plugins/extended-validation/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "@graphql-tools/utils": "^8.8.0"
+    "@graphql-tools/utils": "^8.8.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/filter-operation-type/package.json
+++ b/packages/plugins/filter-operation-type/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql": "16.3.0",
     "typescript": "4.7.4"

--- a/packages/plugins/fragment-arguments/package.json
+++ b/packages/plugins/fragment-arguments/package.json
@@ -45,7 +45,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@types/common-tags": "1.8.1",
     "@graphql-tools/utils": "8.8.0",

--- a/packages/plugins/generic-auth/package.json
+++ b/packages/plugins/generic-auth/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "@envelop/extended-validation": "^1.8.0"
+    "@envelop/extended-validation": "^1.8.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/graphql-jit/package.json
+++ b/packages/plugins/graphql-jit/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "graphql-jit": "^0.7.0",
-    "lru-cache": "^6.0.0"
+    "lru-cache": "^6.0.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql-jit": "0.7.3",

--- a/packages/plugins/graphql-middleware/package.json
+++ b/packages/plugins/graphql-middleware/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql-middleware": "6.1.15",
     "graphql": "16.3.0",

--- a/packages/plugins/graphql-modules/package.json
+++ b/packages/plugins/graphql-modules/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "reflect-metadata": "0.1.13",
     "graphql-modules": "2.0.0",

--- a/packages/plugins/live-query/package.json
+++ b/packages/plugins/live-query/package.json
@@ -50,7 +50,8 @@
     "@graphql-tools/utils": "^8.8.0",
     "@n1ru4l/graphql-live-query": "^0.10.0",
     "@n1ru4l/in-memory-live-query-store": "^0.10.0",
-    "@n1ru4l/graphql-live-query-patch": "^0.7.0"
+    "@n1ru4l/graphql-live-query-patch": "^0.7.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/newrelic/package.json
+++ b/packages/plugins/newrelic/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@types/newrelic": "7.0.3",
     "graphql": "16.3.0",

--- a/packages/plugins/opentelemetry/package.json
+++ b/packages/plugins/opentelemetry/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/tracing": "^0.24.0"
+    "@opentelemetry/tracing": "^0.24.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/operation-field-permissions/package.json
+++ b/packages/plugins/operation-field-permissions/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "@envelop/extended-validation": "^1.8.0"
+    "@envelop/extended-validation": "^1.8.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/parser-cache/package.json
+++ b/packages/plugins/parser-cache/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "lru-cache": "^6.0.0"
+    "lru-cache": "^6.0.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/persisted-operations/package.json
+++ b/packages/plugins/persisted-operations/package.json
@@ -46,6 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@graphql-tools/schema": "8.5.0",
     "graphql": "16.3.0",

--- a/packages/plugins/preload-assets/package.json
+++ b/packages/plugins/preload-assets/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql": "16.3.0",
     "typescript": "4.7.4"

--- a/packages/plugins/prometheus/package.json
+++ b/packages/plugins/prometheus/package.json
@@ -46,6 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "prom-client": "14.0.1",
     "@graphql-tools/schema": "8.5.0",

--- a/packages/plugins/rate-limiter/package.json
+++ b/packages/plugins/rate-limiter/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "graphql-rate-limit": "3.3.0"
+    "graphql-rate-limit": "3.3.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/resource-limitations/package.json
+++ b/packages/plugins/resource-limitations/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@envelop/extended-validation": "^1.8.0",
-    "@graphql-tools/utils": "^8.8.0"
+    "@graphql-tools/utils": "^8.8.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/plugins/response-cache-redis/package.json
+++ b/packages/plugins/response-cache-redis/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "@envelop/response-cache": "^3.1.0",
-    "ioredis": "^4.27.9"
+    "ioredis": "^4.27.9",
+    "tslib": "^2.4.0"
   },
   "peerDependencies": {},
   "buildOptions": {

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@graphql-tools/utils": "^8.8.0",
     "lru-cache": "^6.0.0",
-    "fast-json-stable-stringify": "^2.1.0"
+    "fast-json-stable-stringify": "^2.1.0",
+    "tslib": "^2.4.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.5.0",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@sentry/node": "7.0.0",
     "@sentry/tracing": "7.0.0",

--- a/packages/plugins/statsd/package.json
+++ b/packages/plugins/statsd/package.json
@@ -53,7 +53,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql": "16.3.0",
     "hot-shots": "9.0.0",

--- a/packages/plugins/validation-cache/package.json
+++ b/packages/plugins/validation-cache/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "lru-cache": "^6.0.0"
+    "lru-cache": "^6.0.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -47,7 +47,8 @@
     "definition": "dist/typings/index.d.ts"
   },
   "dependencies": {
-    "@graphql-tools/utils": "^8.8.0"
+    "@graphql-tools/utils": "^8.8.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "graphql": "16.3.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -46,7 +46,9 @@
   "typescript": {
     "definition": "dist/typings/index.d.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "graphql": "16.3.0",
     "typescript": "4.7.4"


### PR DESCRIPTION
## Description

Projects that currently are using yarn Berry with PnP or any strict dependency
resolver, that requires that all dependencies are specified on
package.json otherwise it would endue in an error if not treated correct

Since https://www.typescriptlang.org/tsconfig#importHelpers is currently
being used, tslib should be exported as a dependency to external runners
get the proper import.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Using yarn berry project, install any plugin and try to bundle it via typescript.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

resolves #1497 
