### PR TITLE
Skip GraphQLError by default in Sentry plugin

### DIFF
--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -86,10 +86,7 @@ export type SentryPluginOptions = {
 };
 
 export function defaultSkipError(error: Error): boolean {
-  if (isGraphQLError(error)) {
-    return isGraphQLError(error.originalError);
-  }
-  return false;
+  return isGraphQLError(error);
 }
 
 const sentryTracingSymbol = Symbol('sentryTracing');

--- a/packages/plugins/sentry/test/sentry.spec.ts
+++ b/packages/plugins/sentry/test/sentry.spec.ts
@@ -1,0 +1,9 @@
+import { defaultSkipError } from '../src/index.js';
+import { GraphQLError } from 'graphql';
+
+test('defaultSkipError should return true for GraphQLError', () => {
+  // Throwing a GraphQLError in GraphQL Yoga v3 results in error masking.
+  // The GraphQLError is treated as an expected error.
+  // The sentry plugin should follow this logic and do not capture GraphQLError.
+  expect(defaultSkipError(new GraphQLError('test', {}))).toBe(true);
+});


### PR DESCRIPTION
Throwing a `GraphQLError` in GraphQL Yoga v3 results in error being masked.
The GraphQLError is treated there as an expected error.
The sentry plugin should follow this logic and do not capture GraphQLError.

It's not the case currently: https://github.com/n1ru4l/envelop/actions/runs/3335641522/jobs/5519849055

WDYT?