### PR TITLE
feat(response-cache): support defer and stream

### DIFF
--- a/.changeset/@envelop_response-cache-1896-dependencies.md
+++ b/.changeset/@envelop_response-cache-1896-dependencies.md
@@ -1,9 +1,0 @@
----
-'@envelop/response-cache': patch
----
-
-dependencies updates:
-
-- Added dependency
-  [`@graphql-tools/executor@^1.1.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.1.0)
-  (to `dependencies`)

--- a/.changeset/@envelop_response-cache-1896-dependencies.md
+++ b/.changeset/@envelop_response-cache-1896-dependencies.md
@@ -1,0 +1,9 @@
+---
+'@envelop/response-cache': patch
+---
+
+dependencies updates:
+
+- Added dependency
+  [`@graphql-tools/executor@^1.1.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.1.0)
+  (to `dependencies`)

--- a/.changeset/@envelop_response-cache-1896-dependencies.md
+++ b/.changeset/@envelop_response-cache-1896-dependencies.md
@@ -1,0 +1,9 @@
+---
+'@envelop/response-cache': patch
+---
+
+dependencies updates:
+
+- Updated dependency
+  [`@graphql-tools/utils@^10.0.3` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.0.3)
+  (from `^10.0.0`, in `dependencies`)

--- a/.changeset/six-news-chew.md
+++ b/.changeset/six-news-chew.md
@@ -1,0 +1,6 @@
+---
+'@envelop/response-cache': minor
+'@envelop/types': patch
+---
+
+add support for @defer and @stream

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -51,6 +51,7 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@graphql-tools/executor": "^1.1.0",
     "@graphql-tools/utils": "^10.0.0",
     "@whatwg-node/fetch": "^0.9.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@graphql-tools/executor": "^1.1.0",
-    "@graphql-tools/utils": "^10.0.0",
+    "@graphql-tools/utils": "10.0.3-alpha-20230703152134-22d7eebf",
     "@whatwg-node/fetch": "^0.9.0",
     "fast-json-stable-stringify": "^2.1.0",
     "lru-cache": "^10.0.0",

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -51,8 +51,7 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-tools/executor": "^1.1.0",
-    "@graphql-tools/utils": "10.0.3-alpha-20230703152134-22d7eebf",
+    "@graphql-tools/utils": "^10.0.3",
     "@whatwg-node/fetch": "^0.9.0",
     "fast-json-stable-stringify": "^2.1.0",
     "lru-cache": "^10.0.0",
