### PR TITLE
fix response cache extension type

### DIFF
--- a/.changeset/thin-fishes-unite.md
+++ b/.changeset/thin-fishes-unite.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+fix response cache extensions type

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -182,7 +182,7 @@ export type ResponseCacheExtensions =
       ttl: number;
     }
   | {
-      invalidatedEntities: string[];
+      invalidatedEntities: CacheEntityRecord[];
     };
 
 export type ResponseCacheExecutionResult = ExecutionResult<
@@ -356,16 +356,11 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
               cache.invalidate(identifier.values());
               if (includeExtensionMetadata) {
-                setResult({
-                  ...processedResult,
-                  extensions: {
-                    ...processedResult.extensions,
-                    responseCache: {
-                      ...processedResult.extensions?.responseCache,
-                      invalidatedEntities: Array.from(identifier.values()),
-                    },
-                  },
-                });
+                setResult(
+                  resultWithMetadata(processedResult, {
+                    invalidatedEntities: Array.from(identifier.values()),
+                  }),
+                );
               }
             },
           };
@@ -384,16 +379,9 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
         if (cachedResponse != null) {
           if (includeExtensionMetadata) {
-            onExecuteParams.setResultAndStopExecution({
-              ...cachedResponse,
-              extensions: {
-                ...cachedResponse.extensions,
-                responseCache: {
-                  ...cachedResponse.extensions?.responseCache,
-                  hit: true,
-                },
-              },
-            });
+            onExecuteParams.setResultAndStopExecution(
+              resultWithMetadata(cachedResponse, { hit: true }),
+            );
           } else {
             onExecuteParams.setResultAndStopExecution(cachedResponse);
           }
@@ -445,38 +433,35 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
           if (finalTtl === 0) {
             if (includeExtensionMetadata) {
-              setResult({
-                ...processedResult,
-                extensions: {
-                  ...processedResult.extensions,
-                  responseCache: {
-                    ...processedResult.extensions?.responseCache,
-                    hit: false,
-                    didCache: false,
-                  },
-                },
-              });
+              setResult(resultWithMetadata(processedResult, { hit: false, didCache: false }));
             }
             return;
           }
 
           cache.set(cacheKey, processedResult, identifier.values(), finalTtl);
           if (includeExtensionMetadata) {
-            setResult({
-              ...processedResult,
-              extensions: {
-                ...processedResult.extensions,
-                responseCache: {
-                  ...processedResult.extensions?.responseCache,
-                  hit: false,
-                  didCache: true,
-                  ttl: finalTtl,
-                },
-              },
-            });
+            setResult(
+              resultWithMetadata(processedResult, { hit: false, didCache: true, ttl: finalTtl }),
+            );
           }
         },
       };
+    },
+  };
+}
+
+function resultWithMetadata(
+  result: ExecutionResult,
+  metadata: ResponseCacheExtensions,
+): ResponseCacheExecutionResult {
+  return {
+    ...result,
+    extensions: {
+      ...result.extensions,
+      responseCache: {
+        ...(result as ResponseCacheExecutionResult).extensions?.responseCache,
+        ...metadata,
+      },
     },
   };
 }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Description

Fix the TypeScript type definition of the Response Cache extensions object. It was specifying that `invalidatedEntities` was a string array.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I think that this is a breaking change, but since the type was already wrong, I'm not sure it would break anyone's build.
