### PR TITLE
always eagerly check if cache is enable for the current request

### DIFF
--- a/.changeset/strong-eagles-agree.md
+++ b/.changeset/strong-eagles-agree.md
@@ -1,0 +1,12 @@
+---
+'@envelop/response-cache': major
+---
+
+The `enable` parameter now allows to entirely disable caching. It is checked eagerly and disables
+all cache related processing.
+
+**Breaking Change:**
+
+Previously, `enable` was only controlling cache reading. This means that previously, the automatic
+cache invalidation was still working even with `enable` returning false, which is no longer the
+case. The alternative is to cautiously invalidate data in the related resolvers.

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -22,6 +22,7 @@ import {
   getDirective,
   MapperKind,
   mapSchema,
+  memoize1,
   memoize4,
   mergeIncrementalResult,
 } from '@graphql-tools/utils';
@@ -284,6 +285,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 }: UseResponseCacheParameter<PluginContext>): Plugin<PluginContext> {
   const ignoredTypesMap = new Set<string>(ignoredTypes);
   const typePerSchemaCoordinateMap = new Map<string, string[]>();
+  enabled = enabled ? memoize1(enabled) : enabled;
 
   // never cache Introspections
   ttlPerSchemaCoordinate = { 'Query.__schema': 0, ...ttlPerSchemaCoordinate };

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -228,7 +228,6 @@ describe('useResponseCache', () => {
     `;
     await testInstance.execute(query);
     await testInstance.execute(query);
-    console.log(spy.mock.calls);
     expect(spy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Description

The `enabled` parameter allows the user to disabled the cache at a request level based on the context. This give the user fine grain control of the cache behaviour.

But the current implementation only allow to disabled **reading** from the cache. The rest of the pipeline is still executed, the request result will still be written to the cache, and it will still invalidate the cache.

This PR aims to modify this behaviour by using `enabled` to entirely disable the cache. For this, I check as eagerly as possible the `enabled` function to stop the cache related processing as soon as possible.

Fixes #1963 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## More Context

I'm not sure if I should entirely disable the cache, or if we should still always do the automatic invalidation. Or perhaps having 2 options to control this 2 features separately ?