### PR TITLE
EnvelopError was not skipped by default in Sentry plugin

### DIFF
--- a/.changeset/curvy-cats-complain.md
+++ b/.changeset/curvy-cats-complain.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': patch
+---
+
+fix: EnvelopError was not skipped by default

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -111,7 +111,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const skipOperation = pick('skip', () => false);
   const skipError = pick('skipError', defaultSkipError);
 
-  function addEventId(err: GraphQLError, eventId: string): GraphQLError {
+  function addEventId(err: GraphQLError, eventId: string | null): GraphQLError {
     if (options.eventIdKey === null) {
       return err;
     }
@@ -292,16 +292,19 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
                     .map(v => (typeof v === 'number' ? '$index' : v))
                     .join(' > ');
 
-                  const eventId = Sentry.captureException(err, {
-                    fingerprint: ['graphql', errorPathWithIndex, opName, operationType],
-                    contexts: {
-                      GraphQL: {
-                        operationName: opName,
-                        operationType,
-                        variables: args.variableValues,
-                      },
-                    },
-                  });
+                  const eventId =
+                    err.originalError && skipError(err.originalError)
+                      ? null
+                      : Sentry.captureException(err, {
+                          fingerprint: ['graphql', errorPathWithIndex, opName, operationType],
+                          contexts: {
+                            GraphQL: {
+                              operationName: opName,
+                              operationType,
+                              variables: args.variableValues,
+                            },
+                          },
+                        });
 
                   return addEventId(err, eventId);
                 });

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -112,6 +112,9 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   const skipError = pick('skipError', defaultSkipError);
 
   function addEventId(err: GraphQLError, eventId: string | null): GraphQLError {
+    if (eventId === null) {
+      return err;
+    }
     if (options.eventIdKey === null) {
       return err;
     }


### PR DESCRIPTION
## Description

The `@envelop/sentry` promises to skip `EnvelopErrors` by default, but yet it calls `Sentry.captureException()` on all errors in the `ExecutionResult`.

This PR makes sure the error is no longer reported to Sentry, and also those on which `skipError(error)` is `true`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update