### PR TITLE
ignore subscriptions in response cache plugin

### DIFF
--- a/.changeset/flat-masks-tell.md
+++ b/.changeset/flat-masks-tell.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+Fix usage with subscriptions throwing validation error.

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -209,15 +209,15 @@ const originalDocumentMap = new WeakMap<DocumentNode, DocumentNode>();
 const addTypeNameToDocument = memoize1(function addTypeNameToDocument(
   document: DocumentNode,
 ): DocumentNode {
-  if (
-    document.definitions.some(
-      def => def.kind === Kind.OPERATION_DEFINITION && def.operation === 'subscription',
-    )
-  ) {
-    return document;
-  }
   let documentChanged = false;
   const newDocument = visit(document, {
+    OperationDefinition(node) {
+      // Skip subscriptions to avoid adding __typename to subscription's root selection set
+      if (node.operation === 'subscription') {
+        return false;
+      }
+      return node;
+    },
     SelectionSet(node): SelectionSetNode {
       if (
         !node.selections.some(

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -209,6 +209,13 @@ const originalDocumentMap = new WeakMap<DocumentNode, DocumentNode>();
 const addTypeNameToDocument = memoize1(function addTypeNameToDocument(
   document: DocumentNode,
 ): DocumentNode {
+  if (
+    document.definitions.some(
+      def => def.kind === Kind.OPERATION_DEFINITION && def.operation === 'subscription',
+    )
+  ) {
+    return document;
+  }
   let documentChanged = false;
   const newDocument = visit(document, {
     SelectionSet(node): SelectionSetNode {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -247,7 +247,6 @@ export function assertStreamExecutionValue(
   input: ExecutionReturn,
 ): asserts input is AsyncIterableIterator<ExecutionResult> {
   if (!isAsyncIterable(input)) {
-    console.info(input.errors);
     throw new Error('Received single result but expected stream.');
   }
 }


### PR DESCRIPTION
## Description

Response cache plugin adds type names to every selection set in the query documents to allow introspection and TTL calculation. This introduce a validation error when a subscription is used since the root subscription selection set should only contain one field. Since response cache has no sense in the context of subscriptions, it is safe to just ignore subscription documents.

Fixes https://github.com/dotansimha/graphql-yoga/issues/3005

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

