### PR TITLE
fix: redirect for migration guide

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -18,6 +18,7 @@ export default withGuildDocs({
       '/docs/plugins/introduction': '/docs/plugins',
       '/plugins/use-async-schema': '/docs/guides/migrating-from-v2-to-v3#3-remove-useasyncschema-plugin',
       '/plugins/use-timing': '/docs/guides/migrating-from-v2-to-v3#2-drop-usetiming-plugin',
+      '/docs/guides/migrating-from-v2-to-v3': '/v3/guides/migrating-from-v2-to-v3',
       '/plugins/use-lazy-loaded-schema':
         '/docs/guides/migrating-from-v2-to-v3#4-rename-uselazyloadedschema-to-useschemabycontext',
     }).map(([from, to]) => ({


### PR DESCRIPTION
`/docs/*` refers to a `v2` path and all the new docs live in `/v3` saw sentry for someone trying to go to the migraiton guide from `/docs/` do added this redirect so its easier for them to navigate to