### PR TITLE
fix(response-cache): run enabled only in execution

### DIFF
--- a/.changeset/breezy-pots-lick.md
+++ b/.changeset/breezy-pots-lick.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': patch
+---
+
+Run enabled once only in execution

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -563,11 +563,11 @@ describe('useResponseCache', () => {
 
     const testInstance = createTestkit(
       [
+        useGraphQlJit(),
         useResponseCache({
           session: () => null,
           includeExtensionMetadata: true,
         }),
-        useGraphQlJit(),
       ],
       schema,
     );

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -1,6 +1,6 @@
 import { getIntrospectionQuery, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import * as GraphQLJS from 'graphql';
-import { envelop, useEngine, useLogger, useSchema } from '@envelop/core';
+import { envelop, useEngine, useExtendContext, useLogger, useSchema } from '@envelop/core';
 import { useGraphQlJit } from '@envelop/graphql-jit';
 import { useParserCache } from '@envelop/parser-cache';
 import {
@@ -3721,4 +3721,45 @@ describe('useResponseCache', () => {
 
     return result;
   }
+});
+
+it('calls enabled fn after context building', async () => {
+  expect.assertions(2);
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        foo: String
+      }
+    `,
+    resolvers: { Query: { foo: () => 'hi' } },
+  });
+  const testkit = createTestkit(
+    [
+      useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+      useExtendContext(() => ({ foo: 'bar' })),
+      useResponseCache({
+        session: () => null,
+        ttlPerSchemaCoordinate: { 'Query.foo': Infinity },
+        enabled: context => {
+          expect(context).toMatchObject({ foo: 'bar' });
+          return true;
+        },
+      }),
+    ],
+    schema,
+  );
+
+  const document = /* GraphQL */ `
+    query {
+      foo
+    }
+  `;
+
+  const result = await testkit.execute(document, { foo: 'bar' });
+  assertSingleExecutionValue(result);
+  expect(result).toMatchObject({
+    data: {
+      foo: 'hi',
+    },
+  });
 });


### PR DESCRIPTION
After this change, Response Cache plugin should come after all other plugins modifying the execute fn.
Fixes https://github.com/n1ru4l/envelop/issues/2034