### PR TITLE
(feat): Add @envelop/response-cache-cloudflare-kv

### DIFF
--- a/.changeset/kind-rivers-do.md
+++ b/.changeset/kind-rivers-do.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache-cloudflare-kv': minor
+---
+
+Initial release

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,17 +6,33 @@ const ROOT_DIR = __dirname;
 const TSCONFIG = resolve(ROOT_DIR, 'tsconfig.json');
 const tsconfig = require(TSCONFIG);
 
+/** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'node',
   rootDir: ROOT_DIR,
-  restoreMocks: true,
+  projects: [
+    {
+      displayName: 'Standard Tests',
+      testMatch: [
+        '<rootDir>/**/*.spec.ts',
+        '<rootDir>/**/*.spec.js',
+        '<rootDir>/**/*.test.ts',
+        '<rootDir>/**/*.test.js',
+      ],
+      testPathIgnorePatterns: ['<rootDir>/packages/plugins/response-cache-cloudflare-kv'],
+      restoreMocks: true,
+      modulePathIgnorePatterns: ['dist', 'test-assets', 'test-files', 'fixtures', '.bob'],
+      moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths, {
+        prefix: `${ROOT_DIR}/`,
+      }),
+      cacheDirectory: resolve(ROOT_DIR, `${CI ? '' : 'node_modules/'}.cache/jest`),
+      resolver: 'bob-the-bundler/jest-resolver',
+      setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
+    },
+    // Cloudflare plugin tests need very different build settings
+    // giving Jest a string as project name will make it rely on jest.config files in the package subfolder
+    '<rootDir>/packages/plugins/response-cache-cloudflare-kv',
+  ],
   reporters: ['default'],
-  modulePathIgnorePatterns: ['dist', 'test-assets', 'test-files', 'fixtures', '.bob'],
-  moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths, {
-    prefix: `${ROOT_DIR}/`,
-  }),
   collectCoverage: false,
-  cacheDirectory: resolve(ROOT_DIR, `${CI ? '' : 'node_modules/'}.cache/jest`),
-  resolver: 'bob-the-bundler/jest-resolver',
-  setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "prettier": "prettier --cache --ignore-path .prettierignore --write --list-different .",
     "release": "pnpm build && changeset publish",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "jest --coverage",
     "test:core": "jest ./packages/core --coverage",
     "ts:check": "tsc --noEmit"

--- a/packages/plugins/response-cache-cloudflare-kv/CHANGELOG.md
+++ b/packages/plugins/response-cache-cloudflare-kv/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @envelop/response-cache-cloudflare-kv
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release

--- a/packages/plugins/response-cache-cloudflare-kv/CHANGELOG.md
+++ b/packages/plugins/response-cache-cloudflare-kv/CHANGELOG.md
@@ -1,7 +1,1 @@
 # @envelop/response-cache-cloudflare-kv
-
-## 0.1.0
-
-### Minor Changes
-
-- Initial release

