### PR TITLE
Fix: graphql-modules did not cleanup on subscription end

### DIFF
--- a/.changeset/olive-crabs-accept.md
+++ b/.changeset/olive-crabs-accept.md
@@ -1,0 +1,5 @@
+---
+'@envelop/graphql-modules': patch
+---
+
+Cleanup reference to context value on subscription completion

--- a/packages/plugins/graphql-modules/src/index.ts
+++ b/packages/plugins/graphql-modules/src/index.ts
@@ -29,5 +29,15 @@ export const useGraphQLModules = (app: Application): Plugin => {
         },
       };
     },
+    onSubscribe({ args }) {
+      return {
+        onSubscribeResult: () => {
+          if (args.contextValue && args.contextValue[graphqlModulesControllerSymbol]) {
+            args.contextValue[graphqlModulesControllerSymbol].destroy();
+            args.contextValue[graphqlModulesControllerSymbol] = null;
+          }
+        },
+      };
+    },
   };
 };


### PR DESCRIPTION
## Description

This change replicates a similar cleanup procedure to onSubscribe() that onExecute has in graphql-modules plugin. This was done once we discovered a memory leak in our products related to module injectors not being cleaned up when subscriptions/websocket connections are cleaned up.


The change is almost a copy-paste from the similar onExecute function.

Fixes #1628 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We are running the same change patched with patch-package and verified the memory leak of extraneous injectors has been resolved. A minimal test was added that the code does execute, but I do admit it does not verify the module private variable has been cleaned up. Frankly speaking, I do not know how to best verify that without extensive mocking.

- [x] Created a minimal test to verify subscriptions will not crash despite the cleanup procedure added

**Test Environment**:

- OS: OS/X
- `@envelop/.graphql-modules`:
- NodeJS: 18.0.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
