### PR TITLE
export sha256 internal implementation

### DIFF
--- a/.changeset/funny-dogs-tease.md
+++ b/.changeset/funny-dogs-tease.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+Expose `hashSHA256` sha256 implementation to ease the customization of cache key factory.

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -1,3 +1,4 @@
 export * from './in-memory-cache.js';
 export * from './plugin.js';
 export * from './cache.js';
+export * from './hash-sha256.js';


### PR DESCRIPTION
## Description

To be able to customise the cache key, a user can want to change the data to be included in the hash. To ease this use case, this PR exposes the internal sha256 implementation.

Linked to https://github.com/dotansimha/graphql-yoga/issues/3035

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
