### PR TITLE
feat(useOnResolve): new skipDefaultResolvers options

### DIFF
--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -39,6 +39,12 @@ export type UseOnResolveOptions = {
    * @default true
    */
   skipIntrospection?: boolean;
+  /**
+   * Skip wrapping fields that have the default resolver (no custom resolver).
+   *
+   * @default false
+   */
+  skipDefaultResolvers?: boolean;
 };
 
 /**
@@ -59,6 +65,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
       for (const type of Object.values(schema.getTypeMap())) {
         if ((!opts.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
+            if (opts.skipDefaultResolvers && (!field.resolve || field.resolve === defaultFieldResolver)) continue;
             if (field[hasWrappedResolveSymbol]) continue;
 
             let resolver = (field.resolve || defaultFieldResolver) as Resolver<PluginContext>;


### PR DESCRIPTION
## Description

Adds a new `skipDefaultResolvers` option to `useOnResolve`.

Fixes #2132

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@envelop/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