@@ -60,6 +59,7 @@
   },
   "devDependencies": {
     "@envelop/core": "^4.0.0",
+    "@graphql-tools/executor": "^1.1.0",
     "@graphql-tools/schema": "10.0.0",
     "graphql": "16.6.0",
     "ioredis-mock": "5.9.1",

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -13,6 +13,7 @@ import {
 import {
   ExecutionResult,
   getDocumentString,
+  IncrementalExecutionResult,
   isAsyncIterable,
   Maybe,
   ObjMap,
@@ -508,7 +509,10 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           // The merged result is then used to know if we should cache it and to calculate the ttl.
           let result: ExecutionResult = {};
           return {
-            onNext({ result: { data, incremental, hasNext, errors, extensions }, setResult }) {
+            onNext(payload) {
+              const { data, errors, extensions, incremental, hasNext } =
+                payload.result as IncrementalExecutionResult;
+
               if (data) {
                 // This is the first result with the initial data payload sent to the client. We use it as the base result
                 if (data) {
@@ -530,7 +534,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
               if (!hasNext) {
                 // The query is complete, we can process the final result
-                maybeCacheResult(result, setResult);
+                maybeCacheResult(result, payload.setResult);
               }
             },
           };

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -535,7 +535,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
                 if (incremental) {
                   for (const patch of incremental) {
-                    mergeIncrementalResult(result, patch);
+                    mergeIncrementalResult({ executionResult: result, incrementalResult: patch });
                   }
                 }
 

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -1,5 +1,4 @@
-import { inspect } from 'util';
-import { getIntrospectionQuery, GraphQLDirective, GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { getIntrospectionQuery, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import * as GraphQLJS from 'graphql';
 import { envelop, useEngine, useLogger, useSchema } from '@envelop/core';
 import { useGraphQlJit } from '@envelop/graphql-jit';

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -2892,8 +2892,20 @@ describe('useResponseCache', () => {
       }
     `;
 
-    await logResult('result 1', testInstance.execute(query));
-    await logResult('result 2', testInstance.execute(query));
+    await waitForResult(testInstance.execute(query));
+    expect(await waitForResult(testInstance.execute(query))).toEqual({
+      data: {
+        users: [
+          {
+            id: '1',
+            name: 'User 1',
+            comments: [{ id: '1', text: 'Comment 1 of User 1' }],
+          },
+          { id: '2', name: 'User 2', comments: [] },
+          { id: '3', name: 'User 3', comments: [] },
+        ],
+      },
+    });
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -2965,21 +2977,33 @@ describe('useResponseCache', () => {
       }
     `;
 
-    await logResult('result 1', testInstance.execute(query));
-    await logResult('result 2', testInstance.execute(query));
+    await waitForResult(testInstance.execute(query));
+    expect(await waitForResult(testInstance.execute(query))).toEqual({
+      data: {
+        users: [
+          {
+            id: '1',
+            name: 'User 1',
+            comments: [{ __typename: 'Comment', id: '1', text: 'Comment 1 of User 1' }],
+          },
+          { id: '2', name: 'User 2', comments: [] },
+          { id: '3', name: 'User 3', comments: [] },
+        ],
+      },
+      extensions: { responseCache: { hit: true } },
+    });
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 
-async function logResult(msg: string, result: any) {
+async function waitForResult(result: any) {
   result = await result;
   if (result.next) {
     let res = [];
     for await (const r of result) {
       res.push(r);
     }
-    console.log(msg, inspect(res, { showHidden: false, depth: null, colors: true }));
-  } else {
-    console.log(msg, inspect(result, { showHidden: false, depth: null, colors: true }));
   }
+
+  return result;
 }

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -1,10 +1,14 @@
-import { getIntrospectionQuery, GraphQLObjectType, GraphQLSchema } from 'graphql';
-import { useLogger } from '@envelop/core';
+import { inspect } from 'util';
+import { getIntrospectionQuery, GraphQLDirective, GraphQLObjectType, GraphQLSchema } from 'graphql';
+import * as GraphQLJS from 'graphql';
+import { envelop, useEngine, useLogger, useSchema } from '@envelop/core';
 import { useGraphQlJit } from '@envelop/graphql-jit';
 import { useParserCache } from '@envelop/parser-cache';
 import { assertSingleExecutionValue, createTestkit, TestkitInstance } from '@envelop/testing';
 import { useValidationCache } from '@envelop/validation-cache';
+import { normalizedExecutor } from '@graphql-tools/executor';
 import { makeExecutableSchema } from '@graphql-tools/schema';
+import { mapSchema as cloneSchema } from '@graphql-tools/utils';
 import {
   cacheControlDirective,
   createInMemoryCache,
@@ -2822,4 +2826,160 @@ describe('useResponseCache', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
   });
+
+  it('should cache queries using @stream', async () => {
+    const spy = jest.fn(async function* () {
+      yield {
+        id: 1,
+        name: 'User 1',
+        comments: [{ id: 1, text: 'Comment 1 of User 1' }],
+      };
+      yield { id: 2, name: 'User 2', comments: [] };
+      await new Promise(process.nextTick);
+      yield { id: 3, name: 'User 3', comments: [] };
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        directive @stream on FIELD
+
+        type Query {
+          users: [User!]!
+        }
+
+        type Mutation {
+          updateUser(id: ID!): User!
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          comments: [Comment!]!
+          recentComment: Comment
+        }
+
+        type Comment {
+          id: ID!
+          text: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: spy,
+        },
+      },
+    });
+
+    const testInstance = createTestkit(
+      envelop({
+        plugins: [
+          useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+          useSchema(cloneSchema(schema)),
+          useResponseCache({ session: () => null }),
+        ],
+      }),
+    );
+
+    const query = /* GraphQL */ `
+      query test {
+        users @stream {
+          id
+          name
+          comments {
+            id
+            text
+          }
+        }
+      }
+    `;
+
+    await logResult('result 1', testInstance.execute(query));
+    await logResult('result 2', testInstance.execute(query));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cache queries using @defer', async () => {
+    const spy = jest.fn(async function* () {
+      yield {
+        id: 1,
+        name: 'User 1',
+        comments: [{ id: 1, text: 'Comment 1 of User 1' }],
+      };
+      yield { id: 2, name: 'User 2', comments: [] };
+      await new Promise(process.nextTick);
+      yield { id: 3, name: 'User 3', comments: [] };
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        directive @defer on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        type Query {
+          users: [User!]!
+        }
+
+        type Mutation {
+          updateUser(id: ID!): User!
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          comments: [Comment!]!
+          recentComment: Comment
+        }
+
+        type Comment {
+          id: ID!
+          text: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: spy,
+        },
+      },
+    });
+
+    const testInstance = createTestkit(
+      envelop({
+        plugins: [
+          useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+          useSchema(cloneSchema(schema)),
+          useResponseCache({ session: () => null, includeExtensionMetadata: true }),
+        ],
+      }),
+    );
+
+    const query = /* GraphQL */ `
+      query test {
+        users {
+          id
+          name
+
+          ... on User @defer {
+            comments {
+              id
+              text
+            }
+          }
+        }
+      }
+    `;
+
+    await logResult('result 1', testInstance.execute(query));
+    await logResult('result 2', testInstance.execute(query));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });
+
+async function logResult(msg: string, result: any) {
+  result = await result;
+  if (result.next) {
+    let res = [];
+    for await (const r of result) {
+      res.push(r);
+    }
+    console.log(msg, inspect(res, { showHidden: false, depth: null, colors: true }));
+  } else {
+    console.log(msg, inspect(result, { showHidden: false, depth: null, colors: true }));
+  }
+}

--- a/packages/types/src/graphql.ts
+++ b/packages/types/src/graphql.ts
@@ -79,3 +79,36 @@ export interface ExecutionResult<TData = ObjMap<unknown>, TExtensions = ObjMap<u
   data?: TData | null;
   extensions?: TExtensions;
 }
+
+export interface IncrementalDeferResult<
+  TData = Record<string, unknown>,
+  TExtensions = Record<string, unknown>,
+> extends ExecutionResult<TData, TExtensions> {
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+export interface IncrementalStreamResult<
+  TData = Array<unknown>,
+  TExtensions = Record<string, unknown>,
+> {
+  errors?: ReadonlyArray<any>;
+  items?: TData | null;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: TExtensions;
+}
+
+export type IncrementalResult<
+  TData = Record<string, unknown>,
+  TExtensions = Record<string, unknown>,
+> = IncrementalDeferResult<TData, TExtensions> | IncrementalStreamResult<TData, TExtensions>;
+
+export interface IncrementalExecutionResult<
+  TData = Record<string, unknown>,
+  TExtensions = Record<string, unknown>,
+> extends ExecutionResult<TData, TExtensions> {
+  hasNext: boolean;
+  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  extensions?: TExtensions;
+}

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -2,6 +2,7 @@ import {
   ExecuteFunction,
   ExecutionArgs,
   ExecutionResult,
+  IncrementalExecutionResult,
   ParseFunction,
   SubscribeFunction,
   ValidateFunction,
@@ -311,7 +312,7 @@ export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
   /**
    * The execution result.
    */
-  result: ExecutionResult;
+  result: IncrementalExecutionResult;
   /**
    * Replace the execution result with a new execution result.
    */

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -312,7 +312,7 @@ export type OnExecuteDoneHookResultOnNextHookPayload<ContextType> = {
   /**
    * The execution result.
    */
-  result: IncrementalExecutionResult;
+  result: IncrementalExecutionResult | ExecutionResult;
   /**
    * Replace the execution result with a new execution result.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,6 +1352,9 @@ importers:
 
   packages/plugins/response-cache:
     dependencies:
+      '@graphql-tools/executor':
+        specifier: ^1.1.0
+        version: 1.1.0(graphql@16.6.0)
       '@graphql-tools/utils':
         specifier: ^10.0.0
         version: 10.0.0(graphql@16.6.0)
@@ -4257,6 +4260,20 @@ packages:
       tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: true
+
+  /@graphql-tools/executor@1.1.0(graphql@16.6.0):
+    resolution: {integrity: sha512-+1wmnaUHETSYxiK/ELsT60x584Rw3QKBB7F/7fJ83HKPnLifmE2Dm/K9Eyt6L0Ppekf1jNUbWBpmBGb8P5hAeg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@repeaterjs/repeater': 3.0.4
+      graphql: 16.6.0
+      tslib: 2.5.0
+      value-or-promise: 1.0.12
+    dev: false
 
   /@graphql-tools/merge@8.3.1(graphql@16.6.0):
     resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,12 +1352,9 @@ importers:
 
   packages/plugins/response-cache:
     dependencies:
-      '@graphql-tools/executor':
-        specifier: ^1.1.0
-        version: 1.1.0(graphql@16.6.0)
       '@graphql-tools/utils':
-        specifier: 10.0.3-alpha-20230703152134-22d7eebf
-        version: 10.0.3-alpha-20230703152134-22d7eebf(graphql@16.6.0)
+        specifier: ^10.0.3
+        version: 10.0.3(graphql@16.6.0)
       '@whatwg-node/fetch':
         specifier: ^0.9.0
         version: 0.9.0
@@ -1374,6 +1371,9 @@ importers:
       '@envelop/core':
         specifier: ^4.0.0
         version: link:../../core/dist
+      '@graphql-tools/executor':
+        specifier: ^1.1.0
+        version: 1.1.0(graphql@16.6.0)
       '@graphql-tools/schema':
         specifier: 10.0.0
         version: 10.0.0(graphql@16.6.0)
@@ -4267,13 +4267,13 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 10.0.2(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.3(graphql@16.6.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.4
       graphql: 16.6.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
-    dev: false
+    dev: true
 
   /@graphql-tools/merge@8.3.1(graphql@16.6.0):
     resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}
@@ -4310,7 +4310,7 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 10.0.2(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.3(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.0
 
@@ -4405,9 +4405,10 @@ packages:
       dset: 3.1.2
       graphql: 16.6.0
       tslib: 2.5.0
+    dev: true
 
-  /@graphql-tools/utils@10.0.3-alpha-20230703152134-22d7eebf(graphql@16.6.0):
-    resolution: {integrity: sha512-XMi/wNf/q0qtTwt4M8vnQt2Y6chMTK46D41wTLphSf7gq65NxH4N3DmfMdwN/bYu2UpvO/52A691kuDzIpr+ZQ==}
+  /@graphql-tools/utils@10.0.3(graphql@16.6.0):
+    resolution: {integrity: sha512-6uO41urAEIs4sXQT2+CYGsUTkHkVo/2MpM/QjoHj6D6xoEF2woXHBpdAVi0HKIInDwZqWgEYOwIFez0pERxa1Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4416,7 +4417,6 @@ packages:
       dset: 3.1.2
       graphql: 16.6.0
       tslib: 2.5.0
-    dev: false
 
   /@graphql-tools/utils@7.10.0(graphql@16.6.0):
     resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1356,8 +1356,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(graphql@16.6.0)
       '@graphql-tools/utils':
-        specifier: ^10.0.0
-        version: 10.0.0(graphql@16.6.0)
+        specifier: 10.0.3-alpha-20230703152134-22d7eebf
+        version: 10.0.3-alpha-20230703152134-22d7eebf(graphql@16.6.0)
       '@whatwg-node/fetch':
         specifier: ^0.9.0
         version: 0.9.0
@@ -4267,7 +4267,7 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.2(graphql@16.6.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.4
       graphql: 16.6.0
@@ -4405,6 +4405,18 @@ packages:
       dset: 3.1.2
       graphql: 16.6.0
       tslib: 2.5.0
+
+  /@graphql-tools/utils@10.0.3-alpha-20230703152134-22d7eebf(graphql@16.6.0):
+    resolution: {integrity: sha512-XMi/wNf/q0qtTwt4M8vnQt2Y6chMTK46D41wTLphSf7gq65NxH4N3DmfMdwN/bYu2UpvO/52A691kuDzIpr+ZQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      dset: 3.1.2
+      graphql: 16.6.0
+      tslib: 2.5.0
+    dev: false
 
   /@graphql-tools/utils@7.10.0(graphql@16.6.0):
     resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}


### PR DESCRIPTION
## Description

The reponse-cache plugin should handle queries using `@defer` or `@stream` directives.

Fixes #1122 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

For now, I've made the choice to merge all incremental patches and serve the result on cache hit. An other approach would be to save the patches and replay them on cache hit.
I've this choice because anyway, with the current plugin implementation, I need the merged result to calculate if the result should be cached and the appropriate TTL.
