### PR TITLE
doc: fix generic auth doc examples to not use async or throw

### DIFF
--- a/.changeset/rotten-bananas-change.md
+++ b/.changeset/rotten-bananas-change.md
@@ -1,0 +1,5 @@
+---
+'@envelop/generic-auth': patch
+---
+
+Fix documentation to remove references to async `validateUser` and throwing to report errors

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -64,7 +64,7 @@ const validateUser: ValidateUserFn<UserType> = params => {
   // In `protect-auth-directive` mode, this function will always get called and you can use these parameters to check if the field has the `@auth` or `@skipAuth` directive
 
   if (!user) {
-    throw new Error(`Unauthenticated!`)
+    return new Error(`Unauthenticated!`)
   }
 }
 ```
@@ -303,14 +303,14 @@ const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthDirective
   // to the resolver auth directive arguments.
 
   if (!user) {
-    throw new Error(`Unauthenticated!`)
+    return new Error(`Unauthenticated!`)
   }
 
   const valueNode = fieldAuthDirectiveNode.arguments.find(arg => arg.name.value === 'role').value as EnumValueNode
   const role = valueNode.value
 
   if (role !== user.role) {
-    throw new Error(`No permissions!`)
+    return new Error(`No permissions!`)
   }
 }
 ```
@@ -323,18 +323,18 @@ Here's an example for adding role-aware authentication:
 ```ts
 import { ValidateUserFn } from '@envelop/generic-auth'
 
-const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthExtension }) => {
+const validateUser: ValidateUserFn<UserType> = ({ user, fieldAuthExtension }) => {
   // Now you can use the fieldAuthDirectiveNode parameter to implement custom logic for user validation, with access
   // to the resolver auth directive arguments.
 
   if (!user) {
-    throw new Error(`Unauthenticated!`)
+    return new Error(`Unauthenticated!`)
   }
 
   const role = fieldAuthExtension.role
 
   if (role !== user.role) {
-    throw new Error(`No permissions!`)
+    return new Error(`No permissions!`)
   }
 }
 
@@ -362,7 +362,7 @@ import { ValidateUserFn } from '@envelop/generic-auth'
 
 const validateUser: ValidateUserFn<UserType> = async ({ user, executionArgs, fieldAuthExtension }) => {
   if (!user) {
-    throw new Error(`Unauthenticated!`)
+    return new Error(`Unauthenticated!`)
   }
 
   // You have access to the object define in the resolver tree, allowing to define any custom logic you want.
@@ -381,7 +381,7 @@ const resolvers = {
           validate: ({ user, variables, context }) => {
             // We can now have access to the operation and variables to decide if the user can execute the query
             if (user.id !== variables.userId) {
-              throw new Error(`Unauthorized`)
+              return new Error(`Unauthorized`)
             }
           }
         }


### PR DESCRIPTION
## Description

Fixes the documentation of `@envelop/generic-auth` to reflect the fact that `validateUser` can't return a promise and that validation errors should preferably be returned instead of thrown.

Fixes #1753 

## Type of change

- [x] Documentation change

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
