### PR TITLE
feat(response-cache): support @cacheControl(scope: CacheControlScope)

### DIFF
--- a/.changeset/orange-owls-whisper.md
+++ b/.changeset/orange-owls-whisper.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+add support for scopes to enforce cache privacy

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -6,6 +6,7 @@ import { assertSingleExecutionValue, createTestkit, TestkitInstance } from '@env
 import { useValidationCache } from '@envelop/validation-cache';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import {
+  cacheControlDirective,
   createInMemoryCache,
   defaultBuildResponseCacheKey,
   useResponseCache,
@@ -2497,6 +2498,328 @@ describe('useResponseCache', () => {
     expect(shouldCacheResult).toHaveBeenCalledWith({
       cacheKey,
       result,
+    });
+  });
+
+  describe('supports scope', () => {
+    it('should not cache response with a type with a PRIVATE scope for request without session', async () => {
+      jest.useFakeTimers();
+      const spy = jest.fn(() => [
+        {
+          id: 1,
+          name: 'User 1',
+          comments: [
+            {
+              id: 1,
+              text: 'Comment 1 of User 1',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'User 2',
+          comments: [
+            {
+              id: 2,
+              text: 'Comment 2 of User 2',
+            },
+          ],
+        },
+      ]);
+
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            users: [User!]!
+          }
+
+          type User {
+            id: ID!
+            name: String!
+            comments: [Comment!]!
+            recentComment: Comment
+          }
+
+          type Comment {
+            id: ID!
+            text: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        [
+          useResponseCache({
+            session: () => null,
+            ttl: 200,
+            scopePerSchemaCoordinate: {
+              User: 'PRIVATE',
+            },
+          }),
+        ],
+        schema,
+      );
+
+      const query = /* GraphQL */ `
+        query test {
+          users {
+            id
+            name
+            comments {
+              id
+              text
+            }
+          }
+        }
+      `;
+
+      await testInstance.execute(query);
+      await testInstance.execute(query);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache response with a type with a PRIVATE scope for request without session using @cachControl directive', async () => {
+      jest.useFakeTimers();
+      const spy = jest.fn(() => [
+        {
+          id: 1,
+          name: 'User 1',
+          comments: [
+            {
+              id: 1,
+              text: 'Comment 1 of User 1',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'User 2',
+          comments: [
+            {
+              id: 2,
+              text: 'Comment 2 of User 2',
+            },
+          ],
+        },
+      ]);
+
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          ${cacheControlDirective}
+          type Query {
+            users: [User!]!
+          }
+
+          type User @cacheControl(scope: PRIVATE) {
+            id: ID!
+            name: String!
+            comments: [Comment!]!
+            recentComment: Comment
+          }
+
+          type Comment {
+            id: ID!
+            text: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        [
+          useResponseCache({
+            session: () => null,
+            ttl: 200,
+          }),
+        ],
+        schema,
+      );
+
+      const query = /* GraphQL */ `
+        query test {
+          users {
+            id
+            name
+            comments {
+              id
+              text
+            }
+          }
+        }
+      `;
+
+      await testInstance.execute(query);
+      await testInstance.execute(query);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache response with a field with PRIVATE scope for request without session', async () => {
+      jest.useFakeTimers();
+      const spy = jest.fn(() => [
+        {
+          id: 1,
+          name: 'User 1',
+          comments: [
+            {
+              id: 1,
+              text: 'Comment 1 of User 1',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'User 2',
+          comments: [
+            {
+              id: 2,
+              text: 'Comment 2 of User 2',
+            },
+          ],
+        },
+      ]);
+
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            users: [User!]!
+          }
+
+          type User {
+            id: ID!
+            name: String!
+            comments: [Comment!]!
+            recentComment: Comment
+          }
+
+          type Comment {
+            id: ID!
+            text: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        [
+          useResponseCache({
+            session: () => null,
+            ttl: 200,
+            scopePerSchemaCoordinate: {
+              'User.name': 'PRIVATE',
+            },
+          }),
+        ],
+        schema,
+      );
+
+      const query = /* GraphQL */ `
+        query test {
+          users {
+            id
+            name
+            comments {
+              id
+              text
+            }
+          }
+        }
+      `;
+
+      await testInstance.execute(query);
+      await testInstance.execute(query);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache response with a field with PRIVATE scope for request without session using @cachControl directive', async () => {
+      jest.useFakeTimers();
+      const spy = jest.fn(() => [
+        {
+          id: 1,
+          name: 'User 1',
+          comments: [
+            {
+              id: 1,
+              text: 'Comment 1 of User 1',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'User 2',
+          comments: [
+            {
+              id: 2,
+              text: 'Comment 2 of User 2',
+            },
+          ],
+        },
+      ]);
+
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          ${cacheControlDirective}
+          type Query {
+            users: [User!]!
+          }
+
+          type User {
+            id: ID!
+            name: String! @cacheControl(scope: PRIVATE)
+            comments: [Comment!]!
+            recentComment: Comment
+          }
+
+          type Comment {
+            id: ID!
+            text: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        [
+          useResponseCache({
+            session: () => null,
+            ttl: 200,
+          }),
+        ],
+        schema,
+      );
+
+      const query = /* GraphQL */ `
+        query test {
+          users {
+            id
+            name
+            comments {
+              id
+              text
+            }
+          }
+        }
+      `;
+
+      await testInstance.execute(query);
+      await testInstance.execute(query);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Description

Adds support for the `scope` argument of the Apollo's `@cacheControl` directive.

The goal is to make `@cacheControl` behaviour as close as possible from Apollo's one to make schema using it easily working in Yoga.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
 - ~~Waiting for #1603~~ 

## Further comments

I have also provided a way to use this feature using the configuration object passed to the plugin.
I have only added a `perSchemaCoordinate` way of configuration as I think having both a `perType` and `perCoordinate` is a bit redundant since coordinate can represent a type instead of a field.
