### PR TITLE
fix: Handle null argument values in resource-limitations

### DIFF
--- a/.changeset/cool-stingrays-repeat.md
+++ b/.changeset/cool-stingrays-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@envelop/resource-limitations": patch
+'@envelop/resource-limitations': patch
 ---
 
 Handle null argument values

--- a/.changeset/cool-stingrays-repeat.md
+++ b/.changeset/cool-stingrays-repeat.md
@@ -1,0 +1,5 @@
+---
+"@envelop/resource-limitations": patch
+---
+
+Handle null argument values

--- a/packages/plugins/resource-limitations/src/index.ts
+++ b/packages/plugins/resource-limitations/src/index.ts
@@ -58,7 +58,7 @@ const buildInvalidPaginationRangeErrorMessage = (params: {
   paginationArgumentMaximum: number;
   paginationArgumentMinimum: number;
 }) =>
-  `Invalid pagination argument for field ${params.fieldName}. ` +
+  `Invalid pagination argument for field '${params.fieldName}'. ` +
   `The value for the '${params.argumentName}' argument must be an integer within ${params.paginationArgumentMinimum}-${params.paginationArgumentMaximum}.`;
 
 export const defaultNodeCostLimit = 500000;
@@ -105,7 +105,10 @@ export const ResourceLimitationValidationRule =
                 // eslint-disable-next-line no-console
                 console.warn('Encountered paginated field without pagination arguments.');
               } else if (hasFirst === true || hasLast === true) {
-                if ('first' in argumentValues === false && 'last' in argumentValues === false) {
+                if (
+                  ('first' in argumentValues === false && 'last' in argumentValues === false) ||
+                  (argumentValues.first === null && argumentValues.last === null)
+                ) {
                   context.reportError(
                     new GraphQLError(
                       buildMissingPaginationFieldErrorMessage({
@@ -116,7 +119,7 @@ export const ResourceLimitationValidationRule =
                       fieldNode
                     )
                   );
-                } else if ('first' in argumentValues === true && 'last' in argumentValues === false) {
+                } else if ('first' in argumentValues && !argumentValues.last) {
                   if (
                     argumentValues.first < paginationArgumentMinimum ||
                     argumentValues.first > paginationArgumentMaximum
@@ -136,7 +139,7 @@ export const ResourceLimitationValidationRule =
                     // eslint-disable-next-line dot-notation
                     nodeCost = argumentValues['first'] as number;
                   }
-                } else if ('last' in argumentValues === true && 'false' in argumentValues === false) {
+                } else if (!argumentValues.first && 'last' in argumentValues) {
                   if (
                     argumentValues.last < paginationArgumentMinimum ||
                     argumentValues.last > paginationArgumentMaximum

--- a/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
+++ b/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
@@ -77,6 +77,28 @@ describe('useResourceLimitations', () => {
       "Missing pagination argument for field 'repositories'. Please provide either the 'first' or 'last' field argument."
     );
   });
+  it('requires non-null values on either the first or last field on fields that resolve to a Connection type.', async () => {
+    const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(first: null, last: null) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toEqual(1);
+    expect(result.errors?.[0]?.message).toEqual(
+      "Missing pagination argument for field 'repositories'. Please provide either the 'first' or 'last' field argument."
+    );
+  });
   it('requires the usage of either the first or last field on fields that resolve to a Connection type (other argument provided).', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
@@ -99,6 +121,29 @@ describe('useResourceLimitations', () => {
       "Missing pagination argument for field 'repositories'. Please provide either the 'first' or 'last' field argument."
     );
   });
+  it('ignores null in last field', async () => {
+    const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(first: 1, last: null) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeUndefined();
+    expect(result.extensions).toEqual({
+      resourceLimitations: {
+        nodeCost: 1,
+      },
+    });
+  });
   it('requires the first field to be at least 1', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
@@ -118,7 +163,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'first' argument must be an integer within 1-100."
     );
   });
   it('requires the first field to be at least a custom minimum value', async () => {
@@ -140,7 +185,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 2-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'first' argument must be an integer within 2-100."
     );
   });
   it('requires the first field to be not higher than 100', async () => {
@@ -162,7 +207,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'first' argument must be an integer within 1-100."
     );
   });
   it('requires the first field to be not higher than a custom maximum value', async () => {
@@ -187,8 +232,31 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-99."
+      "Invalid pagination argument for field 'repositories'. The value for the 'first' argument must be an integer within 1-99."
     );
+  });
+  it('ignores null in first field', async () => {
+    const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(first: null, last: 1) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeUndefined();
+    expect(result.extensions).toEqual({
+      resourceLimitations: {
+        nodeCost: 1,
+      },
+    });
   });
   it('requires the last field to be at least 1', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
@@ -209,7 +277,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'last' argument must be an integer within 1-100."
     );
   });
   it('requires the last field to be at least a custom minimum value', async () => {
@@ -231,7 +299,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 2-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'last' argument must be an integer within 2-100."
     );
   });
   it('requires the last field to be not higher than 100', async () => {
@@ -253,7 +321,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-100."
+      "Invalid pagination argument for field 'repositories'. The value for the 'last' argument must be an integer within 1-100."
     );
   });
   it('requires the last field to be not higher than a custom maximum value', async () => {
@@ -278,7 +346,7 @@ describe('useResourceLimitations', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
-      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-99."
+      "Invalid pagination argument for field 'repositories'. The value for the 'last' argument must be an integer within 1-99."
     );
   });
   it('calculates node cost (single)', async () => {


### PR DESCRIPTION
## Description

Handle `null` argument values in `resource-limitations`. Sending `null` for optional arguments is valid according to the GraphQL specificiations. We should support that in this plugin.

Fixes #1577

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `yarn test resource-limitations`

**Test Environment**:

- OS: Ubuntu 20.04
- `@envelop/core`: `main` branch
- NodeJS: 18.*

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules