### PR TITLE
Support introspection

### DIFF
--- a/.changeset/purple-zoos-cry.md
+++ b/.changeset/purple-zoos-cry.md
@@ -1,0 +1,5 @@
+---
+'@envelop/on-resolve': minor
+---
+
+Option to skip executing the `onResolve` hook during introspection queries

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -32,6 +32,10 @@ export type OnResolve<PluginContext extends Record<string, any> = {}> = (
   options: OnResolveOptions<PluginContext>,
 ) => PromiseOrValue<AfterResolver | void>;
 
+export type UseOnResolveOptions = {
+  introspection: Boolean;
+};
+
 /**
  * Wraps the provided schema by hooking into the resolvers of every field.
  *
@@ -39,7 +43,7 @@ export type OnResolve<PluginContext extends Record<string, any> = {}> = (
  */
 export function useOnResolve<PluginContext extends Record<string, any> = {}>(
   onResolve: OnResolve<PluginContext>,
-  excludeIntrospection = true,
+  opts?: UseOnResolveOptions,
 ): Plugin<PluginContext> {
   const hasWrappedResolveSymbol = Symbol('hasWrappedResolve');
   return {
@@ -48,7 +52,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       if (!schema) return; // nothing to do if schema is missing
 
       for (const type of Object.values(schema.getTypeMap())) {
-        if (!(excludeIntrospection && isIntrospectionType(type)) && isObjectType(type)) {
+        if ((opts?.introspection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if (field[hasWrappedResolveSymbol]) continue;
 

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -33,7 +33,7 @@ export type OnResolve<PluginContext extends Record<string, any> = {}> = (
 ) => PromiseOrValue<AfterResolver | void>;
 
 export type UseOnResolveOptions = {
-  introspection: Boolean;
+  skipIntrospection: boolean;
 };
 
 /**
@@ -43,7 +43,7 @@ export type UseOnResolveOptions = {
  */
 export function useOnResolve<PluginContext extends Record<string, any> = {}>(
   onResolve: OnResolve<PluginContext>,
-  opts?: UseOnResolveOptions,
+  opts: UseOnResolveOptions = { skipIntrospection: true },
 ): Plugin<PluginContext> {
   const hasWrappedResolveSymbol = Symbol('hasWrappedResolve');
   return {
@@ -52,7 +52,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       if (!schema) return; // nothing to do if schema is missing
 
       for (const type of Object.values(schema.getTypeMap())) {
-        if ((opts?.introspection || !isIntrospectionType(type)) && isObjectType(type)) {
+        if ((opts?.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if (field[hasWrappedResolveSymbol]) continue;
 

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -33,6 +33,11 @@ export type OnResolve<PluginContext extends Record<string, any> = {}> = (
 ) => PromiseOrValue<AfterResolver | void>;
 
 export type UseOnResolveOptions = {
+  /**
+   * Skip executing the `onResolve` hook on introspection queries.
+   *
+   * @default true
+   */
   skipIntrospection: boolean;
 };
 

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -57,7 +57,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       if (!schema) return; // nothing to do if schema is missing
 
       for (const type of Object.values(schema.getTypeMap())) {
-        if ((opts?.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
+        if ((!opts.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if (field[hasWrappedResolveSymbol]) continue;
 

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -39,6 +39,7 @@ export type OnResolve<PluginContext extends Record<string, any> = {}> = (
  */
 export function useOnResolve<PluginContext extends Record<string, any> = {}>(
   onResolve: OnResolve<PluginContext>,
+  excludeIntrospection = true,
 ): Plugin<PluginContext> {
   const hasWrappedResolveSymbol = Symbol('hasWrappedResolve');
   return {
@@ -47,7 +48,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       if (!schema) return; // nothing to do if schema is missing
 
       for (const type of Object.values(schema.getTypeMap())) {
-        if (!isIntrospectionType(type) && isObjectType(type)) {
+        if (!(excludeIntrospection && isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if (field[hasWrappedResolveSymbol]) continue;
 

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -48,7 +48,7 @@ describe('useOnResolve', () => {
   it('should invoke the callback for introspection', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit([useOnResolve(onResolveFn, { introspection: true })], schema);
+    const testkit = createTestkit([useOnResolve(onResolveFn, { skipIntrospection: true })], schema);
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 
@@ -74,7 +74,10 @@ describe('useOnResolve', () => {
   it('should not invoke the callback for introspection when disabled', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit([useOnResolve(onResolveFn, { introspection: false })], schema);
+    const testkit = createTestkit(
+      [useOnResolve(onResolveFn, { skipIntrospection: false })],
+      schema,
+    );
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -23,7 +23,7 @@ describe('useOnResolve', () => {
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
     const testkit = createTestkit([useOnResolve(onResolveFn)], schema);
 
-    await testkit.execute('{ value1, value2 }');
+    await testkit.execute('{ test: value1, test1: value2 }');
 
     expect(onResolveFn).toBeCalledTimes(2);
     expect(onResolveDoneFn).toBeCalledTimes(2);
@@ -48,7 +48,7 @@ describe('useOnResolve', () => {
   it('should invoke the callback for introspection', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit([useOnResolve(onResolveFn, false)], schema);
+    const testkit = createTestkit([useOnResolve(onResolveFn, { introspection: true })], schema);
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 
@@ -74,7 +74,7 @@ describe('useOnResolve', () => {
   it('should not invoke the callback for introspection when disabled', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit([useOnResolve(onResolveFn)], schema);
+    const testkit = createTestkit([useOnResolve(onResolveFn, { introspection: false })], schema);
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -45,10 +45,13 @@ describe('useOnResolve', () => {
     }
   });
 
-  it('should invoke the callback for introspection', async () => {
+  it('should invoke the callback for introspection when not skipping', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit([useOnResolve(onResolveFn, { skipIntrospection: true })], schema);
+    const testkit = createTestkit(
+      [useOnResolve(onResolveFn, { skipIntrospection: false })],
+      schema,
+    );
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 
@@ -71,13 +74,10 @@ describe('useOnResolve', () => {
     }
   });
 
-  it('should not invoke the callback for introspection when disabled', async () => {
+  it('should not invoke the callback for introspection when skipping', async () => {
     const onResolveDoneFn = jest.fn();
     const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
-    const testkit = createTestkit(
-      [useOnResolve(onResolveFn, { skipIntrospection: false })],
-      schema,
-    );
+    const testkit = createTestkit([useOnResolve(onResolveFn, { skipIntrospection: true })], schema);
 
     await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
 

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -45,6 +45,43 @@ describe('useOnResolve', () => {
     }
   });
 
+  it('should invoke the callback for introspection', async () => {
+    const onResolveDoneFn = jest.fn();
+    const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
+    const testkit = createTestkit([useOnResolve(onResolveFn, false)], schema);
+
+    await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
+
+    expect(onResolveFn).toBeCalledTimes(2);
+    expect(onResolveDoneFn).toBeCalledTimes(2);
+
+    let i = 0;
+    for (const field of ['queryType', 'name']) {
+      expect(onResolveFn.mock.calls[i][0].context).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].root).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].args).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].info).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].info.fieldName).toBe(field);
+      expect(onResolveFn.mock.calls[i][0].resolver).toBeInstanceOf(Function);
+      expect(onResolveFn.mock.calls[i][0].replaceResolver).toBeInstanceOf(Function);
+
+      expect(onResolveDoneFn.mock.calls[i][0].setResult).toBeInstanceOf(Function);
+
+      i++;
+    }
+  });
+
+  it('should not invoke the callback for introspection when disabled', async () => {
+    const onResolveDoneFn = jest.fn();
+    const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
+    const testkit = createTestkit([useOnResolve(onResolveFn)], schema);
+
+    await testkit.execute('{ __schema{ ... on __Schema{ queryType { name } } } }');
+
+    expect(onResolveFn).toBeCalledTimes(0);
+    expect(onResolveDoneFn).toBeCalledTimes(0);
+  });
+
   it('should replace the result using the after hook', async () => {
     const testkit = createTestkit(
       [


### PR DESCRIPTION
## Description

Support introspection types in useOnResolve, to be backwards compatible make it an option and disabled by default.

Fixes # [1981](https://github.com/n1ru4l/envelop/issues/1981)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Unit tested

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