--- a/packages/plugins/response-cache-cloudflare-kv/README.md
+++ b/packages/plugins/response-cache-cloudflare-kv/README.md
@@ -24,9 +24,9 @@ In order to use the Cloudflare KV cache, you need to:
   options. See the example below.
 
 ```ts
-import { createKvCache } from 'envelop-response-cache-cloudflare-kv'
 import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'
 import { useResponseCache } from '@envelop/response-cache'
+import { createKvCache } from '@envelop/response-cache-cloudflare-kv'
 import { resolvers } from './graphql-schema/resolvers.generated'
 import { typeDefs } from './graphql-schema/typeDefs.generated'
 

--- a/packages/plugins/response-cache-cloudflare-kv/README.md
+++ b/packages/plugins/response-cache-cloudflare-kv/README.md
@@ -1,0 +1,61 @@
+## `@envelop/response-cache-cloudflare-kv`
+
+- Supports [Cloudflare KV](https://developers.cloudflare.com/kv/) cache for
+  `@envelop/response-cache` plugin
+- Suitable for graphql servers running on [Cloudflare Workers](https://workers.cloudflare.com/)
+
+[Check out the GraphQL Response Cache Guide for more information](https://envelop.dev/docs/guides/adding-a-graphql-response-cache)
+
+## Getting Started
+
+```bash
+yarn add @envelop/response-cache
+yarn add @envelop/response-cache-cloudflare-kv
+```
+
+## Usage Example
+
+In order to use the Cloudflare KV cache, you need to:
+
+- Create a Cloudflare KV namespace
+- Add that namespace to your `wrangler.toml` in order to access it from your worker. Read the
+  [KV docs](https://developers.cloudflare.com/kv/get-started/) to get started.
+- Pass the KV namespace to the `createKvCache` function and set to the `useResponseCache` plugin
+  options. See the example below.
+
+```ts
+import { createKvCache } from 'envelop-response-cache-cloudflare-kv'
+import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'
+import { useResponseCache } from '@envelop/response-cache'
+import { resolvers } from './graphql-schema/resolvers.generated'
+import { typeDefs } from './graphql-schema/typeDefs.generated'
+
+export type Env = {
+  GRAPHQL_RESPONSE_CACHE: KVNamespace
+}
+export type GraphQLContext = YogaInitialContext & Env & ExecutionContext
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const kvCache = createKvCache({
+      KV: env.GRAPHQL_RESPONSE_CACHE,
+      ctx,
+      keyPrefix: 'graphql' // optional
+    })
+
+    const graphqlServer = createYoga<GraphQLContext>({
+      schema: createSchema({ typeDefs, resolvers }),
+      plugins: [
+        useResponseCache({
+          cache: kvCache,
+          session: () => null,
+          includeExtensionMetadata: true,
+          ttl: 1000 * 10 // 10 seconds
+        })
+      ]
+    })
+
+    return graphqlServer.fetch(request, env, ctx)
+  }
+}
+```

--- a/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
+++ b/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
@@ -8,7 +8,6 @@ const TSCONFIG = resolve(ROOT_DIR, '../../../', 'tsconfig.json');
 const PROJECT_ROOT = resolve(ROOT_DIR, '../../../');
 const tsconfig = require(TSCONFIG);
 
-// eslint-disable-next-line import/no-default-export
 /** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'miniflare',

--- a/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
+++ b/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
@@ -33,4 +33,5 @@ module.exports = {
     wranglerConfigPath: `${resolve(ROOT_DIR)}/wrangler.jest.toml`,
     bindings: { ENVIRONMENT: 'testing' },
   },
+  resolver: 'bob-the-bundler/jest-resolver',
 };

--- a/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
+++ b/packages/plugins/response-cache-cloudflare-kv/jest.config.cjs
@@ -1,0 +1,37 @@
+const { resolve } = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { pathsToModuleNameMapper } = require('ts-jest');
+
+const CI = !!process.env.CI;
+const ROOT_DIR = __dirname;
+const TSCONFIG = resolve(ROOT_DIR, '../../../', 'tsconfig.json');
+const PROJECT_ROOT = resolve(ROOT_DIR, '../../../');
+const tsconfig = require(TSCONFIG);
+
+// eslint-disable-next-line import/no-default-export
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'miniflare',
+  rootDir: ROOT_DIR,
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths, {
+    prefix: `${PROJECT_ROOT}/`,
+  }),
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+  cacheDirectory: resolve(ROOT_DIR, `${CI ? '' : 'node_modules/'}.cache/jest`),
+  modulePathIgnorePatterns: ['dist'],
+  // Configuration is automatically loaded from `.env`, `package.json` and
+  // `wrangler.toml` files by default, but you can pass any additional Miniflare
+  // API options here:
+  testEnvironmentOptions: {
+    wranglerConfigPath: `${resolve(ROOT_DIR)}/wrangler.jest.toml`,
+    bindings: { ENVIRONMENT: 'testing' },
+  },
+};

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -56,6 +56,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231025.0",
     "@envelop/response-cache": "^6.1.0",
+    "jest-environment-miniflare": "^2.14.1",
+    "ts-jest": "29.1.1",
     "typescript": "^5.2.2"
   },
   "publishConfig": {
@@ -63,6 +65,7 @@
     "access": "public"
   },
   "sideEffects": false,
+  "bob": {},
   "buildOptions": {
     "input": "./src/index.ts"
   },

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/n1ru4l/envelop.git",
-    "directory": "packages/plugins/response-cache-redis"
+    "directory": "packages/plugins/response-cache-cloudflare-kv"
   },
   "author": "Adishwar Rishi <adiswa123@gmail.com>",
   "license": "MIT",

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@envelop/response-cache-cloudflare-kv",
+  "version": "0.1.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/n1ru4l/envelop.git",
+    "directory": "packages/plugins/response-cache-redis"
+  },
+  "author": "Adishwar Rishi <adiswa123@gmail.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/typings/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "default": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./*": {
+      "require": {
+        "types": "./dist/typings/*.d.cts",
+        "default": "./dist/cjs/*.js"
+      },
+      "import": {
+        "types": "./dist/typings/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "default": {
+        "types": "./dist/typings/*.d.ts",
+        "default": "./dist/esm/*.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "typings": "dist/typings/index.d.ts",
+  "peerDependencies": {
+    "@envelop/response-cache": "^6.1.0",
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20231025.0",
+    "@envelop/response-cache": "^6.1.0",
+    "typescript": "^5.2.2"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "sideEffects": false,
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "typescript": {
+    "definition": "dist/typings/index.d.ts"
+  }
+}

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -7,7 +7,10 @@
     "url": "https://github.com/n1ru4l/envelop.git",
     "directory": "packages/plugins/response-cache-cloudflare-kv"
   },
-  "author": "Adishwar Rishi <adiswa123@gmail.com>",
+  "author": {
+    "name": "Adishwar Rishi",
+    "url": "https://github.com/AdiRishi"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"

--- a/packages/plugins/response-cache-cloudflare-kv/src/cache-key.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/cache-key.ts
@@ -1,0 +1,24 @@
+export function buildOperationKey(
+  operationId: string,
+  keyPrefix: string | null | undefined = undefined,
+) {
+  if (keyPrefix) {
+    return `${keyPrefix}:operation:${operationId}`;
+  } else {
+    return `operation:${operationId}`;
+  }
+}
+
+export function buildEntityKey(
+  entityTypename: string,
+  entityId: string | number | undefined = undefined,
+  keyPrefix: string | null | undefined = undefined,
+) {
+  let finalKey = keyPrefix ? `${keyPrefix}:` : '';
+  if (entityId) {
+    finalKey += `entity:${entityTypename}:${entityId}`;
+  } else {
+    finalKey += `entity:${entityTypename}`;
+  }
+  return finalKey;
+}

--- a/packages/plugins/response-cache-cloudflare-kv/src/index.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/index.ts
@@ -1,9 +1,9 @@
 import type { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
 import type { Cache, CacheEntityRecord } from '@envelop/response-cache';
-import { buildOperationKey } from './cache-key';
-import { invalidate } from './invalidate';
-import { set } from './set';
+import { buildOperationKey } from './cache-key.js';
+import { invalidate } from './invalidate.js';
+import { set } from './set.js';
 
 export type KvCacheConfig = {
   /**

--- a/packages/plugins/response-cache-cloudflare-kv/src/index.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/index.ts
@@ -1,0 +1,72 @@
+import type { ExecutionResult } from 'graphql';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { Cache, CacheEntityRecord } from '@envelop/response-cache';
+import { buildOperationKey } from './cache-key';
+import { invalidate } from './invalidate';
+import { set } from './set';
+
+export type KvCacheConfig = {
+  /**
+   * The Cloudflare KV namespace that should be used to store the cache
+   */
+  KV: KVNamespace;
+  /**
+   * The Cloudflare worker execution context. Used to perform non-blocking actions like cache storage and invalidation.
+   */
+  ctx: ExecutionContext;
+  /**
+   *  Defines the length of time in milliseconds that a KV result is cached in the global network location it is accessed from.
+   *
+   * The cacheTTL parameter must be an integer greater than or equal to 60000 (60 seconds), which is the default.
+   */
+  cacheReadTTL?: number;
+  /**
+   * A prefix that should be added to all cache keys
+   */
+  keyPrefix?: string;
+};
+
+/**
+ * Creates a cache object that uses Cloudflare KV to store GraphQL responses.
+ * This cache is optimized for Cloudflare workers and uses the `ctx.waitUntil` method to perform non-blocking actions where possible
+ *
+ * To find out more about how this cache is implemented see https://the-guild.dev/blog/graphql-response-caching-with-envelop
+ *
+ * @param config Modify the behavior of the cache as it pertains to Cloudflare KV
+ * @returns A cache object that can be passed to envelop's `useResponseCache` plugin
+ */
+export function createKvCache(config: KvCacheConfig): Cache {
+  const cache: Cache = {
+    async get(id: string) {
+      const ttlInSeconds = Math.max(Math.floor((config.cacheReadTTL ?? 60000) / 1000), 60); // KV TTL must be at least 60 seconds
+      const kvResponse = await config.KV.get(buildOperationKey(id, config.keyPrefix), {
+        type: 'text',
+        cacheTtl: ttlInSeconds,
+      });
+      if (kvResponse) {
+        return JSON.parse(kvResponse) as ExecutionResult;
+      }
+      return undefined;
+    },
+
+    set(
+      /** id/hash of the operation */
+      id: string,
+      /** the result that should be cached */
+      data: ExecutionResult,
+      /** array of entity records that were collected during execution */
+      entities: Iterable<CacheEntityRecord>,
+      /** how long the operation should be cached (in milliseconds) */
+      ttl: number,
+    ) {
+      // Do not block execution of the worker while caching the result
+      config.ctx.waitUntil(set(id, data, entities, ttl, config));
+    },
+
+    invalidate(entities: Iterable<CacheEntityRecord>) {
+      // Do not block execution of the worker while invalidating the cache
+      config.ctx.waitUntil(invalidate(entities, config));
+    },
+  };
+  return cache;
+}

--- a/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
@@ -11,7 +11,7 @@ export async function invalidate(
   for (const entity of entities) {
     const entityKey = buildEntityKey(entity.typename, entity.id, config.keyPrefix);
 
-    for await (const kvKey of _getAllKvKeysForPrefix(entityKey, config)) {
+    for await (const kvKey of getAllKvKeysForPrefix(entityKey, config)) {
       if (kvKey.metadata?.operationKey) {
         kvPromises.push(config.KV.delete(kvKey.metadata?.operationKey));
         kvPromises.push(config.KV.delete(kvKey.name));
@@ -22,7 +22,7 @@ export async function invalidate(
   await Promise.allSettled(kvPromises);
 }
 
-export async function* _getAllKvKeysForPrefix(prefix: string, config: KvCacheConfig) {
+export async function* getAllKvKeysForPrefix(prefix: string, config: KvCacheConfig) {
   let keyListComplete = false;
   let cursor: string | undefined;
 

--- a/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
@@ -1,6 +1,6 @@
 import type { CacheEntityRecord } from '@envelop/response-cache';
-import type { KvCacheConfig } from '.';
-import { buildEntityKey } from './cache-key';
+import { buildEntityKey } from './cache-key.js';
+import type { KvCacheConfig } from './index.js';
 
 export async function invalidate(
   entities: Iterable<CacheEntityRecord>,

--- a/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/invalidate.ts
@@ -1,0 +1,44 @@
+import type { CacheEntityRecord } from '@envelop/response-cache';
+import type { KvCacheConfig } from '.';
+import { buildEntityKey } from './cache-key';
+
+export async function invalidate(
+  entities: Iterable<CacheEntityRecord>,
+  config: KvCacheConfig,
+): Promise<void> {
+  const kvPromises: Promise<unknown>[] = []; // Collecting all the KV operations so we can await them all at once
+
+  for (const entity of entities) {
+    const entityKey = buildEntityKey(entity.typename, entity.id, config.keyPrefix);
+
+    for await (const kvKey of _getAllKvKeysForPrefix(entityKey, config)) {
+      if (kvKey.metadata?.operationKey) {
+        kvPromises.push(config.KV.delete(kvKey.metadata?.operationKey));
+        kvPromises.push(config.KV.delete(kvKey.name));
+      }
+    }
+  }
+
+  await Promise.allSettled(kvPromises);
+}
+
+export async function* _getAllKvKeysForPrefix(prefix: string, config: KvCacheConfig) {
+  let keyListComplete = false;
+  let cursor: string | undefined;
+
+  do {
+    const kvListResponse = await config.KV.list<{ operationKey: string }>({
+      prefix,
+      cursor,
+    });
+    keyListComplete = kvListResponse.list_complete;
+
+    if (!kvListResponse.list_complete) {
+      cursor = kvListResponse.cursor;
+    }
+
+    for (const keyResult of kvListResponse.keys) {
+      yield keyResult;
+    }
+  } while (!keyListComplete);
+}

--- a/packages/plugins/response-cache-cloudflare-kv/src/set.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/set.ts
@@ -1,0 +1,42 @@
+import type { ExecutionResult } from 'graphql';
+import type { CacheEntityRecord } from '@envelop/response-cache';
+import type { KvCacheConfig } from '.';
+import { buildEntityKey, buildOperationKey } from './cache-key';
+
+export async function set(
+  /** id/hash of the operation */
+  id: string,
+  /** the result that should be cached */
+  data: ExecutionResult,
+  /** array of entity records that were collected during execution */
+  entities: Iterable<CacheEntityRecord>,
+  /** how long the operation should be cached (in milliseconds) */
+  ttl: number,
+  config: KvCacheConfig,
+): Promise<void> {
+  const ttlInSeconds = Math.max(Math.floor(ttl / 1000), 60); // KV TTL must be at least 60 seconds
+  const operationKey = buildOperationKey(id, config.keyPrefix);
+  const operationKeyWithoutPrefix = buildOperationKey(id);
+  const kvPromises: Promise<unknown>[] = []; // Collecting all the KV operations so we can await them all at once
+
+  kvPromises.push(
+    config.KV.put(operationKey, JSON.stringify(data), {
+      expirationTtl: ttlInSeconds,
+      metadata: { operationKey },
+    }),
+  );
+
+  // Store connections between the entities and the operation key
+  // E.g if the entities are User:1 and User:2, we need to know that the operation key is connected to both of them
+  for (const entity of entities) {
+    const entityKey = buildEntityKey(entity.typename, entity.id, config.keyPrefix);
+    kvPromises.push(
+      config.KV.put(`${entityKey}:${operationKeyWithoutPrefix}`, operationKey, {
+        expirationTtl: ttlInSeconds,
+        metadata: { operationKey },
+      }),
+    );
+  }
+
+  await Promise.allSettled(kvPromises);
+}

--- a/packages/plugins/response-cache-cloudflare-kv/src/set.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/set.ts
@@ -1,7 +1,7 @@
 import type { ExecutionResult } from 'graphql';
 import type { CacheEntityRecord } from '@envelop/response-cache';
-import type { KvCacheConfig } from '.';
-import { buildEntityKey, buildOperationKey } from './cache-key';
+import { buildEntityKey, buildOperationKey } from './cache-key.js';
+import type { KvCacheConfig } from './index.js';
 
 export async function set(
   /** id/hash of the operation */

--- a/packages/plugins/response-cache-cloudflare-kv/test/cache-key.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/cache-key.spec.ts
@@ -1,0 +1,42 @@
+import { buildEntityKey, buildOperationKey } from '../src/cache-key';
+
+describe('cacheKey.spec.ts', () => {
+  describe('buildOperationKey', () => {
+    const operationId = '1B9502F92EFA53AFF0AC650794AA79891E4B6900';
+
+    test('should build a key with no prefix', () => {
+      const key = buildOperationKey(operationId);
+      expect(key).toEqual(`operation:${operationId}`);
+    });
+
+    test('should build a key with a prefix', () => {
+      const key = buildOperationKey(operationId, 'prefix');
+      expect(key).toEqual(`prefix:operation:${operationId}`);
+    });
+  });
+
+  describe('buildEntityKey', () => {
+    const entityTypename = 'User';
+    const entityId = '1';
+
+    test('should build a key with no prefix', () => {
+      const key = buildEntityKey(entityTypename, entityId);
+      expect(key).toEqual(`entity:${entityTypename}:${entityId}`);
+    });
+
+    test('should build a key with a prefix', () => {
+      const key = buildEntityKey(entityTypename, entityId, 'prefix');
+      expect(key).toEqual(`prefix:entity:${entityTypename}:${entityId}`);
+    });
+
+    test('should build a key with no entity id and no prefix', () => {
+      const key = buildEntityKey(entityTypename);
+      expect(key).toEqual(`entity:${entityTypename}`);
+    });
+
+    test('should build a key with no entity id and a prefix', () => {
+      const key = buildEntityKey(entityTypename, undefined, 'prefix');
+      expect(key).toEqual(`prefix:entity:${entityTypename}`);
+    });
+  });
+});

--- a/packages/plugins/response-cache-cloudflare-kv/test/cache-key.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/cache-key.spec.ts
@@ -1,4 +1,4 @@
-import { buildEntityKey, buildOperationKey } from '../src/cache-key';
+import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
 
 describe('cacheKey.spec.ts', () => {
   describe('buildOperationKey', () => {

--- a/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
@@ -1,0 +1,83 @@
+import { ExecutionResult } from 'graphql';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { Cache } from '@envelop/response-cache';
+import { buildOperationKey } from '../src/cache-key';
+import { createKvCache, type KvCacheConfig } from '../src/index';
+
+type Env = {
+  ENVIRONMENT: 'testing' | 'development' | 'production';
+  GRAPHQL_RESPONSE_CACHE: KVNamespace;
+};
+
+describe('@envelop/response-cache-cloudflare-kv integration tests', () => {
+  let env: Env;
+  let config: KvCacheConfig;
+  let maxTtl: number;
+  let executionContext: ExecutionContext;
+  let cache: Cache;
+  const dataValue: ExecutionResult<{ key: string }, { extensions: string }> = {
+    errors: [],
+    data: { key: 'value' },
+    extensions: { extensions: 'value' },
+  };
+  const dataKey = '1B9502F92EFA53AFF0AC650794AA79891E4B6900';
+
+  beforeEach(() => {
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    env = getMiniflareBindings<Env>();
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    executionContext = new ExecutionContext();
+    config = {
+      KV: env.GRAPHQL_RESPONSE_CACHE,
+      ctx: executionContext,
+      keyPrefix: 'vitest',
+    };
+    maxTtl = 60 * 1000; // 1 minute
+    cache = createKvCache(config);
+  });
+
+  test('should work with a basic set() and get()', async () => {
+    await cache.set(
+      dataKey,
+      dataValue,
+      [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
+      maxTtl,
+    );
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    await getMiniflareWaitUntil(executionContext);
+
+    const result = await cache.get(dataKey);
+    expect(result).toEqual(dataValue);
+
+    const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+    const operationValue = await env.GRAPHQL_RESPONSE_CACHE.get(operationKey, 'text');
+    expect(operationValue).toBeTruthy();
+    expect(JSON.parse(operationValue!)).toEqual(dataValue);
+  });
+
+  test('should return null when calling get() on a non-existent key', async () => {
+    const result = await cache.get(dataKey);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return null when calling get() on an invalidated key', async () => {
+    await cache.set(
+      dataKey,
+      dataValue,
+      [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
+      maxTtl,
+    );
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    await getMiniflareWaitUntil(executionContext);
+
+    await cache.invalidate([{ typename: 'User' }]);
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    await getMiniflareWaitUntil(executionContext);
+
+    const result = await cache.get(dataKey);
+    expect(result).toBeUndefined();
+
+    const allKeys = await config.KV.list();
+    expect(allKeys.keys.length).toEqual(0);
+  });
+});

--- a/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
@@ -1,8 +1,8 @@
 import { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
 import type { Cache } from '@envelop/response-cache';
-import { buildOperationKey } from '../src/cache-key';
-import { createKvCache, type KvCacheConfig } from '../src/index';
+import { buildOperationKey } from '../src/cache-key.js';
+import { createKvCache, type KvCacheConfig } from '../src/index.js';
 
 type Env = {
   ENVIRONMENT: 'testing' | 'development' | 'production';

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -1,9 +1,9 @@
 import { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
-import { KvCacheConfig } from '../src';
-import { buildEntityKey, buildOperationKey } from '../src/cache-key';
-import { _getAllKvKeysForPrefix, invalidate } from '../src/invalidate';
-import { set } from '../src/set';
+import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
+import { KvCacheConfig } from '../src/index.js';
+import { _getAllKvKeysForPrefix, invalidate } from '../src/invalidate.js';
+import { set } from '../src/set.js';
 
 type Env = {
   ENVIRONMENT: 'testing' | 'development' | 'production';

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -1,0 +1,167 @@
+import { ExecutionResult } from 'graphql';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import { KvCacheConfig } from '../src';
+import { buildEntityKey, buildOperationKey } from '../src/cache-key';
+import { _getAllKvKeysForPrefix, invalidate } from '../src/invalidate';
+import { set } from '../src/set';
+
+type Env = {
+  ENVIRONMENT: 'testing' | 'development' | 'production';
+  GRAPHQL_RESPONSE_CACHE: KVNamespace;
+};
+
+describe('invalidate.test.ts', () => {
+  let env: Env;
+  let maxTtl: number;
+  let executionContext: ExecutionContext;
+  let config: KvCacheConfig;
+  const keyPrefix = 'vitest';
+
+  describe('_getAllKvKeysForPrefix()', () => {
+    beforeEach(() => {
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      env = getMiniflareBindings<Env>();
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      executionContext = new ExecutionContext();
+      config = {
+        KV: env.GRAPHQL_RESPONSE_CACHE,
+        ctx: executionContext,
+        keyPrefix,
+      };
+      maxTtl = 60 * 1000; // 1 minute
+    });
+
+    test('should successfully iterate over a KV namespace with no keys', async () => {
+      // kv cache has no keys at this point
+      const keys = [];
+      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+        keys.push(kvKey);
+      }
+      expect(keys).toEqual([]);
+    });
+
+    test('should successfully iterate over a KV namespace with less than 1000 keys', async () => {
+      // setup kv cache
+      for (let i = 0; i < 500; i++) {
+        await env.GRAPHQL_RESPONSE_CACHE.put(`vitest:entity:User:${i}`, 'value', {
+          metadata: { operationKey: `vitest:operation:${i}` },
+        });
+      }
+
+      const keys = [];
+      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+        keys.push(kvKey);
+        const userId = kvKey.name.split(':')[3];
+        expect(kvKey.metadata).toEqual({
+          operationKey: `vitest:operation:${userId}`,
+        });
+      }
+      expect(keys.length).toEqual(500);
+    });
+
+    test('should successfully iterate over a KV namespace with more than 1000 keys', async () => {
+      // setup kv cache
+      for (let i = 0; i < 1500; i++) {
+        await env.GRAPHQL_RESPONSE_CACHE.put(`vitest:entity:User:${i}`, 'value', {
+          metadata: { operationKey: `vitest:operation:${i}` },
+        });
+      }
+
+      const keys = [];
+      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+        keys.push(kvKey);
+        const indexId = kvKey.name.split(':')[3];
+        expect(kvKey.metadata).toEqual({
+          operationKey: `vitest:operation:${indexId}`,
+        });
+      }
+      expect(keys.length).toEqual(1500);
+    });
+  });
+
+  describe('invalidate()', () => {
+    const dataValue: ExecutionResult<{ key: string }, { extensions: string }> = {
+      errors: [],
+      data: { key: 'value' },
+      extensions: { extensions: 'value' },
+    };
+    const dataKey = '1B9502F92EFA53AFF0AC650794AA79891E4B6900';
+
+    async function collectAllKeys(prefix: string) {
+      const keys = [];
+      for await (const kvKey of _getAllKvKeysForPrefix(prefix, config)) {
+        keys.push(kvKey);
+      }
+      return keys;
+    }
+
+    beforeEach(() => {
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      env = getMiniflareBindings<Env>();
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      executionContext = new ExecutionContext();
+      config = {
+        KV: env.GRAPHQL_RESPONSE_CACHE,
+        ctx: executionContext,
+        keyPrefix,
+      };
+      maxTtl = 60 * 1000; // 1 minute
+    });
+
+    test('should invalidate all entity keys given only a type', async () => {
+      await set(
+        dataKey,
+        dataValue,
+        [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
+        maxTtl,
+        config,
+      );
+
+      await invalidate([{ typename: 'User' }], config);
+
+      const allKeys = await collectAllKeys(keyPrefix);
+      expect(allKeys.length).toEqual(0);
+    });
+
+    test('should invalidate only given entity and operation key', async () => {
+      await set(
+        dataKey,
+        dataValue,
+        [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
+        maxTtl,
+        config,
+      );
+
+      await invalidate([{ typename: 'User', id: 1 }], config);
+
+      const allKeys = await collectAllKeys(keyPrefix);
+      expect(allKeys.length).toEqual(2);
+
+      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      const operationKeyWithoutPrefix = buildOperationKey(dataKey);
+      const entityTypeKey = buildEntityKey('User', undefined, config.keyPrefix);
+      const entityKey1 = buildEntityKey('User', 1, config.keyPrefix);
+      const entityKey2 = buildEntityKey('User', 2, config.keyPrefix);
+
+      expect(allKeys.find(k => k.name === operationKey)).not.toBeDefined();
+
+      expect(
+        allKeys.find(k => k.name === `${entityTypeKey}:${operationKeyWithoutPrefix}`),
+      ).toBeDefined();
+      expect(
+        allKeys.find(k => k.name === `${entityTypeKey}:${operationKeyWithoutPrefix}`)?.metadata,
+      ).toEqual({ operationKey });
+
+      expect(
+        allKeys.find(k => k.name === `${entityKey1}:${operationKeyWithoutPrefix}`),
+      ).not.toBeDefined();
+
+      expect(
+        allKeys.find(k => k.name === `${entityKey2}:${operationKeyWithoutPrefix}`),
+      ).toBeDefined();
+      expect(
+        allKeys.find(k => k.name === `${entityKey2}:${operationKeyWithoutPrefix}`)?.metadata,
+      ).toEqual({ operationKey });
+    });
+  });
+});

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -2,7 +2,7 @@ import { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
 import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
 import { KvCacheConfig } from '../src/index.js';
-import { _getAllKvKeysForPrefix, invalidate } from '../src/invalidate.js';
+import { getAllKvKeysForPrefix, invalidate } from '../src/invalidate.js';
 import { set } from '../src/set.js';
 
 type Env = {
@@ -34,7 +34,7 @@ describe('invalidate.test.ts', () => {
     test('should successfully iterate over a KV namespace with no keys', async () => {
       // kv cache has no keys at this point
       const keys = [];
-      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
         keys.push(kvKey);
       }
       expect(keys).toEqual([]);
@@ -49,7 +49,7 @@ describe('invalidate.test.ts', () => {
       }
 
       const keys = [];
-      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
         keys.push(kvKey);
         const userId = kvKey.name.split(':')[3];
         expect(kvKey.metadata).toEqual({
@@ -68,7 +68,7 @@ describe('invalidate.test.ts', () => {
       }
 
       const keys = [];
-      for await (const kvKey of _getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
         keys.push(kvKey);
         const indexId = kvKey.name.split(':')[3];
         expect(kvKey.metadata).toEqual({
@@ -89,7 +89,7 @@ describe('invalidate.test.ts', () => {
 
     async function collectAllKeys(prefix: string) {
       const keys = [];
-      for await (const kvKey of _getAllKvKeysForPrefix(prefix, config)) {
+      for await (const kvKey of getAllKvKeysForPrefix(prefix, config)) {
         keys.push(kvKey);
       }
       return keys;

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -1,9 +1,9 @@
 import { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
-import { KvCacheConfig } from '../src/';
-import { buildEntityKey, buildOperationKey } from '../src/cache-key';
-import { _getAllKvKeysForPrefix } from '../src/invalidate';
-import { set } from '../src/set';
+import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
+import { KvCacheConfig } from '../src/index.js';
+import { _getAllKvKeysForPrefix } from '../src/invalidate.js';
+import { set } from '../src/set.js';
 
 type Env = {
   ENVIRONMENT: 'testing' | 'development' | 'production';

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -1,0 +1,110 @@
+import { ExecutionResult } from 'graphql';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import { KvCacheConfig } from '../src/';
+import { buildEntityKey, buildOperationKey } from '../src/cache-key';
+import { _getAllKvKeysForPrefix } from '../src/invalidate';
+import { set } from '../src/set';
+
+type Env = {
+  ENVIRONMENT: 'testing' | 'development' | 'production';
+  GRAPHQL_RESPONSE_CACHE: KVNamespace;
+};
+
+describe('set.test.ts', () => {
+  let env: Env;
+  let maxTtl: number;
+  let executionContext: ExecutionContext;
+  let config: KvCacheConfig;
+  const keyPrefix = 'vitest';
+  const dataValue: ExecutionResult<{ key: string }, { extensions: string }> = {
+    errors: [],
+    data: { key: 'value' },
+    extensions: { extensions: 'value' },
+  };
+  const dataKey = '1B9502F92EFA53AFF0AC650794AA79891E4B6900';
+
+  async function collectAllKeys(prefix: string) {
+    const keys = [];
+    for await (const kvKey of _getAllKvKeysForPrefix(prefix, config)) {
+      keys.push(kvKey);
+    }
+    return keys;
+  }
+
+  describe('set()', () => {
+    beforeEach(() => {
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      env = getMiniflareBindings<Env>();
+      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+      executionContext = new ExecutionContext();
+      config = {
+        KV: env.GRAPHQL_RESPONSE_CACHE,
+        ctx: executionContext,
+        keyPrefix: 'vitest',
+      };
+      maxTtl = 60 * 1000; // 1 minute
+    });
+
+    test('should save the operation and entity keys in the KV store', async () => {
+      await set(
+        dataKey,
+        dataValue,
+        [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
+        maxTtl,
+        config,
+      );
+      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      const operationKeyWithoutPrefix = buildOperationKey(dataKey);
+      const entityTypeKey = buildEntityKey('User', undefined, config.keyPrefix);
+      const entityKey1 = buildEntityKey('User', 1, config.keyPrefix);
+      const entityKey2 = buildEntityKey('User', 2, config.keyPrefix);
+
+      const allKeys = await collectAllKeys(keyPrefix);
+      expect(allKeys.length).toEqual(4);
+
+      expect(allKeys.find(k => k.name === operationKey)).toBeDefined();
+      expect(allKeys.find(k => k.name === operationKey)?.metadata).toEqual({ operationKey });
+
+      expect(
+        allKeys.find(k => k.name === `${entityTypeKey}:${operationKeyWithoutPrefix}`),
+      ).toBeDefined();
+      expect(
+        allKeys.find(k => k.name === `${entityTypeKey}:${operationKeyWithoutPrefix}`)?.metadata,
+      ).toEqual({ operationKey });
+
+      expect(
+        allKeys.find(k => k.name === `${entityKey1}:${operationKeyWithoutPrefix}`),
+      ).toBeDefined();
+      expect(
+        allKeys.find(k => k.name === `${entityKey1}:${operationKeyWithoutPrefix}`)?.metadata,
+      ).toEqual({ operationKey });
+
+      expect(
+        allKeys.find(k => k.name === `${entityKey2}:${operationKeyWithoutPrefix}`),
+      ).toBeDefined();
+      expect(
+        allKeys.find(k => k.name === `${entityKey2}:${operationKeyWithoutPrefix}`)?.metadata,
+      ).toEqual({ operationKey });
+    });
+
+    test('should function even if there are no entities', async () => {
+      await set(dataKey, dataValue, [], maxTtl, config);
+      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      const operationKeyWithoutPrefix = buildOperationKey(dataKey);
+
+      const allKeys = await collectAllKeys(keyPrefix);
+      expect(allKeys.length).toEqual(1);
+
+      expect(allKeys.find(k => k.name === operationKey)).toBeDefined();
+      expect(allKeys.find(k => k.name === operationKey)?.metadata).toEqual({ operationKey });
+
+      expect(
+        allKeys.find(
+          k =>
+            k.name ===
+            `${buildEntityKey('User', undefined, config.keyPrefix)}:${operationKeyWithoutPrefix}`,
+        ),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -2,7 +2,7 @@ import { ExecutionResult } from 'graphql';
 import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
 import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
 import { KvCacheConfig } from '../src/index.js';
-import { _getAllKvKeysForPrefix } from '../src/invalidate.js';
+import { getAllKvKeysForPrefix } from '../src/invalidate.js';
 import { set } from '../src/set.js';
 
 type Env = {
@@ -25,7 +25,7 @@ describe('set.test.ts', () => {
 
   async function collectAllKeys(prefix: string) {
     const keys = [];
-    for await (const kvKey of _getAllKvKeysForPrefix(prefix, config)) {
+    for await (const kvKey of getAllKvKeysForPrefix(prefix, config)) {
       keys.push(kvKey);
     }
     return keys;

--- a/packages/plugins/response-cache-cloudflare-kv/wrangler.jest.toml
+++ b/packages/plugins/response-cache-cloudflare-kv/wrangler.jest.toml
@@ -1,0 +1,14 @@
+name = "test-graphql-worker"
+main = "src/index.ts"
+compatibility_date = "2023-11-06"
+compatibility_flags = ["nodejs_compat"]
+workers_dev = true
+
+[vars]
+ENVIRONMENT = 'testing'
+
+[[kv_namespaces]]
+binding = "GRAPHQL_RESPONSE_CACHE"
+id = "<ignored>"
+preview_id = "<ignored>"
+

--- a/packages/plugins/response-cache/README.md
+++ b/packages/plugins/response-cache/README.md
@@ -170,9 +170,9 @@ In order to use the Cloudflare KV cache, you need to:
 The example below demonstrates how to use this with graphql-yoga within a Cloudflare Worker script.
 
 ```ts
