### PR TITLE
Turn off eslint no-use-before-define

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
       }
     ],
     "no-useless-constructor": "off",
+    "no-use-before-define": "off",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {


### PR DESCRIPTION
eslint's `no-use-before-define` raises false positives for types:

```ts
type A = B; // error: 'B' was used before it was defined.
type B = any;
```

Since TypeScript itself disallows usage of variables before declaration, it makes sense to disable all matching eslint rules.

In essence:
```json
{
  "no-use-before-define": "off",
  "typescript-eslint/no-use-before-define": "off"
}
```