### PR TITLE
fix: include validation rule names in cache key

### DIFF
--- a/.changeset/few-experts-relax.md
+++ b/.changeset/few-experts-relax.md
@@ -1,0 +1,8 @@
+---
+'@envelop/validation-cache': patch
+---
+
+Include the validation rule names within the operation cache key.
+
+This prevents skipping conditional validation rules in other plugins.
+Please make sure your validation rules always have a unique `name` property.

--- a/packages/plugins/parser-cache/test/parser-cache.spec.ts
+++ b/packages/plugins/parser-cache/test/parser-cache.spec.ts
@@ -1,4 +1,4 @@
-import { buildSchema, DocumentNode, GraphQLError, parse } from 'graphql';
+import { buildSchema, DocumentNode, parse } from 'graphql';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { useParserCache } from '../src/index.js';
 import { Plugin } from '@envelop/types';

--- a/packages/plugins/validation-cache/src/index.ts
+++ b/packages/plugins/validation-cache/src/index.ts
@@ -50,26 +50,30 @@ export const useValidationCache = (pluginOptions: ValidationCacheOptions = {}): 
     onParse({ params, extendContext }) {
       extendContext({ [rawDocumentSymbol]: params.source.toString() });
     },
-    onValidate({ params, context, setResult }) {
-      let ruleKey = '';
-      if (Array.isArray(params.rules)) {
-        // Note: We could also order them... but that might be too much
-        for (const rule of params.rules) {
-          ruleKey = ruleKey + rule.name;
+    onValidate({ params, context, setValidationFn, validateFn }) {
+      // We use setValidateFn over accessing params.rules directly, as other plugins in the chain might add more rules.
+      // This would cause an issue if we are constructing the cache key here already.
+      setValidationFn((...args) => {
+        let ruleKey = '';
+        if (Array.isArray(args[2])) {
+          // Note: We could also order them... but that might be too much
+          for (const rule of args[2]) {
+            ruleKey = ruleKey + rule.name;
+          }
         }
-      }
 
-      const key: string = ruleKey + (context[rawDocumentSymbol] ?? print(params.documentAST));
-      const cachedResult = resultCache.get(key);
+        const key: string = ruleKey + (context[rawDocumentSymbol] ?? print(params.documentAST));
+        const cachedResult = resultCache.get(key);
 
-      if (cachedResult !== undefined) {
-        setResult(cachedResult);
-      }
+        if (cachedResult !== undefined) {
+          return cachedResult;
+        }
 
-      return ({ result }) => {
-        // @ts-expect-error TODO: not sure how we will make it dev friendly
+        const result = validateFn(...args);
         resultCache.set(key, result);
-      };
+
+        return result;
+      });
     },
   };
 };

--- a/packages/plugins/validation-cache/src/index.ts
+++ b/packages/plugins/validation-cache/src/index.ts
@@ -51,7 +51,15 @@ export const useValidationCache = (pluginOptions: ValidationCacheOptions = {}): 
       extendContext({ [rawDocumentSymbol]: params.source.toString() });
     },
     onValidate({ params, context, setResult }) {
-      const key: string = context[rawDocumentSymbol] ?? print(params.documentAST);
+      let ruleKey = '';
+      if (Array.isArray(params.rules)) {
+        // Note: We could also order them... but that might be too much
+        for (const rule of params.rules) {
+          ruleKey = ruleKey + rule.name;
+        }
+      }
+
+      const key: string = ruleKey + (context[rawDocumentSymbol] ?? print(params.documentAST));
       const cachedResult = resultCache.get(key);
 
       if (cachedResult !== undefined) {


### PR DESCRIPTION
Include the validation rule names within the operation cache key.

This prevents skipping conditional validation rules in other plugins.
Please make sure your validation rules always have a unique `name` property.

**Note:** I would also prefer to hash the validation names... but we currently have no way of doing cross-platform hashing in a sync and performant way. 😅 We could use something like https://github.com/emn178/js-sha1/blob/master/src/sha1.js instead for now.

____

**Note:** In a follow-up PR we should also create a hash key per GraphQLSchema instead of resetting the whole cache in case of a schema change.