### PR TITLE
add `usePrunedSchema` plugin

### DIFF
--- a/packages/plugins/pruned-schema/README.md
+++ b/packages/plugins/pruned-schema/README.md
@@ -1,0 +1,34 @@
+## `@envelop/pruned-schema`
+
+This plugins clean up the registered schema by removing unused and empty types.
+
+## Getting Started
+
+```bash
+yarn add @envelop/pruned-schema
+```
+
+## Usage Example
+
+See
+[@graphql-tools/utils/pruneSchema](https://the-guild.dev/graphql/tools/docs/api/interfaces/utils_src.PruneSchemaOptions)
+for the list of available options.
+
+```ts
+import { execute, parse, subscribe, validate } from 'graphql'
+import { envelop } from '@envelop/core'
+import { usePrunedSchema } from '@envelop/response-cache'
+
+const getEnveloped = envelop({
+  parse,
+  validate,
+  execute,
+  subscribe,
+  plugins: [
+    // ... other plugins ...
+    usePrunedSchema({
+      // pruneSchema options
+    })
+  ]
+})
+```

--- a/packages/plugins/pruned-schema/package.json
+++ b/packages/plugins/pruned-schema/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@envelop/pruned-schema",
+  "version": "1.0.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/n1ru4l/envelop.git",
+    "directory": "packages/plugins/pruned-schema"
+  },
+  "author": "Valentin Cocaud <v.cocaud@gmail.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/typings/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "default": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./*": {
+      "require": {
+        "types": "./dist/typings/*.d.cts",
+        "default": "./dist/cjs/*.js"
+      },
+      "import": {
+        "types": "./dist/typings/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "default": {
+        "types": "./dist/typings/*.d.ts",
+        "default": "./dist/esm/*.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "typings": "dist/typings/index.d.ts",
+  "peerDependencies": {
+    "@envelop/core": "^5.0.0",
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "@graphql-tools/utils": "^10.0.3",
+    "tslib": "^2.5.0"
+  },
+  "devDependencies": {
+    "@envelop/core": "^5.0.0",
+    "graphql": "16.8.1",
+    "typescript": "5.1.3"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "sideEffects": false,
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "typescript": {
+    "definition": "dist/typings/index.d.ts"
+  }
+}

--- a/packages/plugins/pruned-schema/src/index.ts
+++ b/packages/plugins/pruned-schema/src/index.ts
@@ -1,0 +1,24 @@
+import type { GraphQLSchema } from 'graphql';
+import type { Plugin } from '@envelop/core';
+import { pruneSchema, PruneSchemaOptions } from '@graphql-tools/utils';
+
+export function usePrunedSchema(options: PruneSchemaOptions): Plugin {
+  const prunedSchemas = new WeakSet<GraphQLSchema>();
+
+  return {
+    onSchemaChange({ schema, replaceSchema }) {
+      if (prunedSchemas.has(schema)) {
+        return;
+      }
+
+      const prunedSchema = pruneSchema(schema, options);
+      prunedSchemas.add(prunedSchema);
+      prunedSchema.extensions = {
+        ...prunedSchema.extensions,
+        ...schema.extensions,
+      };
+
+      replaceSchema(prunedSchema);
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,9 +1321,6 @@ importers:
       '@envelop/core':
         specifier: ^5.0.0
         version: link:../../core/dist
-      '@graphql-tools/schema':
-        specifier: 10.0.2
-        version: 10.0.2(graphql@16.6.0)
       graphql:
         specifier: 16.6.0
         version: 16.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1309,6 +1309,29 @@ importers:
         version: 5.1.3
     publishDirectory: dist
 
+  packages/plugins/pruned-schema:
+    dependencies:
+      '@graphql-tools/utils':
+        specifier: ^10.0.3
+        version: 10.0.13(graphql@16.6.0)
+      tslib:
+        specifier: ^2.5.0
+        version: 2.6.2
+    devDependencies:
+      '@envelop/core':
+        specifier: ^5.0.0
+        version: link:../../core/dist
+      '@graphql-tools/schema':
+        specifier: 10.0.2
+        version: 10.0.2(graphql@16.6.0)
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      typescript:
+        specifier: 5.1.3
+        version: 5.1.3
+    publishDirectory: dist
+
   packages/plugins/rate-limiter:
     dependencies:
       '@envelop/on-resolve':
@@ -4776,7 +4799,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.5
       graphql: 16.6.0
-      tslib: 2.5.0
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: true
 
@@ -4936,7 +4959,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       dset: 3.1.2
       graphql: 16.6.0
-      tslib: 2.5.0
+      tslib: 2.6.2
     dev: false
 
   /@graphql-tools/utils@10.0.6(graphql@16.6.0):


### PR DESCRIPTION
## Description

Adds a plugin to automatically clean up the schema by applying [`pruneSchema` from `@graphql-tools/utils`](https://the-guild.dev/graphql/tools/docs/api/modules/utils_src#pruneschema).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
