### PR TITLE
useResponseCache onParse check if Subscription

### DIFF
--- a/.changeset/sharp-kings-fix.md
+++ b/.changeset/sharp-kings-fix.md
@@ -1,0 +1,5 @@
+---
+"@envelop/response-cache": patch
+---
+
+useResponseCache onParse check if Subscription

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -1,5 +1,6 @@
 import jsonStableStringify from 'fast-json-stable-stringify';
 import {
+  DefinitionNode,
   DocumentNode,
   ExecutionArgs,
   getOperationAST,
@@ -261,17 +262,16 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   return {
     onParse() {
       return ({ result, replaceParseResult }) => {
-        // Check if the operation is a subscription
-        const operationAST = getOperationAST(result);
-        if (operationAST?.operation === "subscription") {
-          // If it's a subscription, simply return without modifying the result
-          return;
-        }
+        const hasSubscription = (result.definitions as DefinitionNode[]).some(
+          def => def.kind === Kind.OPERATION_DEFINITION && def.operation === 'subscription',
+        );
 
         // Existing logic for non-subscription operations
-        if (!originalDocumentMap.has(result) && result.kind === Kind.DOCUMENT) {
-          const newDocument = addTypeNameToDocument(result);
-          replaceParseResult(newDocument);
+        if (!hasSubscription) {
+          if (!originalDocumentMap.has(result) && result.kind === Kind.DOCUMENT) {
+            const newDocument = addTypeNameToDocument(result);
+            replaceParseResult(newDocument);
+          }
         }
       };
     },

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -261,6 +261,14 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   return {
     onParse() {
       return ({ result, replaceParseResult }) => {
+        // Check if the operation is a subscription
+        const operationAST = getOperationAST(result);
+        if (operationAST?.operation === "subscription") {
+          // If it's a subscription, simply return without modifying the result
+          return;
+        }
+
+        // Existing logic for non-subscription operations
         if (!originalDocumentMap.has(result) && result.kind === Kind.DOCUMENT) {
           const newDocument = addTypeNameToDocument(result);
           replaceParseResult(newDocument);

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -2993,6 +2993,40 @@ describe('useResponseCache', () => {
     });
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should work with subscriptions', async () => {
+    jest.useFakeTimers();
+
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          comment: String!
+        }
+
+        type Subscription {
+          comment: String!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          comment: {
+            subscribe: async function* () {
+              yield 'Hello World!';
+            },
+          },
+        },
+      },
+    });
+    const operation = /* GraphQL */ `
+      subscription {
+        comment
+      }
+    `;
+    const testInstance = createTestkit([useResponseCache({ session: () => null })], schema);
+
+    const res = await testInstance.execute(operation);
+    expect(JSON.stringify(res)).not.toContain('only one top level field');
+  });
 });
 
 async function waitForResult(result: any) {

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -2995,8 +2995,6 @@ describe('useResponseCache', () => {
   });
 
   it('should work with subscriptions', async () => {
-    jest.useFakeTimers();
-
     const schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `
         type Query {
@@ -3027,6 +3025,48 @@ describe('useResponseCache', () => {
     const res = await testInstance.execute(operation);
     expect(JSON.stringify(res)).not.toContain('only one top level field');
   });
+});
+
+it('should work with named subscription in combined query and subscription document', async () => {
+  // Setting up the GraphQL schema (same as the provided test case)
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        comment: String!
+      }
+
+      type Subscription {
+        comment: String!
+      }
+    `,
+    resolvers: {
+      Subscription: {
+        comment: {
+          subscribe: async function* () {
+            yield 'Hello World!';
+          },
+        },
+      },
+    },
+  });
+
+  // Defining the GraphQL operation with a named query and subscription
+  const operation = /* GraphQL */ `
+    query Foo {
+      comment
+    }
+
+    subscription Sub {
+      comment
+    }
+  `;
+
+  // Executing the operation (passing the raw GraphQL string directly)
+  const testInstance = createTestkit([useResponseCache({ session: () => null })], schema);
+  const res = await testInstance.execute(operation);
+
+  // Validating the results (This is a generic validation. Adjust based on actual requirements.)
+  expect(JSON.stringify(res)).not.toContain('only one top level field');
 });
 
 async function waitForResult(result: any) {


### PR DESCRIPTION
## Description

The onParse method has been modified to address an issue where it was adding a __typename field to all operations, including subscriptions. This was leading to disruptions in subscriptions as they were not designed to recognize or process this field. To resolve this, a check has been implemented to determine if the call is a subscription before proceeding.

```
[
  {
    "message": "Anonymous Subscription must select only one top level field.",
    "extensions": {
      "http": {
        "spec": true,
        "status": 400
      }
    }
  },
  {
    "message": "Anonymous Subscription must not select an introspection top level field.",
    "extensions": {
      "http": {
        "spec": true,
        "status": 400
      }
    }
  }
]
```

Fixes # (issue)
https://github.com/n1ru4l/envelop/issues/1920

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

[Stackblitz](https://stackblitz.com/edit/node-dazht5?file=src%2Fapp.module.ts)

## How Has This Been Tested?

[Stackblitz](https://stackblitz.com/edit/node-dazht5?file=src%2Fapp.module.ts)

- [x] check if subscription is used with cache

**Test Environment**:

- OS: Windows
- `@envelop/..`: 4
- NodeJS: 18

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

