### PR TITLE
remove mode:prom-tracing benchmark, not relevant anymore

### DIFF
--- a/benchmark/app.js
+++ b/benchmark/app.js
@@ -99,24 +99,6 @@ const envelopsMap = {
     ],
     enableInternalTracing: true,
   }),
-  'prom-tracing': envelop({
-    plugins: [
-      useEngine(GraphQLJS),
-      useSchema(createSchema()),
-      useParserCache(),
-      useValidationCache(),
-      usePrometheus({
-        contextBuilding: true,
-        deprecatedFields: true,
-        errors: true,
-        execute: true,
-        parse: true,
-        resolvers: true,
-        validate: true,
-      }),
-    ],
-    enableInternalTracing: true,
-  }),
 };
 
 const app = fastify();

--- a/benchmark/k6.js
+++ b/benchmark/k6.js
@@ -74,18 +74,6 @@ export const options = buildOptions({
     envelop_total: ['p(95)<=1'],
     event_loop_lag: ['avg==0', 'p(99)==0'],
   },
-  'prom-tracing': {
-    no_errors: ['rate>0.98'],
-    expected_result: ['rate>0.98'],
-    http_req_duration: ['p(95)<=40'],
-    graphql_execute: ['p(95)<=6'],
-    graphql_context: ['p(95)<=1'],
-    graphql_validate: ['p(95)<=1'],
-    graphql_parse: ['p(95)<=1'],
-    envelop_init: ['p(95)<=1'],
-    envelop_total: ['p(95)<=6'],
-    event_loop_lag: ['avg==0', 'p(99)==0'],
-  },
   'envelop-cache-and-no-internal-tracing': {
     no_errors: ['rate>0.98'],
     expected_result: ['rate>0.98'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,7 +1393,7 @@ importers:
   packages/plugins/response-cache-redis:
     dependencies:
       '@envelop/response-cache':
-        specifier: ^5.3.2
+        specifier: ^5.5.0
         version: link:../response-cache/dist
       ioredis:
         specifier: ^4.27.9


### PR DESCRIPTION
Remove flaky benchmark, since it's not relevant anymore.