### PR TITLE
(doc: plugin testing) remove undefined buildSchema from doc examples

### DIFF
--- a/website/src/pages/v3/plugins/testing.mdx
+++ b/website/src/pages/v3/plugins/testing.mdx
@@ -22,10 +22,18 @@ To test a plugin in a real GraphQL environment, just create a Testkit Envelop:
 
 ```ts
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing'
+import { makeExecutableSchema } from '@graphql-tools/schema'
 import { useMyPlugin } from './my-plugin'
 
 describe('My Plugin', () => {
-  const mySchema = buildSchema(`type Query { foo: String }`)
+  const mySchema = makeExecutableSchema({
+    typeDefs: `type Query { foo: String }`,
+    resolvers: {
+      Query: {
+        foo: () => 'bar'
+      }
+    }
+  })
 
   it('Should run correctly with no errors', async () => {
     // Create a testkit for the plugin, using the plugin and a dummy schema
@@ -35,7 +43,7 @@ describe('My Plugin', () => {
     // During tests, it's simpler to assume you are dealing with a non-stream responses
     assertSingleExecutionValue(result)
     // Assert that the result is correct
-    expect(result.data).toBeDefined()
+    expect(result.data?.foo).toBe('bar')
   })
 })
 ```
@@ -47,10 +55,18 @@ and run the same testing flow for multiple plugins together:
 
 ```ts
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing'
+import { makeExecutableSchema } from '@graphql-tools/schema'
 import { getEnveloped } from './my-app'
 
 describe('My GQL App', () => {
-  const mySchema = buildSchema(`type Query { foo: String }`)
+  const mySchema = makeExecutableSchema({
+    typeDefs: `type Query { foo: String }`,
+    resolvers: {
+      Query: {
+        foo: () => 'bar'
+      }
+    }
+  })
 
   it('Should run correctly with no errors', async () => {
     // Create a testkit based on the envelop, with a dummy schema
@@ -60,7 +76,7 @@ describe('My GQL App', () => {
     // During tests, it's simpler to assume you are dealing with a non-stream responses
     assertSingleExecutionValue(result)
     // Assert that the result is correct
-    expect(result.data).toBeDefined()
+    expect(result.data?.foo).toBe('bar')
   })
 })
 ```


### PR DESCRIPTION
## Description

The plugin testing documentation was using an undefined function (`buildSchema`) in its examples, which was a bit confusing.
This PR replaces this fake function by the creation of a real schema, which doesn't add that much noise and makes the example clearer.

## Type of change

Documentation update

