### PR TITLE
Update skipped error doc for Sentry plugin

### DIFF
--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -77,8 +77,8 @@ const getEnveloped = envelop({
   traceId, parentId and more.
 - `operationName` - Produces a "op" (operation) of created Span.
 - `skip` (default: none) - Produces a "op" (operation) of created Span.
-- `skipError` (default: ignored `EnvelopError`) - Indicates whether or not to skip Sentry exception
-  reporting for a given error. By default, this plugin skips all `EnvelopError` errors and does not
+- `skipError` (default: ignored `GraphQLError`) - Indicates whether or not to skip Sentry exception
+  reporting for a given error. By default, this plugin skips all `GraphQLError` errors and does not
   report it to Sentry.
 - `eventIdKey` (default: `'sentryEventId'`) - The key in the error's extensions field used to expose
   the generated Sentry event id. Set to `null` to disable.


### PR DESCRIPTION
## Description

This PR changes the name of the skipped error from `EnvelopError` to `GraphQLError` which is the current behaviour of the Sentry plugin:

- [Link to code](https://github.com/n1ru4l/envelop/blob/main/packages/plugins/sentry/src/index.ts#L83) confirming that `GraphQLError` is skipped
- `EnvelopError` was deprecated in v3: [link](https://the-guild.dev/graphql/envelop/v3/guides/migrating-from-v2-to-v3#3-remove-enveloperror) 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules