### PR TITLE
Adds the root sentry span to a resolver's context

### DIFF
--- a/.changeset/red-rocks-teach.md
+++ b/.changeset/red-rocks-teach.md
@@ -1,0 +1,5 @@
+---
+"@envelop/sentry": patch
+---
+
+Adds the root sentry span to a resolver's context - so you can safely grab it from your own code without relying on singletons.

--- a/packages/plugins/sentry/__tests__/sentry.spec.ts
+++ b/packages/plugins/sentry/__tests__/sentry.spec.ts
@@ -43,8 +43,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush();
 
     const reports = sentryTestkit.reports();
     expect(reports).toHaveLength(1);
@@ -89,8 +88,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush();
 
     expect(sentryTestkit.reports()).toHaveLength(0);
   });
@@ -130,8 +128,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush();
 
     const reports = sentryTestkit.reports();
     expect(reports).toHaveLength(1);
@@ -176,8 +173,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush();
 
     expect(sentryTestkit.reports()).toHaveLength(0);
   });
@@ -246,8 +242,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush();
 
     const reports = sentryTestkit.reports();
     expect(reports).toHaveLength(1);
@@ -292,6 +287,5 @@ test('sets the span in the query context', async () => {
     }
   `);
 
-  // run sentry flush
-  await new Promise(res => setTimeout(res, 10));
+  await Sentry.flush();
 });

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -179,7 +179,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
         Sentry.configureScope(scope => options.configureScope!(args, scope));
       }
 
-      extendContext({ sentry: { span: rootSpan } });
+      extendContext({ sentry: { scope } });
 
       return {
         onExecuteDone(payload) {

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -104,7 +104,7 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
   }
 
   return {
-    onExecute({ args }) {
+    onExecute({ args, extendContext }) {
       if (skipOperation(args)) {
         return;
       }
@@ -178,6 +178,8 @@ export const useSentry = (options: SentryPluginOptions = {}): Plugin => {
       if (options.configureScope) {
         Sentry.configureScope(scope => options.configureScope!(args, scope));
       }
+
+      extendContext({ sentry: { span: rootSpan } });
 
       return {
         onExecuteDone(payload) {


### PR DESCRIPTION
## Description

Hello folks, I was going through Sentry tracing, and I needed access to set my parent span on a transaction. Now, this is reasonably easy to do via:

```ts
const opScope = Sentry.getCurrentHub().getScope()?.getSpan()
```

But relying on a bunch of globals feels a little bit off for me, when context is really what this sort of thing is for (IMO.) So, this PR adds span into the operation context. I've scoped it into a `sentry` object - in case there more things added further down the line.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (maybe?)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
