### PR TITLE
fix: validation cache for ESM environments

### DIFF
--- a/.changeset/calm-adults-walk.md
+++ b/.changeset/calm-adults-walk.md
@@ -1,0 +1,5 @@
+---
+'@envelop/validation-cache': patch
+---
+
+fix: validation cache for ESM environments

--- a/packages/plugins/validation-cache/package.json
+++ b/packages/plugins/validation-cache/package.json
@@ -49,8 +49,7 @@
   "dependencies": {
     "lru-cache": "^6.0.0",
     "tslib": "^2.5.0",
-    "fast-json-stable-stringify": "^2.1.0",
-    "sha1-es": "^1.8.2"
+    "hash-it": "^6.0.0"
   },
   "devDependencies": {
     "graphql": "16.6.0",

--- a/packages/plugins/validation-cache/sha1.d.ts
+++ b/packages/plugins/validation-cache/sha1.d.ts
@@ -1,8 +1,0 @@
-declare module 'sha1-es' {
-  declare const api = {
-    hash: (str: string): string => '',
-  };
-
-  // eslint-disable-next-line import/no-default-export
-  export default api;
-}

--- a/packages/plugins/validation-cache/src/index.ts
+++ b/packages/plugins/validation-cache/src/index.ts
@@ -1,8 +1,7 @@
 import { Plugin } from '@envelop/core';
 import { GraphQLError, print, introspectionFromSchema, type GraphQLSchema } from 'graphql';
-import jsonStableStringify from 'fast-json-stable-stringify';
 import LRU from 'lru-cache';
-import SHA1 from 'sha1-es';
+import hashIt from 'hash-it';
 
 export interface ValidationCache {
   /**
@@ -31,7 +30,7 @@ function getSchemaHash(schema: GraphQLSchema) {
     return hash;
   }
   const introspection = introspectionFromSchema(schema);
-  hash = SHA1.hash(jsonStableStringify(introspection.__schema));
+  hash = String(hashIt(introspection.__schema));
   schemaHashCache.set(schema, hash);
   return hash;
 }

--- a/packages/plugins/validation-cache/src/stubs.d.ts
+++ b/packages/plugins/validation-cache/src/stubs.d.ts
@@ -1,4 +1,0 @@
-declare module 'js-sha1' {
-  // eslint-disable-next-line import/no-default-export
-  export default function sha1(input: string): string;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7789,6 +7789,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-it@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hash-it/-/hash-it-6.0.0.tgz#188df5a8ca2f8e036690e35f2ef88bd9417ff334"
+  integrity sha512-KHzmSFx1KwyMPw0kXeeUD752q/Kfbzhy6dAZrjXV9kAIXGqzGvv8vhkUqj+2MGZldTo0IBpw6v7iWE7uxsvH0w==
+
 hash-obj@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/hash-obj/-/hash-obj-4.0.0.tgz#3fafeb0b5f17994441dbe04efbdee82e26b74c8c"
@@ -12681,11 +12686,6 @@ sha.js@^2.4.11, sha.js@^2.4.9:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-sha1-es@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/sha1-es/-/sha1-es-1.8.2.tgz#6957c79749f67bf056732abbe53d424ff4205286"
-  integrity sha512-7gzO0Y7RBt1Qsq8D1fC+So6zsnkwRcZas8sGO9Xp4bOkDhG5s4fzSP0i9yUs6aVzSH7+urqqh6uk0z+dMDeF9A==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

`@envelop/validation-cache` has a dependency on an old library `sha1-es` which does not work well in ESM environments. This PR replaces the hashing logic to use [`hash-it`](https://github.com/planttheidea/hash-it) which works in Node 4+ and edge runtimes, and runs 5-10 times faster than `sha1-es`.

Fixes https://github.com/n1ru4l/envelop/issues/1732 Related https://github.com/n1ru4l/envelop/pull/1727

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I used the new build inside my ESM codebase and everything worked as expected.

**Test Environment**:

- OS: MacOS
- `@envelop/validation-cache` 5.1.1
- NodeJS: `18.14.2`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I don't know how to generate the changeset to document the change in dependencies for `@envelop/validation-cache`.
