### PR TITLE
Don't use `Id` TypeScript generic utility that can cause a circular constraint error

### DIFF
--- a/.changeset/fresh-forks-visit.md
+++ b/.changeset/fresh-forks-visit.md
@@ -1,0 +1,5 @@
+---
+'@envelop/types': patch
+---
+
+Don't use `Id` TypeScript generic utility that can cause a circular constraint error

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -2,14 +2,10 @@ export type OptionalPropertyNames<T> = { [K in keyof T]-?: {} extends { [P in K]
 
 export type SpreadProperties<L, R, K extends keyof L & keyof R> = { [P in K]: L[P] | Exclude<R[P], undefined> };
 
-export type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
-
-export type SpreadTwo<L, R> = Id<
-  Pick<L, Exclude<keyof L, keyof R>> &
-    Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
-    Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
-    SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
->;
+export type SpreadTwo<L, R> = Pick<L, Exclude<keyof L, keyof R>> &
+  Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
+  Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
+  SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>;
 
 export type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R] ? SpreadTwo<L, Spread<R>> : {};
 

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -2,6 +2,9 @@ export type OptionalPropertyNames<T> = { [K in keyof T]-?: {} extends { [P in K]
 
 export type SpreadProperties<L, R, K extends keyof L & keyof R> = { [P in K]: L[P] | Exclude<R[P], undefined> };
 
+/** @deprecated Because it can cause https://github.com/n1ru4l/envelop/issues/1120. */
+export type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+
 export type SpreadTwo<L, R> = Pick<L, Exclude<keyof L, keyof R>> &
   Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
   Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &


### PR DESCRIPTION
Closes #1120
Fixes https://github.com/dotansimha/graphql-yoga/issues/2123

The Id utility seams to semantically do _nothing_ and removing it fixes the circular constraint error.

```ts
type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
// =
type Id<T> = T extends T ? { [K in keyof T]: T[K] } : never;
// =
type Id<T> = { [K in keyof T]: T[K] };
```

And in the case where it was used, these two should yield the same result:

```ts
type SpreadTwo<L, R> = Id<
  Pick<L, Exclude<keyof L, keyof R>> &
    Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
    Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
    SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
>;
// =
type SpreadTwo<L, R> = Pick<L, Exclude<keyof L, keyof R>> &
  Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
  Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
  SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>;
```