### PR TITLE
fix cache invalidation on mutation when using @defer and @stream

### DIFF
--- a/.changeset/fresh-pants-serve.md
+++ b/.changeset/fresh-pants-serve.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+Handle mutations when using `@defer` or `@stream` directives

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -17,7 +17,6 @@ import {
   Maybe,
   ObjMap,
   OnExecuteDoneHookResult,
-  OnExecuteDoneHookResultOnNextHook,
   Plugin,
 } from '@envelop/core';
 import {
@@ -190,20 +189,20 @@ export function defaultGetDocumentString(executionArgs: ExecutionArgs): string {
 
 export type ResponseCacheExtensions =
   | {
-    hit: true;
-  }
+      hit: true;
+    }
   | {
-    hit: false;
-    didCache: false;
-  }
+      hit: false;
+      didCache: false;
+    }
   | {
-    hit: false;
-    didCache: true;
-    ttl: number;
-  }
+      hit: false;
+      didCache: true;
+      ttl: number;
+    }
   | {
-    invalidatedEntities: CacheEntityRecord[];
-  };
+      invalidatedEntities: CacheEntityRecord[];
+    };
 
 export type ResponseCacheExecutionResult = ExecutionResult<
   ObjMap<unknown>,
@@ -274,7 +273,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   shouldCacheResult = defaultShouldCacheResult,
   includeExtensionMetadata = typeof process !== 'undefined'
     ? // eslint-disable-next-line dot-notation
-    process.env['NODE_ENV'] === 'development' || !!process.env['DEBUG']
+      process.env['NODE_ENV'] === 'development' || !!process.env['DEBUG']
     : false,
 }: UseResponseCacheParameter<PluginContext>): Plugin<PluginContext> {
   const ignoredTypesMap = new Set<string>(ignoredTypes);

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -3112,19 +3112,20 @@ describe('useResponseCache', () => {
     assertSingleExecutionValue(result);
     expect(result).toEqual({ data: { me: 'me' } });
     expect(spy).toHaveBeenCalledTimes(1);
-    it('should invalidate cache queries using @defer', async () => {
-      const spy = jest.fn(async function* () {
-        yield {
-          id: 1,
-          name: 'User 1',
-          comments: [{ id: 1, text: 'Comment 1 of User 1' }],
-        };
-        yield { id: 2, name: 'User 2', comments: [] };
-        await new Promise(process.nextTick);
-        yield { id: 3, name: 'User 3', comments: [] };
-      });
-      const schema = makeExecutableSchema({
-        typeDefs: /* GraphQL */ `
+  });
+  it('should invalidate cache queries using @defer', async () => {
+    const spy = jest.fn(async function* () {
+      yield {
+        id: 1,
+        name: 'User 1',
+        comments: [{ id: 1, text: 'Comment 1 of User 1' }],
+      };
+      yield { id: 2, name: 'User 2', comments: [] };
+      await new Promise(process.nextTick);
+      yield { id: 3, name: 'User 3', comments: [] };
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
         directive @defer on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
         type Query {
@@ -3147,27 +3148,27 @@ describe('useResponseCache', () => {
           text: String!
         }
       `,
-        resolvers: {
-          Mutation: {
-            updateUser: () => ({ id: 3, name: 'User 3', comments: [] }),
-          },
-          Query: {
-            users: spy,
-          },
+      resolvers: {
+        Mutation: {
+          updateUser: () => ({ id: 3, name: 'User 3', comments: [] }),
         },
-      });
+        Query: {
+          users: spy,
+        },
+      },
+    });
 
-      const testInstance = createTestkit(
-        envelop({
-          plugins: [
-            useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
-            useSchema(cloneSchema(schema)),
-            useResponseCache({ session: () => null, includeExtensionMetadata: true }),
-          ],
-        }),
-      );
+    const testInstance = createTestkit(
+      envelop({
+        plugins: [
+          useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+          useSchema(cloneSchema(schema)),
+          useResponseCache({ session: () => null, includeExtensionMetadata: true }),
+        ],
+      }),
+    );
 
-      const query = /* GraphQL */ `
+    const query = /* GraphQL */ `
       query test {
         users {
           id
@@ -3176,10 +3177,10 @@ describe('useResponseCache', () => {
       }
     `;
 
-      await testInstance.execute(query);
-      console.log(
-        await waitForResult(
-          testInstance.execute(/* GraphQL */ `
+    await testInstance.execute(query);
+    console.log(
+      await waitForResult(
+        testInstance.execute(/* GraphQL */ `
           mutation {
             updateUser(id: "3") {
               id
@@ -3192,11 +3193,10 @@ describe('useResponseCache', () => {
             }
           }
         `),
-        ),
-      );
-      await testInstance.execute(query);
-      expect(spy).toHaveBeenCalledTimes(2);
-    });
+      ),
+    );
+    await testInstance.execute(query);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   async function waitForResult(result: any) {
@@ -3211,3 +3211,4 @@ describe('useResponseCache', () => {
 
     return result;
   }
+});

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -3112,17 +3112,102 @@ describe('useResponseCache', () => {
     assertSingleExecutionValue(result);
     expect(result).toEqual({ data: { me: 'me' } });
     expect(spy).toHaveBeenCalledTimes(1);
+    it('should invalidate cache queries using @defer', async () => {
+      const spy = jest.fn(async function* () {
+        yield {
+          id: 1,
+          name: 'User 1',
+          comments: [{ id: 1, text: 'Comment 1 of User 1' }],
+        };
+        yield { id: 2, name: 'User 2', comments: [] };
+        await new Promise(process.nextTick);
+        yield { id: 3, name: 'User 3', comments: [] };
+      });
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+        directive @defer on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        type Query {
+          users: [User!]!
+        }
+
+        type Mutation {
+          updateUser(id: ID!): User!
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          comments: [Comment!]!
+          recentComment: Comment
+        }
+
+        type Comment {
+          id: ID!
+          text: String!
+        }
+      `,
+        resolvers: {
+          Mutation: {
+            updateUser: () => ({ id: 3, name: 'User 3', comments: [] }),
+          },
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        envelop({
+          plugins: [
+            useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+            useSchema(cloneSchema(schema)),
+            useResponseCache({ session: () => null, includeExtensionMetadata: true }),
+          ],
+        }),
+      );
+
+      const query = /* GraphQL */ `
+      query test {
+        users {
+          id
+          name
+        }
+      }
+    `;
+
+      await testInstance.execute(query);
+      console.log(
+        await waitForResult(
+          testInstance.execute(/* GraphQL */ `
+          mutation {
+            updateUser(id: "3") {
+              id
+              ... on User @defer {
+                comments {
+                  id
+                  text
+                }
+              }
+            }
+          }
+        `),
+        ),
+      );
+      await testInstance.execute(query);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
   });
-});
 
-async function waitForResult(result: any) {
-  result = await result;
-  if (result.next) {
-    let res = [];
-    for await (const r of result) {
-      res.push(r);
+  async function waitForResult(result: any) {
+    result = await result;
+    if (result.next) {
+      let res = [];
+      for await (const r of result) {
+        res.push(r);
+      }
+      return res;
     }
-  }
 
-  return result;
-}
+    return result;
+  }


### PR DESCRIPTION
## Description

Response cache plugin supports `@defer` and `@stream` directives, but it was handling them only for queries, not for mutations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
