### PR TITLE
Update express-graphql to use `useEngine`

### DIFF
--- a/examples/express-graphql/index.ts
+++ b/examples/express-graphql/index.ts
@@ -1,5 +1,5 @@
-import { envelop, useLogger, useSchema } from '@envelop/core';
-import { parse, validate, execute, subscribe } from 'graphql';
+import { envelop, useLogger, useSchema, useEngine } from '@envelop/core';
+import * as GraphQLJS from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
@@ -18,11 +18,7 @@ const schema = makeExecutableSchema({
 });
 
 const getEnveloped = envelop({
-  parse,
-  validate,
-  execute,
-  subscribe,
-  plugins: [useSchema(schema), useLogger()],
+  plugins: [useEngine(GraphQLJS), useSchema(schema), useLogger()],
 });
 
 const app = express();


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

I got an error when using it:
```
Error: No `parse` function found! Register it using "useEngine" plugin.
```

Regarding the doc, it seems to be better to use `useEngine` to defined GraphQL stuff: https://github.com/n1ru4l/envelop/blob/f66e1245f5fb782caee11f92758f9f8ca0cb3a43/website/src/pages/v3/core.mdx#useengine

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

I wasn't able to properly test it inside that folder because it seems TS is broken.
But the problem was fixed in a pet project using express.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

