### PR TITLE
(fix) incorrect handling of maxAge: 0 in @cacheControl directive

### DIFF
--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -345,7 +345,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
               'cacheControl',
             ) as unknown as CacheControlDirective[] | undefined;
             cacheControlAnnotations?.forEach(cacheControl => {
-              if (cacheControl.maxAge) {
+              if (cacheControl.maxAge !== undefined) {
                 ttlPerType[type.name] = cacheControl.maxAge * 1000;
               }
               if (cacheControl.scope) {
@@ -371,7 +371,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
               'cacheControl',
             ) as unknown as CacheControlDirective[] | undefined;
             cacheControlAnnotations?.forEach(cacheControl => {
-              if (cacheControl.maxAge) {
+              if (cacheControl.maxAge !== undefined) {
                 ttlPerSchemaCoordinate[schemaCoordinates] = cacheControl.maxAge * 1000;
               }
               if (cacheControl.scope) {

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -345,7 +345,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
               'cacheControl',
             ) as unknown as CacheControlDirective[] | undefined;
             cacheControlAnnotations?.forEach(cacheControl => {
-              if (cacheControl.maxAge !== undefined) {
+              if (cacheControl.maxAge != null) {
                 ttlPerType[type.name] = cacheControl.maxAge * 1000;
               }
               if (cacheControl.scope) {
@@ -371,7 +371,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
               'cacheControl',
             ) as unknown as CacheControlDirective[] | undefined;
             cacheControlAnnotations?.forEach(cacheControl => {
-              if (cacheControl.maxAge !== undefined) {
+              if (cacheControl.maxAge != null) {
                 ttlPerSchemaCoordinate[schemaCoordinates] = cacheControl.maxAge * 1000;
               }
               if (cacheControl.scope) {
@@ -461,6 +461,10 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
             if (fieldData == null || (Array.isArray(fieldData) && fieldData.length === 0)) {
               const inferredTypes = typePerSchemaCoordinateMap.get(`${typename}.${fieldName}`);
               inferredTypes?.forEach(inferredType => {
+                if (inferredType in ttlPerType) {
+                  const maybeTtl = ttlPerType[inferredType] as unknown;
+                  currentTtl = calculateTtl(maybeTtl, currentTtl);
+                }
                 identifier.set(inferredType, { typename: inferredType });
               });
             }


### PR DESCRIPTION
## Description

This PR addresses the issue where the `@cacheControl` directive does not correctly handle `maxAge: 0`. Previously, due to a falsy check, setting `maxAge` to `0` was incorrectly treated as undefined, leading to unexpected caching behavior. This change ensures that `maxAge: 0` is correctly interpreted to mean "do not cache".

Fixes # [issue](https://github.com/n1ru4l/envelop/issues/2108)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Adjusted unit tests to cover the case where `maxAge` is set to `0`.
- Manually tested in a development environment to ensure that setting `maxAge: 0` correctly prevents caching.

**Test Environment**:

- OS: Linux
- `@envelop/response-cache`: 6.1.1
- NodeJS: 20

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

This change is crucial for enabling correct caching behavior in GraphQL applications, especially for scenarios where caching should be explicitly disabled.
