### PR TITLE
give access to execute args in generic auth plugin

### DIFF
--- a/.changeset/short-singers-bake.md
+++ b/.changeset/short-singers-bake.md
@@ -2,4 +2,40 @@
 '@envelop/generic-auth': minor
 ---
 
-give access to execute args in generic auth plugin
+give access to execute args in `validateUser` function.
+
+This is useful in conjunction with the `fieldAuthExtension` parameter to achieve custom per field validation:
+
+```ts
+import { ValidateUserFn } from '@envelop/generic-auth'
+
+const validateUser: ValidateUserFn<UserType> = async ({ user, executionArgs, fieldAuthExtension }) => {
+  if (!user) {
+    throw new Error(`Unauthenticated!`)
+  }
+
+  // You have access to the object define in the resolver tree, allowing to define any custom logic you want.
+  const validate = fieldAuthExtension?.validate
+  if (validate) {
+    await validate({ user, variables: executionArgs.variableValues, context: executionArgs.contextValue })
+  }
+}
+
+const resolvers = {
+  Query: {
+    user: {
+      resolve: (_, { userId }) => getUser(userId),
+      extensions: {
+        auth: {
+          validate: ({ user, variables, context }) => {
+            // We can now have access to the operation and variables to decide if the user can execute the query
+            if (user.id !== variables.userId) {
+              throw new Error(`Unauthorized`)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/.changeset/short-singers-bake.md
+++ b/.changeset/short-singers-bake.md
@@ -1,0 +1,5 @@
+---
+'@envelop/generic-auth': minor
+---
+
+give access to execute args in generic auth plugin

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -256,7 +256,7 @@ const GraphQLQueryType = new GraphQLObjectType({
 
 > If you are using a different field extension for authentication, you can pass `directiveOrExtensionFieldName` configuration to customize it.
 
-##### Extend authentication with custom directive logic
+#### Extend authentication with custom logic
 
 You can also specify a custom `validateUser` function and get access to a handy object while using the `protect-all` and `protect-granular` mode:
 
@@ -274,7 +274,9 @@ const validateUser: ValidateUserFn<UserType> = async ({ user }) => {
 }
 ```
 
-And it's also possible to add custom parameters to your `@auth` directive. Here's an example for adding role-aware authentication:
+##### With a custom directive with arguments
+
+It is possible to add custom parameters to your `@auth` directive. Here's an example for adding role-aware authentication:
 
 ```graphql
 enum Role {
@@ -291,8 +293,8 @@ Then, you use the `directiveNode` parameter to check the arguments:
 import { ValidateUserFn } from '@envelop/generic-auth'
 
 const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthDirectiveNode }) => {
-  // Now you can use the 3rd parameter to implement custom logic for user validation, with access
-  // to the resolver data and information.
+  // Now you can use the fieldAuthDirectiveNode parameter to implement custom logic for user validation, with access
+  // to the resolver auth directive arguments.
 
   if (!user) {
     throw new Error(`Unauthenticated!`)
@@ -303,6 +305,82 @@ const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthDirective
 
   if (role !== user.role) {
     throw new Error(`No permissions!`)
+  }
+}
+```
+
+##### With a custom field extensions
+
+You can use custom field extension to pass data to your `validateUser` function instead of using a directive.
+Here's an example for adding role-aware authentication:
+
+```ts
+import { ValidateUserFn } from '@envelop/generic-auth'
+
+const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthExtension }) => {
+  // Now you can use the fieldAuthDirectiveNode parameter to implement custom logic for user validation, with access
+  // to the resolver auth directive arguments.
+
+  if (!user) {
+    throw new Error(`Unauthenticated!`)
+  }
+
+  const role = fieldAuthExtension.role
+
+  if (role !== user.role) {
+    throw new Error(`No permissions!`)
+  }
+}
+
+const resolvers = {
+  Query: {
+    user: {
+      me: (_, __, { currentUser }) => currentUser,
+      extensions: {
+        auth: {
+          role: 'USER'
+        }
+      }
+    }
+  }
+}
+```
+
+##### With a custom validation function per field
+
+You can also have access to operation variables and context via the `executionArgs` parameter.
+This can be useful in conjunction with the `fieldAuthExtension` parameter to achieve custom per field validation.
+
+```ts
+import { ValidateUserFn } from '@envelop/generic-auth'
+
+const validateUser: ValidateUserFn<UserType> = async ({ user, executionArgs, fieldAuthExtension }) => {
+  if (!user) {
+    throw new Error(`Unauthenticated!`)
+  }
+
+  // You have access to the object define in the resolver tree, allowing to define any custom logic you want.
+  const validate = fieldAuthExtension?.validate
+  if (validate) {
+    await validate({ user, variables: executionArgs.variableValues, context: executionArgs.contextValue })
+  }
+}
+
+const resolvers = {
+  Query: {
+    user: {
+      resolve: (_, { userId }) => getUser(userId),
+      extensions: {
+        auth: {
+          validate: ({ user, variables, context }) => {
+            // We can now have access to the operation and variables to decide if the user can execute the query
+            if (user.id !== variables.userId) {
+              throw new Error(`Unauthorized`)
+            }
+          }
+        }
+      }
+    }
   }
 }
 ```

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -1,6 +1,7 @@
 import { DefaultContext, Maybe, Plugin, PromiseOrValue } from '@envelop/core';
 import {
   DirectiveNode,
+  ExecutionArgs,
   FieldNode,
   getNamedType,
   GraphQLError,
@@ -30,6 +31,8 @@ export type ValidateUserFnParams<UserType> = {
   fieldAuthDirectiveNode: DirectiveNode | undefined;
   /** The extensions used for authentication (If using an extension based flow). */
   fieldAuthExtension: unknown | undefined;
+  /** The args passed to the execution function (including operation context and variables) **/
+  args: ExecutionArgs;
 };
 
 export type ValidateUserFn<UserType> = (params: ValidateUserFnParams<UserType>) => void | UnauthenticatedError;
@@ -176,6 +179,7 @@ export const useGenericAuth = <
                     objectType,
                     fieldAuthDirectiveNode,
                     fieldAuthExtension,
+                    args,
                   });
                   if (error) {
                     context.reportError(error);

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -32,7 +32,7 @@ export type ValidateUserFnParams<UserType> = {
   /** The extensions used for authentication (If using an extension based flow). */
   fieldAuthExtension: unknown | undefined;
   /** The args passed to the execution function (including operation context and variables) **/
-  args: ExecutionArgs;
+  executionArgs: ExecutionArgs;
 };
 
 export type ValidateUserFn<UserType> = (params: ValidateUserFnParams<UserType>) => void | UnauthenticatedError;
@@ -179,7 +179,7 @@ export const useGenericAuth = <
                     objectType,
                     fieldAuthDirectiveNode,
                     fieldAuthExtension,
-                    args,
+                    executionArgs: args,
                   });
                   if (error) {
                     context.reportError(error);


### PR DESCRIPTION
## Description

This PR aims to give more flexibility to the user validation of the generic-auth plugin byt giving access to the execute args.
This would give access to context and variables of the operation.

Fixes #1527

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have published this PR as `@emrys-myrddin/envelop-generic-auth@4.5.0-fork.1` and tested it on my company's project.
I was able to build a plugin leading to the api I have describe in the issue #1527.

**Test Environment**:

- OS: macOS 12.5.1
- `@envelop/generic-auth`: v4.5.0
- NodeJS: v16.14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - The documentation is not very exhaustive on available arguments, I'm not sure it is needed to modify it. I've just updated code documentation.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Not sure any test are needed here since types already ensure that this works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
