### PR TITLE
better plugin order when using addPlugin API

### DIFF
--- a/.changeset/thick-walls-agree.md
+++ b/.changeset/thick-walls-agree.md
@@ -1,0 +1,12 @@
+---
+'@envelop/core': major
+---
+
+The `addPlugin` function now insert the plugin in place in the plugin list, leading to a more
+predictable execution order.
+
+**Breaking Change:** This change alter the execution order of plugins. This can break some plugins
+that was relying on the fact the `addPlugin` allowed to push a plugin to the end of the plugin list.
+
+If it is the case, the best fix is to reorder the plugin list and ensure the plugin is in the right
+position, after all its dependencies.

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -106,12 +106,13 @@ export function createEnvelopOrchestrator<PluginsContext extends DefaultContext>
   const contextErrorHandlers: Array<OnContextErrorHandler> = [];
 
   // Iterate all plugins and trigger onPluginInit
-  for (const [i, plugin] of plugins.entries()) {
+  for (let i = 0; i < plugins.length; i++) {
+    const plugin = plugins[i];
     plugin.onPluginInit &&
       plugin.onPluginInit({
         plugins,
         addPlugin: newPlugin => {
-          plugins.push(newPlugin);
+          plugins.splice(i + 1, 0, newPlugin);
         },
         setSchema: modifiedSchema => replaceSchema(modifiedSchema, i),
         registerContextErrorHandler: handler => contextErrorHandlers.push(handler),

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -108,15 +108,17 @@ export function createEnvelopOrchestrator<PluginsContext extends DefaultContext>
   // Iterate all plugins and trigger onPluginInit
   for (let i = 0; i < plugins.length; i++) {
     const plugin = plugins[i];
+    const pluginsToAdd: Plugin[] = [];
     plugin.onPluginInit &&
       plugin.onPluginInit({
         plugins,
         addPlugin: newPlugin => {
-          plugins.splice(i + 1, 0, newPlugin);
+          pluginsToAdd.push(newPlugin);
         },
         setSchema: modifiedSchema => replaceSchema(modifiedSchema, i),
         registerContextErrorHandler: handler => contextErrorHandlers.push(handler),
       });
+    pluginsToAdd.length && plugins.splice(i + 1, 0, ...pluginsToAdd);
   }
 
   // A set of before callbacks defined here in order to allow it to be used later

--- a/packages/core/test/plugin-init.spec.ts
+++ b/packages/core/test/plugin-init.spec.ts
@@ -1,0 +1,41 @@
+import { createTestkit } from '@envelop/testing';
+import { envelop } from '../src/index.js';
+import { useEnvelop } from '../src/plugins/use-envelop.js';
+import { query, schema } from './common.js';
+
+describe('plugin init', () => {
+  describe('addPlugin', () => {
+    it('should call plugins in the correct order', async () => {
+      let callNumber = 0;
+      const createPlugin = (order: number) => ({
+        order,
+        onExecute() {
+          expect(callNumber).toBe(order);
+
+          callNumber++;
+        },
+      });
+
+      const teskit = createTestkit(
+        [
+          createPlugin(0),
+          useEnvelop(
+            envelop({
+              plugins: [createPlugin(1), createPlugin(2)],
+            }),
+          ),
+          useEnvelop(
+            envelop({
+              plugins: [createPlugin(3), createPlugin(4)],
+            }),
+          ),
+          createPlugin(5),
+        ],
+        schema,
+      );
+      await teskit.execute(query, {});
+
+      expect.assertions(6);
+    });
+  });
+});

--- a/packages/core/test/plugin-init.spec.ts
+++ b/packages/core/test/plugin-init.spec.ts
@@ -16,6 +16,7 @@ describe('plugin init', () => {
         },
       });
 
+      //TODO: Add test with nested envelops when the related bug is fixed
       const teskit = createTestkit(
         [
           createPlugin(0),

--- a/packages/core/test/plugin-init.spec.ts
+++ b/packages/core/test/plugin-init.spec.ts
@@ -16,27 +16,33 @@ describe('plugin init', () => {
         },
       });
 
-      //TODO: Add test with nested envelops when the related bug is fixed
       const teskit = createTestkit(
         [
           createPlugin(0),
-          useEnvelop(
-            envelop({
-              plugins: [createPlugin(1), createPlugin(2)],
-            }),
-          ),
-          useEnvelop(
-            envelop({
-              plugins: [createPlugin(3), createPlugin(4)],
-            }),
-          ),
-          createPlugin(5),
+          {
+            onPluginInit({ addPlugin }) {
+              addPlugin(createPlugin(1));
+              addPlugin(createPlugin(2));
+            },
+          },
+          {
+            onPluginInit({ addPlugin }) {
+              addPlugin(createPlugin(3));
+              addPlugin({
+                onPluginInit({ addPlugin }) {
+                  addPlugin(createPlugin(4));
+                },
+              });
+              addPlugin(createPlugin(5));
+            },
+          },
+          createPlugin(6),
         ],
         schema,
       );
       await teskit.execute(query, {});
 
-      expect.assertions(6);
+      expect.assertions(7);
     });
   });
 });


### PR DESCRIPTION
## Description

In Envelop, plugin hooks execution order is most of the time very important. Some plugins can depend on some data a previous plugin put in the context to work properly for example.

Today, the execution order can be a bit tricky to predict because if a plugin rely under the hood on `addPlugin` API, it can push new hooks to the end of the plugin list. It is particularly visible with the `useEnvelop` which insert its plugins at the end of the plugin list, which is a bit confusing and difficult to predict for most of developers.

Here a basic example:
```ts
import baseEnvelop from './shared/envelop'
import useLogger from './logger-plugin'

const getEnveloped = envelop({
  plugins: [
    useEnvelop(baseEnvelop), // <= Can break the logger since it will execute after it while being defined before it
    useLogger(),
  ]
})
```

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

> Since this introduces slight difference in execution order, some things can break in existing code, but it should be rare and visible very quickly.

## How Has This Been Tested?

It passes all the current test suites

## Further comments

This comes in response to multiple issues or support messages we got concerning this exact problem of unexpected execution order.
