### PR TITLE
fix(auth0): change Auth0 plugin audience property's type

### DIFF
--- a/packages/plugins/auth0/src/index.ts
+++ b/packages/plugins/auth0/src/index.ts
@@ -9,7 +9,7 @@ const { decode, verify } = jwtPkg;
 
 export type Auth0PluginOptions = {
   domain: string;
-  audience: string;
+  audience: string | RegExp | Array<string | RegExp> | undefined;
 
   preventUnauthenticatedAccess?: boolean;
   onError?: (error: Error) => void;

--- a/packages/plugins/auth0/src/index.ts
+++ b/packages/plugins/auth0/src/index.ts
@@ -9,7 +9,7 @@ const { decode, verify } = jwtPkg;
 
 export type Auth0PluginOptions = {
   domain: string;
-  audience: string | RegExp | Array<string | RegExp> | undefined;
+  audience: VerifyOptions['audience'];
 
   preventUnauthenticatedAccess?: boolean;
   onError?: (error: Error) => void;


### PR DESCRIPTION
## Description

Change type of Auth0 plugin's audience property to accept what the underlying jsonwebtoken library accepts. This is needed e.g. if the protected resource accepts JWTs from multiple applications.

Fixes # [2199](https://github.com/n1ru4l/envelop/issues/2199)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

NA

## How Has This Been Tested?

Tested using a @ts-ignored audience property and passing it an array of audiences.

**Test Environment**:

- OS: MacOS
- `@envelop/auth0`: 6.0.0
- NodeJS: 20

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This change is very limited as it is only a passthrough property that has a type available in the downstream package that has been implemented here as well.  
