### PR TITLE
[Sentry] SentryPluginOptions and Configuration descriptions

### DIFF
--- a/.changeset/popular-seahorses-serve.md
+++ b/.changeset/popular-seahorses-serve.md
@@ -1,0 +1,6 @@
+---
+'@envelop/sentry': patch
+---
+
+Removed includedResolverArgs from SentryPluginOptions as it lead to no functionality. Updated plugin
+website documentation accordingly.

--- a/.changeset/popular-seahorses-serve.md
+++ b/.changeset/popular-seahorses-serve.md
@@ -2,5 +2,4 @@
 '@envelop/sentry': patch
 ---
 
-Removed includedResolverArgs from SentryPluginOptions as it lead to no functionality. Updated plugin
-website documentation accordingly.
+Removed includedResolverArgs from SentryPluginOptions as it lead to no functionality.

--- a/.changeset/popular-seahorses-serve.md
+++ b/.changeset/popular-seahorses-serve.md
@@ -1,5 +1,5 @@
 ---
-'@envelop/sentry': patch
+'@envelop/sentry': major
 ---
 
 Removed includedResolverArgs from SentryPluginOptions as it lead to no functionality.

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -60,7 +60,7 @@ const getEnveloped = envelop({
 
 - `startTransaction` (default: `true`) - Starts a new transaction for every GraphQL Operation. When
   disabled, an already existing Transaction will be used.
-- `renameTransaction` (default: `false`) - Creates a Span for every resolve function.
+- `renameTransaction` (default: `false`) - Renames Transaction.
 - `includeRawResult` (default: `false`) - Adds result of each resolver and operation to Span's data
   (available under "result")
 - `includeResolverArgs` (default: `false`) - Adds arguments of each resolver to Span's tag called

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -63,8 +63,6 @@ const getEnveloped = envelop({
 - `renameTransaction` (default: `false`) - Renames Transaction.
 - `includeRawResult` (default: `false`) - Adds result of each resolver and operation to Span's data
   (available under "result")
-- `includeResolverArgs` (default: `false`) - Adds arguments of each resolver to Span's tag called
-  "args"
 - `includeExecuteVariables` (default: `false`) - Adds operation's variables to a Scope (only in case
   of errors)
 - `appendTags` - See example above. Allow you to manipulate the tags reports on the Sentry

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -29,11 +29,6 @@ export type SentryPluginOptions<PluginContext extends Record<string, any>> = {
    */
   includeRawResult?: boolean;
   /**
-   * Adds arguments of each resolver to Span's tag called "args"
-   * @default false
-   */
-  includeResolverArgs?: boolean;
-  /**
    * Adds operation's variables to a Scope (only in case of errors)
    * @default false
    */


### PR DESCRIPTION

## Description

Spotted two minor inconsistencies in the `@envelop/sentry` package. 

1. The `SentryPluginOptions` espouse an option called `includeResolverArgs` but variable is unused.
1. The plugin's website has a mislabelling for the `renameTransaction` option, noting that flipping it to true would record a span for each resolver.
1. I have also removed `includeResolverArgs` from the configuration section of the plugin's website. 

I believe the second inconsistency is a hold-over when `useSentry` used to have the (absolutely wonderful and dearly missed for perf analysis) `trackResolvers` option. 

This could be 2 issues and 2 PRs but I hope you'll allow this infraction to avoid high overheads for minor contributions

Fixes #2162 (issue)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

See issue

## How Has This Been Tested?

SentryPluginOptions:
Tried sentry pkg, non-functioning option is gone from type guidance

Website:
Text updated
**Test Environment**:


- OS: Ubuntu 22.04
- NodeJS: 18.04
- `@envelop/*` versions:
  - `@envelop/core`: `5.0.0`
  - `@envelop/sentry`: `8.0.0`


## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ x I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I found making these minor contributions quite gruelling. There's a lot of copying-from-issue-to-PR and the contribution document suggests watching a 28 minute(!!!) video. I am certain this is helpful in triaging and cooperating on major changes in a controlled manner, but discouraging for someone like me who uses these packages often and spotted a couple of simple errors. 
