### PR TITLE
(fix): Try fixing cloudflare worker type issue with kv plugin

### DIFF
--- a/.changeset/tough-pugs-fetch.md
+++ b/.changeset/tough-pugs-fetch.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache-cloudflare-kv': minor
+---
+
+Change @cloudflare/workers-types to an optional peer dependency of the package

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -50,14 +50,19 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20231121.0",
     "@envelop/response-cache": "^6.1.1",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+      "optional": true
+    }
   },
   "dependencies": {
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20231025.0",
     "@envelop/response-cache": "^6.1.1",
     "jest-environment-miniflare": "^2.14.1",
     "ts-jest": "29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1392,6 +1392,9 @@ importers:
 
   packages/plugins/response-cache-cloudflare-kv:
     dependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20231121.0
+        version: 4.20231121.0
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1399,9 +1402,6 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
     devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20231025.0
-        version: 4.20231025.0
       '@envelop/response-cache':
         specifier: ^6.1.1
         version: link:../response-cache/dist
@@ -4287,6 +4287,9 @@ packages:
     resolution: {integrity: sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==}
     dev: true
 
+  /@cloudflare/workers-types@4.20231121.0:
+    resolution: {integrity: sha512-+kWfpCkqiepwAKXyHoE0gnkPgkLhz0/9HOBIGhHRsUvUKvhUtm3mbqqoGRWgF1qcjzrDUBbrrOq4MYHfFtc2RA==}
+
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -5551,7 +5554,7 @@ packages:
     resolution: {integrity: sha512-hfactEWiHuHOmE29XFG8oLNCF6+HqjD6Mb80CzidcVmLlBTEtSC3PEF+DXPyvNdLXpBolZMKOuC/yzzloWvACA==}
     engines: {node: '>=16.13'}
     dependencies:
-      '@cloudflare/workers-types': 4.20231025.0
+      '@cloudflare/workers-types': 4.20231121.0
       '@miniflare/cache': 2.14.1
       '@miniflare/core': 2.14.1
       '@miniflare/d1': 2.14.1


### PR DESCRIPTION
## Description

Working on #2104

- This PR moves `@cloudflare/workers-types` to a peer dependency status. This should help the typescript compiler not double up and mix types when this package is used within other Cloudflare projects
- I've connected the issue, however I wait to refrain from auto-closing it as I'm not 100% confident with the change, so we will have to release a new version before I can test it out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It's rather difficult to test this change without actually releasing a new version of the package. The build process used here is bespoke, so replicating it is also difficult.

That being said, I've tried to follow the process I did when making https://github.com/AdiRishi/cachified-adapter-cloudflare-kv
That package also is built for workers, and setting `@cloudflare/workers-types` as a peer dependency seemed to work when using the published package. So my hope is that the same approach will work here.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

