### PR TITLE
Fix wrong variable check in resource-limitations

### DIFF
--- a/packages/plugins/resource-limitations/src/index.ts
+++ b/packages/plugins/resource-limitations/src/index.ts
@@ -136,7 +136,7 @@ export const ResourceLimitationValidationRule =
                     // eslint-disable-next-line dot-notation
                     nodeCost = argumentValues['first'] as number;
                   }
-                } else if ('last' in argumentValues === true && 'false' in argumentValues === false) {
+                } else if ('last' in argumentValues === true && 'first' in argumentValues === false) {
                   if (
                     argumentValues.last < paginationArgumentMinimum ||
                     argumentValues.last > paginationArgumentMaximum


### PR DESCRIPTION
## Description

While debugging another issue with this plugin, I noticed that one of the conditional checks is using a wrong value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

None.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
