### PR TITLE
Fix broken image for `sentry` plugin

### DIFF
--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -4,15 +4,15 @@ This plugin collects errors and performance tracing for your execution flow, and
 
 This is how it looks like in Sentry for error tracking:
 
-![Example](./error1.png)
-![Example](./error2.png)
+![Example](https://raw.githubusercontent.com/n1ru4l/envelop/main/packages/plugins/sentry/error1.png)
+![Example](https://raw.githubusercontent.com/n1ru4l/envelop/main/packages/plugins/sentry/error2.png)
 
 > The operation name, document, variables are collected on errors, and the breadcrumbs that led to the error. You can also add any custom values that you need.
 
 And for performance tracking:
 
-![Example](./perf1.png)
-![Example](./perf2.png)
+![Example](https://raw.githubusercontent.com/n1ru4l/envelop/main/packages/plugins/sentry/perf1.png)
+![Example](https://raw.githubusercontent.com/n1ru4l/envelop/main/packages/plugins/sentry/perf2.png)
 
 > You can get information about each resolver (including field and type names), it's execution time and arguments. Also, in case of an error, the performance log and info are attached automatically to the reported Sentry error.
 


### PR DESCRIPTION
Temp fix for broken images.
We should change the way we generate the plugin pages.