-import { createKvCache } from 'envelop-response-cache-cloudflare-kv'
 import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'
 import { useResponseCache } from '@envelop/response-cache'
+import { createKvCache } from '@envelop/response-cache-cloudflare-kv'
 import { resolvers } from './graphql-schema/resolvers.generated'
 import { typeDefs } from './graphql-schema/typeDefs.generated'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1390,6 +1390,26 @@ importers:
         version: 5.1.3
     publishDirectory: dist
 
+  packages/plugins/response-cache-cloudflare-kv:
+    dependencies:
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20231025.0
+        version: 4.20231025.0
+      '@envelop/response-cache':
+        specifier: ^6.1.0
+        version: link:../response-cache/dist
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
+    publishDirectory: dist
+
   packages/plugins/response-cache-redis:
     dependencies:
       '@envelop/response-cache':
@@ -8528,7 +8548,7 @@ packages:
       lodash.get: 4.4.2
       p-limit: 4.0.0
       resolve.exports: 2.0.2
-      tslib: 2.5.0
+      tslib: 2.6.2
       typescript: 5.1.3
       yargs: 17.7.2
       zod: 3.21.4
@@ -19140,6 +19160,12 @@ packages:
 
   /typescript@5.1.3:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1405,6 +1405,12 @@ importers:
       '@envelop/response-cache':
         specifier: ^6.1.0
         version: link:../response-cache/dist
