### PR TITLE
fix: prevent double-wrapping of field.resolve

### DIFF
--- a/.changeset/eighty-ties-lay.md
+++ b/.changeset/eighty-ties-lay.md
@@ -1,0 +1,5 @@
+---
+'@envelop/on-resolve': patch
+---
+
+Prevent re-wrapping field resolvers with useOnResolve plugin. Fixes #1773

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -49,7 +49,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       for (const type of Object.values(schema.getTypeMap())) {
         if (!isIntrospectionType(type) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
-            if (field.resolve?.[hasWrappedResolveSymbol]) continue;
+            if (field[hasWrappedResolveSymbol]) continue;
 
             let resolver = (field.resolve || defaultFieldResolver) as Resolver<PluginContext>;
 
@@ -87,7 +87,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
               return result;
             };
 
-            field.resolve[hasWrappedResolveSymbol] = true;
+            field[hasWrappedResolveSymbol] = true;
           }
         }
       }

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -68,6 +68,9 @@ describe('useOnResolve', () => {
     const testkit = createTestkit(
       [
         useOnResolve(() => afterResolve),
+        // This _should_ trigger another afterResolve call
+        useOnResolve(() => afterResolve),
+        // This should _NOT_ trigger another afterResolve call
         {
           onSchemaChange({ schema, replaceSchema }) {
             replaceSchema(schema);
@@ -78,7 +81,8 @@ describe('useOnResolve', () => {
     );
 
     const result = await testkit.execute('{ value1 }');
-    expect(afterResolve).toBeCalledTimes(1);
+    // Expect two calls, not four.
+    expect(afterResolve).toBeCalledTimes(2);
 
     assertSingleExecutionValue(result);
     expect(result.data?.value1).toBe('value2');


### PR DESCRIPTION
## Description

Prevent double-wrapping of field.resolve in the useOnResolve plugin. See #1772. Prior to this fix, other plugins which use the useOnResolve plugin could be executed multiple times per field if other plugins used replaceSchema.

Fixes #1772

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Added a new test to `use-on-resolve.spec.ts`. 

https://github.com/jonapgar-groupby/envelop/blob/main/packages/plugins/on-resolve/test/use-on-resolve.spec.ts#L64-L85

You can locally verify the issue in #1772 by running the tests on this branch after commenting out the ` if (field.resolve?.[hasWrappedResolveSymbol]) continue;` line:

https://github.com/jonapgar-groupby/envelop/blob/main/packages/plugins/on-resolve/src/index.ts#L52



