### PR TITLE
[response-cache] automatically add entity id to document

### DIFF
--- a/.changeset/early-tigers-lie.md
+++ b/.changeset/early-tigers-lie.md
@@ -1,0 +1,6 @@
+---
+'@envelop/response-cache': minor
+---
+
+Automatically add the entities id to the request document. This change allows the plugin to not
+require anymore each query to carefuly include all keys of all entities.

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -294,15 +294,14 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           }
 
           if (cacheControlDirective) {
-            const schemaCoordinate = `${typeName}.${fieldName}`;
             const cacheControlAnnotations = getDirective(schema, fieldConfig, 'cacheControl');
             cacheControlAnnotations?.forEach(cacheControl => {
               const ttl = cacheControl.maxAge * 1000;
               if (ttl != null) {
-                ttlPerSchemaCoordinate[schemaCoordinate] = ttl;
+                ttlPerSchemaCoordinate[schemaCoordinates] = ttl;
               }
               if (cacheControl.scope) {
-                scopePerSchemaCoordinate[schemaCoordinate] = cacheControl.scope;
+                scopePerSchemaCoordinate[schemaCoordinates] = cacheControl.scope;
               }
             });
           }

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -280,6 +280,115 @@ describe('useResponseCache', () => {
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
+  it('purges the cached query operation execution result upon executing a mutation that invalidates resources without having the id in the request', async () => {
+    const spy = jest.fn(() => [
+      {
+        id: 1,
+        name: 'User 1',
+        comments: [
+          {
+            id: 1,
+            text: 'Comment 1 of User 1',
+          },
+        ],
+      },
+      {
+        id: 2,
+        name: 'User 2',
+        comments: [
+          {
+            id: 2,
+            text: 'Comment 2 of User 2',
+          },
+        ],
+      },
+    ]);
+
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          users: [User!]!
+        }
+
+        type Mutation {
+          updateUser(id: ID!): User!
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          comments: [Comment!]!
+          recentComment: Comment
+        }
+
+        type Comment {
+          id: ID!
+          text: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: spy,
+        },
+        Mutation: {
+          updateUser(_, { id }) {
+            return {
+              id,
+              name: `User ${id}`,
+            };
+          },
+        },
+      },
+    });
+
+    const testInstance = createTestkit(
+      [useResponseCache({ session: () => null, includeExtensionMetadata: true })],
+      schema,
+    );
+
+    const query = /* GraphQL */ `
+      query test {
+        users {
+          name
+          comments {
+            id
+            text
+          }
+        }
+      }
+    `;
+
+    let result = await testInstance.execute(query);
+    assertSingleExecutionValue(result);
+    expect(result.extensions?.responseCache).toEqual({ hit: false, didCache: true, ttl: Infinity });
+    result = await testInstance.execute(query);
+    assertSingleExecutionValue(result);
+    expect(result.extensions?.responseCache).toEqual({ hit: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    result = await testInstance.execute(
+      /* GraphQL */ `
+        mutation it($id: ID!) {
+          updateUser(id: $id) {
+            name
+          }
+        }
+      `,
+      {
+        id: 1,
+      },
+    );
+    assertSingleExecutionValue(result);
+    expect(result?.extensions?.responseCache).toEqual({
+      invalidatedEntities: [{ id: '1', typename: 'User' }],
+    });
+
+    result = await testInstance.execute(query);
+    assertSingleExecutionValue(result);
+    expect(result.extensions?.responseCache).toEqual({ hit: false, didCache: true, ttl: Infinity });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
   it('purges the cached query operation execution result upon executing a mutation that invalidates resources & having useGraphQlJit plugin at the same time', async () => {
     const spy = jest.fn(() => [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: link:../packages/core/dist
       '@envelop/graphql-jit':
         specifier: '*'
-        version: link:../packages/plugins/graphql-jit/dist
+        version: 6.0.5(@envelop/core@packages+core+dist)(graphql@16.6.0)
       '@envelop/parser-cache':
         specifier: '*'
         version: link:../packages/plugins/parser-cache/dist
@@ -4384,6 +4384,20 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
+
+  /@envelop/graphql-jit@6.0.5(@envelop/core@packages+core+dist)(graphql@16.6.0):
+    resolution: {integrity: sha512-yrgZslAtOBPPfJlW4orT5Ge/k1gSy1gn/1QDNcPVv/6lprbHYaC/QXAo5WdHxSA0KYgzxqYOSX1jnSQjMDkOWA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@envelop/core': ^4.0.3
+      graphql: 16.6.0
+    dependencies:
+      '@envelop/core': link:packages/core/dist
+      graphql: 16.6.0
+      graphql-jit: 0.8.0(graphql@16.6.0)
+      lru-cache: 10.0.0
+      tslib: 2.6.2
+    dev: false
 
   /@esbuild/android-arm64@0.17.7:
     resolution: {integrity: sha512-fOUBZvcbtbQJIj2K/LMKcjULGfXLV9R4qjXFsi3UuqFhIRJHz0Fp6kFjsMFI6vLuPrfC5G9Dmh+3RZOrSKY2Lg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: link:../packages/core/dist
       '@envelop/graphql-jit':
         specifier: '*'
-        version: 6.0.5(@envelop/core@packages+core+dist)(graphql@16.6.0)
+        version: link:../packages/plugins/graphql-jit/dist
       '@envelop/parser-cache':
         specifier: '*'
         version: link:../packages/plugins/parser-cache/dist
@@ -4384,20 +4384,6 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
-
-  /@envelop/graphql-jit@6.0.5(@envelop/core@packages+core+dist)(graphql@16.6.0):
-    resolution: {integrity: sha512-yrgZslAtOBPPfJlW4orT5Ge/k1gSy1gn/1QDNcPVv/6lprbHYaC/QXAo5WdHxSA0KYgzxqYOSX1jnSQjMDkOWA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@envelop/core': ^4.0.3
-      graphql: 16.6.0
-    dependencies:
-      '@envelop/core': link:packages/core/dist
-      graphql: 16.6.0
-      graphql-jit: 0.8.0(graphql@16.6.0)
-      lru-cache: 10.0.0
-      tslib: 2.6.2
-    dev: false
 
   /@esbuild/android-arm64@0.17.7:
     resolution: {integrity: sha512-fOUBZvcbtbQJIj2K/LMKcjULGfXLV9R4qjXFsi3UuqFhIRJHz0Fp6kFjsMFI6vLuPrfC5G9Dmh+3RZOrSKY2Lg==}


### PR DESCRIPTION
## Description

Since the cache rely on entity id to link entity to cached response, the id needs to be part of the selection of each composite type.

We have the same requirement for the `__typeName`, which is automatically added to the document to avoid missing this field.

This PR aims to do the same thing with the id field.

Fixes #1969

## Type of change

- [x] New feature (non-breaking change which adds functionality)