+      jest-environment-miniflare:
+        specifier: ^2.14.1
+        version: 2.14.1(jest@29.7.0)
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.23.2)(jest@29.7.0)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4984,6 +4990,10 @@ packages:
       - supports-color
     dev: true
 
+  /@iarna/toml@2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: true
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -5345,6 +5355,166 @@ packages:
       '@types/react': 18.2.37
       react: 18.2.0
     dev: false
+
+  /@miniflare/cache@2.14.1:
+    resolution: {integrity: sha512-f/o6UBV6UX+MlhjcEch73/wjQvvNo37dgYmP6Pn2ax1/mEHhJ7allNAqenmonT4djNeyB3eEYV3zUl54wCEwrg==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+      http-cache-semantics: 4.1.0
+      undici: 5.20.0
+    dev: true
+
+  /@miniflare/core@2.14.1:
+    resolution: {integrity: sha512-d+SGAda/VoXq+SKz04oq8ATUwQw5755L87fgPR8pTdR2YbWkxdbmEm1z2olOpDiUjcR86aN6NtCjY6tUC7fqaw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@miniflare/queues': 2.14.1
+      '@miniflare/shared': 2.14.1
+      '@miniflare/watcher': 2.14.1
+      busboy: 1.6.0
+      dotenv: 10.0.0
+      kleur: 4.1.5
+      set-cookie-parser: 2.4.8
+      undici: 5.20.0
+      urlpattern-polyfill: 4.0.3
+    dev: true
+
+  /@miniflare/d1@2.14.1:
+    resolution: {integrity: sha512-MulDDBsDD8o5DwiqdMeJZy2vLoMji+NWnLcuibSag2mayA0LJcp0eHezseZNkW+knciWR1gMP8Xpa4Q1KwkbKA==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/durable-objects@2.14.1:
+    resolution: {integrity: sha512-T+oHGw5GcEIilkzrf0xDES7jzLVqcXJzSGsEIWqnBFLtdlKmrZF679ulRLBbyMVgvpQz6FRONh9jTH1XIiuObQ==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+      '@miniflare/storage-memory': 2.14.1
+      undici: 5.20.0
+    dev: true
+
+  /@miniflare/html-rewriter@2.14.1:
+    resolution: {integrity: sha512-vp4uZXuEKhtIaxoXa7jgDAPItlzjbfoUqYWp+fwDKv4J4mfQnzzs/5hwjbE7+Ihm/KNI0zNi8P0sSWjIRFl6ng==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+      html-rewriter-wasm: 0.4.1
+      undici: 5.20.0
+    dev: true
+
+  /@miniflare/kv@2.14.1:
+    resolution: {integrity: sha512-Gp07Wcszle7ptsoO8mCtKQRs0AbQnYo1rgnxUcsTL3xJJaHXEA/B9EKSADS2XzJMeY4PgUOHU6Rf08OOF2yWag==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/queues@2.14.1:
+    resolution: {integrity: sha512-uBzrbBkIgtNoztDpmMMISg/brYtxLHRE7oTaN8OVnq3bG+3nF9kQC42HUz+Vg+sf65UlvhSaqkjllgx+fNtOxQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/r2@2.14.1:
+    resolution: {integrity: sha512-grOMnGf2XSicbgxMYMBfWE37k/e7l5NnwXZIViQ+N06uksp+MLA8E6yKQNtvrWQS66TM8gBvMnWo96OFmYjb6Q==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+      undici: 5.20.0
+    dev: true
+
+  /@miniflare/runner-vm@2.14.1:
+    resolution: {integrity: sha512-UobsGM0ICVPDlJD54VPDSx0EXrIY3nJMXBy2zIFuuUOz4hQKXvMQ6jtAlJ8UNKer+XXI3Mb/9R/gfU8r6kxIMA==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/shared-test-environment@2.14.1:
+    resolution: {integrity: sha512-hfactEWiHuHOmE29XFG8oLNCF6+HqjD6Mb80CzidcVmLlBTEtSC3PEF+DXPyvNdLXpBolZMKOuC/yzzloWvACA==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@cloudflare/workers-types': 4.20231025.0
+      '@miniflare/cache': 2.14.1
+      '@miniflare/core': 2.14.1
+      '@miniflare/d1': 2.14.1
+      '@miniflare/durable-objects': 2.14.1
+      '@miniflare/html-rewriter': 2.14.1
+      '@miniflare/kv': 2.14.1
+      '@miniflare/queues': 2.14.1
+      '@miniflare/r2': 2.14.1
+      '@miniflare/shared': 2.14.1
+      '@miniflare/sites': 2.14.1
+      '@miniflare/storage-memory': 2.14.1
+      '@miniflare/web-sockets': 2.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /@miniflare/shared@2.14.1:
+    resolution: {integrity: sha512-73GnLtWn5iP936ctE6ZJrMqGu134KOoIIveq5Yd/B+NnbFfzpuzjCpkLrnqjkDdsxDbruXSb5eTR/SmAdpJxZQ==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@types/better-sqlite3': 7.6.7
+      kleur: 4.1.5
+      npx-import: 1.1.4
+      picomatch: 2.3.1
+    dev: true
+
+  /@miniflare/sites@2.14.1:
+    resolution: {integrity: sha512-AbbIcU6VBeaNqVgMiLMWN2a09eX3jZmjaEi0uKqufVDqW/QIz47/30aC0O9qTe+XYpi3jjph/Ux7uEY8Z+enMw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/kv': 2.14.1
+      '@miniflare/shared': 2.14.1
+      '@miniflare/storage-file': 2.14.1
+    dev: true
+
+  /@miniflare/storage-file@2.14.1:
+    resolution: {integrity: sha512-faZu9tRSW6c/looVFI/ZhkdGsIc9NfNCbSl3jJRmm7xgyZ+/S+dQ5JtGVbVsUIX8YGWDyE2j3oWCGCjxGLEpkg==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+      '@miniflare/storage-memory': 2.14.1
+    dev: true
+
+  /@miniflare/storage-memory@2.14.1:
+    resolution: {integrity: sha512-lfQbQwopVWd4W5XzrYdp0rhk3dJpvSmv1Wwn9RhNO20WrcuoxpdSzbmpBahsgYVg+OheVaEbS6RpFqdmwwLTog==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/watcher@2.14.1:
+    resolution: {integrity: sha512-dkFvetm5wk6pwunlYb/UkI0yFNb3otLpRm5RDywMUzqObEf+rCiNNAbJe3HUspr2ncZVAaRWcEaDh82vYK5cmw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.1
+    dev: true
+
+  /@miniflare/web-sockets@2.14.1:
+    resolution: {integrity: sha512-3N//L5EjF7+xXd7qCLR2ylUwm8t2MKyGPGWEtRBrQ2xqYYWhewKTjlquHCOPU5Irnnd/4BhTmFA55MNrq7m4Nw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.1
+      '@miniflare/shared': 2.14.1
+      undici: 5.20.0
+      ws: 8.14.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
 
   /@n1ru4l/graphql-live-query-patch-jsondiffpatch@0.8.0(graphql@16.6.0):
     resolution: {integrity: sha512-m5OPdEhBbqQ+pkFz2dQmPl10JW/RB1Qc2zoVn9QTEXvyeSzQmrl+qNtn3nvv87P9rQDiRD/JWlD86BFX0XloBg==}
@@ -6968,6 +7138,12 @@ packages:
 
   /@types/benchmark@2.1.5:
     resolution: {integrity: sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==}
+    dev: true
+
+  /@types/better-sqlite3@7.6.7:
+    resolution: {integrity: sha512-+c2YGPWY5831v3uj2/X0HRTK94u1GXU3sCnLqu7AKlxlSfawswnAiJR//TFzSL5azWsLQkG/uS+YnnqHtuZxPw==}
+    dependencies:
+      '@types/node': 20.9.0
     dev: true
 
   /@types/body-parser@1.19.2:
@@ -10232,6 +10408,11 @@ packages:
       domhandler: 5.0.3
     dev: true
 
+  /dotenv@10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
+    dev: true
+
   /dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
@@ -10948,6 +11129,21 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+    dev: true
+
+  /execa@6.1.0:
+    resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 3.0.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
     dev: true
 
   /execa@7.1.1:
@@ -12522,6 +12718,10 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /html-rewriter-wasm@0.4.1:
+    resolution: {integrity: sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==}
+    dev: true
+
   /html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
     dev: false
@@ -12632,6 +12832,11 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /human-signals@3.0.1:
+    resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
+    engines: {node: '>=12.20.0'}
     dev: true
 
   /human-signals@4.3.1:
@@ -13390,6 +13595,27 @@ packages:
       jest-get-type: 29.6.3
       jest-util: 29.7.0
       pretty-format: 29.7.0
+    dev: true
+
+  /jest-environment-miniflare@2.14.1(jest@29.7.0):
+    resolution: {integrity: sha512-IkyCJ7LJCIXE1xJaExPRVHTK+6RxFJYEQjaVnpMCn9gEXSnjZhFwxdD3uFJq3J9QtcuZKRFBKJurnmGFCV4otQ==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      jest: '>=27'
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@miniflare/queues': 2.14.1
+      '@miniflare/runner-vm': 2.14.1
+      '@miniflare/shared': 2.14.1
+      '@miniflare/shared-test-environment': 2.14.1
+      jest: 29.7.0(@types/node@20.9.0)(ts-node@10.9.1)
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /jest-environment-node@29.7.0:
@@ -15775,6 +16001,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
+  /npx-import@1.1.4:
+    resolution: {integrity: sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==}
+    dependencies:
+      execa: 6.1.0
+      parse-package-name: 1.0.0
+      semver: 7.5.4
+      validate-npm-package-name: 4.0.0
+    dev: true
+
   /nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
@@ -16102,6 +16337,10 @@ packages:
   /parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
     dev: false
+
+  /parse-package-name@1.0.0:
+    resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
+    dev: true
 
   /parse-path@7.0.0:
     resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
@@ -17832,7 +18071,6 @@ packages:
 
   /set-cookie-parser@2.4.8:
     resolution: {integrity: sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==}
-    dev: false
 
   /set-function-name@2.0.1:
     resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
@@ -18922,6 +19160,40 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /ts-jest@29.1.1(@babel/core@7.23.2)(jest@29.7.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.23.2
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.9.0)(ts-node@10.9.1)
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.4
+      typescript: 5.2.2
+      yargs-parser: 21.1.1
+    dev: true
+
   /ts-node@10.9.1(@types/node@20.9.0)(typescript@5.1.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -19200,6 +19472,13 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  /undici@5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
+    engines: {node: '>=12.18'}
+    dependencies:
+      busboy: 1.6.0
+    dev: true
 
   /undici@5.25.2:
     resolution: {integrity: sha512-tch8RbCfn1UUH1PeVCXva4V8gDpGAud/w0WubD6sHC46vYQ3KDxL+xv1A2UxK0N6jrVedutuPHxe1XIoqerwMw==}
@@ -19504,6 +19783,10 @@ packages:
       querystring: 0.2.0
     dev: false
 
+  /urlpattern-polyfill@4.0.3:
+    resolution: {integrity: sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==}
+    dev: true
+
   /urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
     dev: false
@@ -19603,6 +19886,13 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /validate-npm-package-name@4.0.0:
+    resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      builtins: 5.0.1
     dev: true
 
   /validator@13.9.0:
@@ -20022,7 +20312,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: false
 
   /xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "incremental": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "packages",
+    "rootDir": ".",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "incremental": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": ".",
+    "rootDirs": [".", "packages"],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,


### PR DESCRIPTION
## Description

This PR creates a new package `@envelop/response-cache-cloudflare-kv` which acts as a companion to @envelop/response-cache, allowing users to use Cloudflare KV as a datastore.
This is ideal for users making graphql servers in Cloudflare workers since it gives them a globally distributed low latency data store.

Fixes #2055 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
This section is a work in progress
So far I have tested this plugin externally with detailed vitest unit tests. I'm trying to work out how to do the necessary setup for unit tests in this environment.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
I've left a detailed description of the proposed change and some engineering discussions in the linked issue.
