### PR TITLE
docs: fix typo in @envelop/statsd installation instructions

### DIFF
--- a/packages/plugins/statsd/README.md
+++ b/packages/plugins/statsd/README.md
@@ -19,7 +19,7 @@ Available metrics:
 ## Getting Started
 
 ```
-yarn add hot-shots @envelop/stats
+yarn add hot-shots @envelop/statsd
 ```
 
 ## Usage Example


### PR DESCRIPTION

## Description

Fix typo in @envelop/statsd installation instructions


## Type of change

Documentation fix


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

