### PR TITLE
fix replace resolver persistence

### DIFF
--- a/.changeset/hip-beds-hear.md
+++ b/.changeset/hip-beds-hear.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+fix replace resolver fn persistence

--- a/packages/core/src/traced-schema.ts
+++ b/packages/core/src/traced-schema.ts
@@ -17,12 +17,13 @@ export function prepareTracedSchema(schema: GraphQLSchema | null | undefined): v
       const fields = Object.values(type.getFields());
 
       for (const field of fields) {
-        let resolverFn: ResolverFn = (field.resolve || defaultFieldResolver) as ResolverFn;
+        const originalResolver: ResolverFn = (field.resolve || defaultFieldResolver) as ResolverFn;
 
         field.resolve = async (root, args, context, info) => {
           if (context && context[resolversHooksSymbol]) {
             const hooks: OnResolverCalledHook[] = context[resolversHooksSymbol];
             const afterCalls: AfterResolverHook[] = [];
+            let resolverFn = originalResolver;
 
             for (const hook of hooks) {
               const afterFn = await hook({
@@ -66,7 +67,7 @@ export function prepareTracedSchema(schema: GraphQLSchema | null | undefined): v
               throw resultErr;
             }
           } else {
-            return resolverFn(root, args, context, info);
+            return originalResolver(root, args, context, info);
           }
         };
       }


### PR DESCRIPTION
## Description

This PR aims to fix the feature allowing to replace the resolver function in place just before it is called.

Since the `onResolverCalled` hook is being called on each resolver calls, it is expected that the `replaceResolverFn` function only applies to this resolver call. This PR implement this behaviour.

Fixes #1524

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
	- Since this is changing the behaviour of `replaceResolverFn`, it possible that it introduce some unexpected breaking changes if some relied on the persistent replacement.
- [ ] This change requires a documentation update
	- Since this is an undocumented feature, there isn't any documentation update needed for now.

## How Has This Been Tested?

I have added test cases to the test suite.

**Test Environment**:

- OS: macOS 12.5.1
- `@envelop/core`: 98840fda07b1bc1d6d84d18c6da01eebcb096d88
- NodeJS: 16.14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
