### PR TITLE
chore(docs/disable-introspection): fix-typo

### DIFF
--- a/packages/plugins/disable-introspection/README.md
+++ b/packages/plugins/disable-introspection/README.md
@@ -25,7 +25,7 @@ The plugin optionally accepts a configuration object:
 
 ```
 {
-  disableIf?: ({contest, params}) => boolean
+  disableIf?: ({context, params}) => boolean
 }
 ```
 


### PR DESCRIPTION
Just fixing a typo in documentation.