### PR TITLE
preserve masked errors' path

### DIFF
--- a/packages/core/src/plugins/use-masked-errors.ts
+++ b/packages/core/src/plugins/use-masked-errors.ts
@@ -32,6 +32,8 @@ function createSerializableGraphQLError(
 ): SerializableGraphQLErrorLike {
   const error = new Error(message) as SerializableGraphQLErrorLike;
   error.name = 'GraphQLError';
+
+  const hasPath = originalError && typeof originalError === 'object' && 'path' in originalError;
   if (isDev) {
     const extensions =
       originalError instanceof Error
@@ -48,6 +50,7 @@ function createSerializableGraphQLError(
   Object.defineProperty(error, 'toJSON', {
     value() {
       return {
+        ...(hasPath ? {path: originalError.path} : {}),
         message: error.message,
         extensions: error.extensions,
       };

--- a/packages/core/test/plugins/use-masked-errors.spec.ts
+++ b/packages/core/test/plugins/use-masked-errors.spec.ts
@@ -105,6 +105,7 @@ describe('useMaskedErrors', () => {
     expect(result.errors).toHaveLength(1);
     const [error] = result.errors!;
     expect(error.message).toEqual(DEFAULT_ERROR_MESSAGE);
+    expect(error.path).toEqual(['secret']);
   });
 
   it('Should not mask expected errors', async () => {
@@ -116,6 +117,7 @@ describe('useMaskedErrors', () => {
     const [error] = result.errors!;
     expect(error.message).toEqual('This message goes to all the clients out there!');
     expect(error.extensions).toEqual({ foo: 1 });
+    expect(error.path).toEqual(['secretEnvelop']);
   });
 
   it('Should not mask GraphQL operation syntax errors (of course it does not since we are only hooking in after execute, but just to be sure)', async () => {
@@ -142,6 +144,7 @@ describe('useMaskedErrors', () => {
     expect(JSON.stringify(result)).toMatchInlineSnapshot(
       `"{"errors":[{"message":"This message goes to all the clients out there!","locations":[{"line":1,"column":9}],"path":["secretWithExtensions"],"extensions":{"code":"Foo","message":"Bar"}}],"data":null}"`,
     );
+    expect(error.path).toEqual(['secretWithExtensions']);
   });
 
   it('Should properly mask context creation errors with a custom error message', async () => {
@@ -159,6 +162,7 @@ describe('useMaskedErrors', () => {
       await testInstance.execute(`query { secretWithExtensions }`);
     } catch (err) {
       expect(err).toMatchInlineSnapshot(`[GraphQLError: My Custom Error Message.]`);
+      expect(error.path).toEqual(['secretWithExtensions']);
     }
   });
   it('Should properly mask context creation errors', async () => {
@@ -176,6 +180,7 @@ describe('useMaskedErrors', () => {
       await testInstance.execute(`query { secretWithExtensions }`);
     } catch (err: any) {
       expect(err.message).toEqual(DEFAULT_ERROR_MESSAGE);
+      expect(error.path).toEqual(['secretWithExtensions']);
     }
   });
 
@@ -196,6 +201,7 @@ describe('useMaskedErrors', () => {
       if (err instanceof GraphQLError) {
         expect(err.message).toEqual(`No context for you!`);
         expect(err.extensions).toEqual({ foo: 1 });
+        expect(error.path).toEqual(['secretWithExtensions']);
       } else {
         throw err;
       }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

When using useMaskedError - it hides the path of where error occured - making impossible where the error occured.

Fixes #2091

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

can be seen in the issue.

## How Has This Been Tested?

description in the issue

**Test Environment**:

- OS: archlinux
- `@envelop/5.0.0`:
- NodeJS: 20

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
