### PR TITLE
doc: Remove async validation from useGenericAuth docs

### DIFF
--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -198,9 +198,9 @@ Then, in your resolvers, you can execute the check method based on your needs:
 const resolvers = {
   Query: {
     me: async (root, args, context) => {
-      const validationError = context.validateUser();
+      const validationError = context.validateUser()
       if (validationError) {
-        throw validationError;
+        throw validationError
       }
 
       const currentUser = context.currentUser
@@ -389,11 +389,7 @@ validation.
 ```ts
 import { ValidateUserFn } from '@envelop/generic-auth'
 
-const validateUser: ValidateUserFn<UserType> = ({
-  user,
-  executionArgs,
-  fieldAuthExtension
-}) => {
+const validateUser: ValidateUserFn<UserType> = ({ user, executionArgs, fieldAuthExtension }) => {
   if (!user) {
     return new Error(`Unauthenticated!`)
   }

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -175,7 +175,7 @@ type UserType = {
 const resolveUserFn: ResolveUserFn<UserType> = async context => {
   /* ... */
 }
-const validateUser: ValidateUserFn<UserType> = async params => {
+const validateUser: ValidateUserFn<UserType> = params => {
   /* ... */
 }
 
@@ -198,7 +198,11 @@ Then, in your resolvers, you can execute the check method based on your needs:
 const resolvers = {
   Query: {
     me: async (root, args, context) => {
-      await context.validateUser()
+      const validationError = context.validateUser();
+      if (validationError) {
+        throw validationError;
+      }
+
       const currentUser = context.currentUser
 
       return currentUser
@@ -292,7 +296,7 @@ the `protect-all` and `protect-granular` mode:
 import { GraphQLError } from 'graphql'
 import { ValidateUserFn } from '@envelop/generic-auth'
 
-const validateUser: ValidateUserFn<UserType> = async ({ user }) => {
+const validateUser: ValidateUserFn<UserType> = ({ user }) => {
   // Now you can use the 3rd parameter to implement custom logic for user validation, with access
   // to the resolver data and information.
 
@@ -321,7 +325,7 @@ Then, you use the `directiveNode` parameter to check the arguments:
 ```ts
 import { ValidateUserFn } from '@envelop/generic-auth'
 
-const validateUser: ValidateUserFn<UserType> = async ({ user, fieldAuthDirectiveNode }) => {
+const validateUser: ValidateUserFn<UserType> = ({ user, fieldAuthDirectiveNode }) => {
   // Now you can use the fieldAuthDirectiveNode parameter to implement custom logic for user validation, with access
   // to the resolver auth directive arguments.
 
@@ -385,7 +389,7 @@ validation.
 ```ts
 import { ValidateUserFn } from '@envelop/generic-auth'
 
-const validateUser: ValidateUserFn<UserType> = async ({
+const validateUser: ValidateUserFn<UserType> = ({
   user,
   executionArgs,
   fieldAuthExtension
@@ -397,7 +401,7 @@ const validateUser: ValidateUserFn<UserType> = async ({
   // You have access to the object define in the resolver tree, allowing to define any custom logic you want.
   const validate = fieldAuthExtension?.validate
   if (validate) {
-    await validate({
+    return validate({
       user,
       variables: executionArgs.variableValues,
       context: executionArgs.contextValue


### PR DESCRIPTION
## Description

Removes any mention of asynchronous validation from the documentation as it is not actually possible, and results in typescript errors.

Fixes #2021

## Type of change

- [x] Documentation change

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
