### PR TITLE
Allow using ignoredTypes and ttlPerType with types that do not have an id field

### DIFF
--- a/.changeset/proud-yaks-raise.md
+++ b/.changeset/proud-yaks-raise.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+Fix ignoredTypes and ttlPerType not working for types without id field

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -265,22 +265,26 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
                         };
                       }
                     }
+
+                    if (ignoredTypesMap.has(typename)) {
+                      skip = true;
+                    }
+                    if (skip === true) {
+                      return;
+                    }
+
+                    types.add(typename);
+                    if (typename in ttlPerType) {
+                      currentTtl = calculateTtl(ttlPerType[typename], currentTtl);
+                    }
+
                     if (idFields.includes(fieldName)) {
-                      if (ignoredTypesMap.has(typename)) {
-                        skip = true;
-                      }
-                      if (skip === true) {
-                        return;
-                      }
                       return (id: string) => {
                         identifier.set(`${typename}:${id}`, { typename, id });
-                        types.add(typename);
-                        if (typename in ttlPerType) {
-                          currentTtl = calculateTtl(ttlPerType[typename], currentTtl);
-                        }
                         return id;
                       };
                     }
+
                     return undefined;
                   },
                 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

It's currently not possible to ignore or set a ttl for types that do not have an id field. This PR allows both ttlPerType and ignoredTypes to be used with types that do not have an id field.

Fixes #1624

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A:`yarn test response-cache` fails on first commit (29470a1c79099aa79b7a53d258081a588e9a117b)
- [x] Test b: `yarn test response-cache` passes on first commit (434412bf67a838870a6e72f4d62fab649c6263b7)

**Test Environment**:

- OS: MacOS, Linux (codespaces)
- `@envelop/response-cache`: 4.0.4
- NodeJS: 19.5.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
