### PR TITLE
make the context referentialy stable

### DIFF
--- a/.changeset/wise-teachers-eat.md
+++ b/.changeset/wise-teachers-eat.md
@@ -1,0 +1,7 @@
+---
+'@envelop/core': patch
+---
+
+The context is now referentialy stable. It means the context passed to all hooks and to all resolver
+is guaranted to always be the same object instance. This unique object instance will be mutated as
+needed to extend the context.

--- a/packages/core/test/context.spec.ts
+++ b/packages/core/test/context.spec.ts
@@ -169,4 +169,25 @@ describe('contextFactory', () => {
       }
     });
   });
+
+  it('should preserve referential stability of the context', async () => {
+    const testKit = createTestkit(
+      [
+        {
+          onContextBuilding({ extendContext }) {
+            extendContext({ foo: 'bar' });
+            return ({ extendContext }) => {
+              extendContext({ bar: 'foo' });
+            };
+          },
+        },
+      ],
+      schema,
+    );
+
+    const context = {};
+    await testKit.execute(query, {}, context);
+
+    expect(context).toMatchObject({ foo: 'bar', bar: 'foo' });
+  });
 });

--- a/packages/core/test/enveloped.spec.ts
+++ b/packages/core/test/enveloped.spec.ts
@@ -1,0 +1,22 @@
+import { createTestkit } from '@envelop/testing';
+import { query, schema } from './common';
+
+describe('enveloped', () => {
+  it('should preserve referential stability of the context', async () => {
+    const testKit = createTestkit(
+      [
+        {
+          onEnveloped({ extendContext }) {
+            extendContext({ foo: 'bar' });
+          },
+        },
+      ],
+      schema,
+    );
+
+    const context: any = {};
+    await testKit.execute(query, {}, context);
+
+    expect(context.foo).toEqual('bar');
+  });
+});

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -536,6 +536,24 @@ describe('execute', () => {
     await result.return!();
     expect(isReturnCalled).toEqual(true);
   });
+
+  it('should preserve referential stability of the context', async () => {
+    const testKit = createTestkit(
+      [
+        {
+          onExecute({ extendContext }) {
+            extendContext({ foo: 'bar' });
+          },
+        },
+      ],
+      schema,
+    );
+
+    const context = {};
+    await testKit.execute(query, {}, context);
+
+    expect(context).toMatchObject({ foo: 'bar' });
+  });
 });
 
 it.each([

--- a/packages/core/test/parse.spec.ts
+++ b/packages/core/test/parse.spec.ts
@@ -109,4 +109,27 @@ describe('parse', () => {
     expect(result.data?.currentUser).toBeDefined();
     expect(result.data?.me).not.toBeDefined();
   });
+
+  it('should preserve referential stability of the context', async () => {
+    const testKit = createTestkit(
+      [
+        {
+          onParse({ extendContext }) {
+            extendContext({ foo: 'bar' });
+
+            return ({ extendContext }) => {
+              extendContext({ bar: 'foo' });
+            };
+          },
+        },
+      ],
+      schema,
+    );
+
+    const context: any = {};
+    await testKit.execute(query, {}, context);
+
+    expect(context.foo).toEqual('bar');
+    expect(context.bar).toEqual('foo');
+  });
 });

--- a/packages/core/test/validate.spec.ts
+++ b/packages/core/test/validate.spec.ts
@@ -173,4 +173,27 @@ describe('validate', () => {
       }
     `);
   });
+
+  it('should preserve referential stability of the context', async () => {
+    const testKit = createTestkit(
+      [
+        {
+          onValidate({ extendContext }) {
+            extendContext({ foo: 'bar' });
+
+            return ({ extendContext }) => {
+              extendContext({ bar: 'foo' });
+            };
+          },
+        },
+      ],
+      schema,
+    );
+
+    const context: any = {};
+    await testKit.execute(query, {}, context);
+
+    expect(context.foo).toEqual('bar');
+    expect(context.bar).toEqual('foo');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1391,7 +1391,7 @@ importers:
   packages/plugins/response-cache-redis:
     dependencies:
       '@envelop/response-cache':
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: link:../response-cache/dist
       ioredis:
         specifier: ^4.27.9


### PR DESCRIPTION
## Description

Today, when the context is extended via the provided `extendContext` parameter, the context is mutated or cloned depending on the hook.

This PR aims to unify the behaviour of every hooks by always mutating the context when extending. This avoid to create unnecessary object instances and to have a referentially stable context object.

The reference stability is usefull to allow plugins to reference the context outside of envelop hooks. Here an example of usage with a DAO relying on context for some its methods. Without referential stability, developer will always have to give the context as a parameter.

```ts
class DAO extends Client {
	constructor({ context }) {
		this.context = context
	}

	getCurrentUser() {
		return this.getUser(this.context.auth.userId)
	}

	getUser(id) {
		return this.query(sql`SELECT * FROM users WHERE user.id = ${id}`)
	}
}

const daoPlugin = {
	onEveloped({ extendContext, context }) {
		extendContext({ dao: new DAO({ context }) })
	}
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected) => __I'm not sure if this is a breaking change. It could, but I think most of the time, this behaviour is the one expected__

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

