### PR TITLE
fix cache invalidations when result contains empty values

### DIFF
--- a/.changeset/hungry-lies-rescue.md
+++ b/.changeset/hungry-lies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+Fix cache invalidations when result contains empty values


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes #1953 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Issue #1953 contains most relevant information, also I added a new test `purges cached empty query operation execution result via imperative cache.invalidate api using typename`.

**Test Environment**:

- OS: MacOS
- `@envelop/...`:
- NodeJS: 18.16.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This might as well just be a draft. I'm not sure if I need to follow the `CONTRIBUTING.md` for drafts. Let me know if this is useful or not.
