### PR TITLE
feat(response-cache): add extras property to get scope and its metadata from buildResponseCacheKey

### DIFF
--- a/.changeset/rich-kiwis-stand.md
+++ b/.changeset/rich-kiwis-stand.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+Add `extras` function to `BuildResponseCacheKeyFunction` to get computed scope

--- a/.changeset/sour-cars-hang.md
+++ b/.changeset/sour-cars-hang.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+Added `getScope` callback in `buildResponseCacheKey` params

--- a/.changeset/sour-cars-hang.md
+++ b/.changeset/sour-cars-hang.md
@@ -1,5 +1,0 @@
----
-'@envelop/response-cache': minor
----
-
-Added `getScope` callback in `buildResponseCacheKey` params

--- a/packages/plugins/response-cache/README.md
+++ b/packages/plugins/response-cache/README.md
@@ -863,3 +863,55 @@ mutation SetNameMutation {
   }
 }
 ```
+
+#### Get scope of the query
+
+Useful for building a cache key that is shared across all sessions when `PUBLIC`.
+
+```ts
+import jsonStableStringify from 'fast-json-stable-stringify'
+import { execute, parse, subscribe, validate } from 'graphql'
+import { envelop } from '@envelop/core'
+import { hashSHA256, useResponseCache } from '@envelop/response-cache'
+
+const getEnveloped = envelop({
+  parse,
+  validate,
+  execute,
+  subscribe,
+  plugins: [
+    // ... other plugins ...
+    useResponseCache({
+      ttl: 2000,
+      session: request => getSessionId(request),
+      buildResponseCacheKey: ({
+        getScope,
+        sessionId,
+        documentString,
+        operationName,
+        variableValues
+      }) =>
+        // Use `getScope()` to put a unique key for every session when `PUBLIC`
+        hashSHA256(
+          [
+            getScope() === 'PUBLIC' ? 'PUBLIC' : sessionId,
+            documentString,
+            operationName ?? '',
+            jsonStableStringify(variableValues ?? {})
+          ].join('|')
+        ),
+      scopePerSchemaCoordinate: {
+        // Set scope for an entire query
+        'Query.getProfile': 'PRIVATE',
+        // Set scope for an entire type
+        PrivateProfile: 'PRIVATE',
+        // Set scope for a single field
+        'Profile.privateData': 'PRIVATE'
+      }
+    })
+  ]
+})
+```
+
+> Note: The use of this callback will increase the ram usage since it memoizes the scope for each
+> query in a weak map.

--- a/packages/plugins/response-cache/src/get-scope.ts
+++ b/packages/plugins/response-cache/src/get-scope.ts
@@ -1,0 +1,115 @@
+import {
+  FieldNode,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLSchema,
+  Kind,
+  parse,
+  SelectionNode,
+  visit,
+} from 'graphql';
+import { memoize1 } from '@graphql-tools/utils';
+import { isPrivate, type CacheControlDirective } from './plugin';
+
+/** Parse the selected query fields */
+function parseSelections(selections: readonly SelectionNode[] = [], record: Record<string, any>) {
+  for (const selection of selections) {
+    if (selection.kind === Kind.FIELD) {
+      record[selection.name.value] = {};
+      parseSelections(selection.selectionSet?.selections, record[selection.name.value]);
+    }
+  }
+}
+
+/** Iterate over record and parse its fields with schema type */
+function parseRecordWithSchemaType(
+  type: GraphQLOutputType,
+  record: Record<string, any>,
+  prefix?: string,
+): Set<string> {
+  let fields = new Set<string>();
+  if (type instanceof GraphQLNonNull || type instanceof GraphQLList) {
+    fields = new Set([...fields, ...parseRecordWithSchemaType(type.ofType, record, prefix)]);
+  }
+
+  if (type instanceof GraphQLObjectType) {
+    const newPrefixes = [...(prefix ?? []), type.name];
+    fields.add(newPrefixes.join('.'));
+
+    const typeFields = type.getFields();
+    for (const key of Object.keys(record)) {
+      const field = typeFields[key];
+      if (!field) {
+        continue;
+      }
+
+      fields.add([...newPrefixes, field.name].join('.'));
+      if (Object.keys(record[key]).length > 0) {
+        fields = new Set([...fields, ...parseRecordWithSchemaType(field.type, record[key])]);
+      }
+    }
+  }
+
+  return fields;
+}
+
+function getSchemaCoordinatesFromQuery(schema: GraphQLSchema, query: string): Set<string> {
+  const ast = parse(query);
+  let fields = new Set<string>();
+
+  // Launch the field visitor
+  visit(ast, {
+    // Parse the fields of the root of query
+    Field: node => {
+      const record: Record<string, any> = {};
+      const queryFields = schema.getQueryType()?.getFields()[node.name.value];
+
+      if (queryFields) {
+        record[node.name.value] = {};
+        parseSelections(node.selectionSet?.selections, record[node.name.value]);
+
+        fields.add(`Query.${node.name.value}`);
+        fields = new Set([
+          ...fields,
+          ...parseRecordWithSchemaType(queryFields.type, record[node.name.value]),
+        ]);
+      }
+    },
+    // And each fragment
+    FragmentDefinition: fragment => {
+      const type = fragment.typeCondition.name.value;
+      fields = new Set([
+        ...fields,
+        ...(
+          fragment.selectionSet.selections.filter(({ kind }) => kind === Kind.FIELD) as FieldNode[]
+        ).map(({ name: { value } }) => `${type}.${value}`),
+      ]);
+    },
+  });
+
+  return fields;
+}
+
+export const getScopeFromQuery = (
+  schema: GraphQLSchema,
+  query: string,
+): {
+  scope: NonNullable<CacheControlDirective['scope']>;
+  metadata: { privateProperty?: string };
+} => {
+  const fn = memoize1(({ query }: { query: string }) => {
+    const schemaCoordinates = getSchemaCoordinatesFromQuery(schema, query);
+
+    for (const coordinate of schemaCoordinates) {
+      if (isPrivate(coordinate)) {
+        return { scope: 'PRIVATE' as const, metadata: { privateProperty: coordinate } };
+      }
+    }
+
+    return { scope: 'PUBLIC' as const, metadata: {} };
+  });
+
+  return fn({ query });
+};

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -2,3 +2,4 @@ export * from './in-memory-cache.js';
 export * from './plugin.js';
 export * from './cache.js';
 export * from './hash-sha256.js';
+export * from './get-scope.js';

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -36,7 +36,7 @@ import {
 } from '@graphql-tools/utils';
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
 import type { Cache, CacheEntityRecord } from './cache.js';
-import { getScopeFromQuery, Scope } from './get-scope.js';
+import { getScopeFromQuery, GetScopeFromQueryOptions, Scope } from './get-scope.js';
 import { hashSHA256 } from './hash-sha256.js';
 import { createInMemoryCache } from './in-memory-cache.js';
 
@@ -574,8 +574,14 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
             operationName: onExecuteParams.args.operationName,
             sessionId,
             context: onExecuteParams.args.contextValue,
-            extras: (schema: GraphQLSchema) =>
-              getScopeFromQuery(schema, onExecuteParams.args.document.loc.source.body),
+            extras: (
+              schema: GraphQLSchema,
+              options?: Omit<GetScopeFromQueryOptions, 'includeExtensionMetadata'>,
+            ) =>
+              getScopeFromQuery(schema, onExecuteParams.args.document.loc.source.body, {
+                ...options,
+                includeExtensionMetadata,
+              }),
           }),
         cacheKey => {
           const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   ExecutionArgs,
   getOperationAST,
   GraphQLDirective,
+  GraphQLSchema,
   GraphQLType,
   isListType,
   isNonNullType,
@@ -35,6 +36,7 @@ import {
 } from '@graphql-tools/utils';
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
 import type { Cache, CacheEntityRecord } from './cache.js';
+import { getScopeFromQuery } from './get-scope.js';
 import { hashSHA256 } from './hash-sha256.js';
 import { createInMemoryCache } from './in-memory-cache.js';
 
@@ -52,6 +54,13 @@ export type BuildResponseCacheKeyFunction = (params: {
   sessionId: Maybe<string>;
   /** GraphQL Context */
   context: ExecutionArgs['contextValue'];
+  /** Extras of the query (won't be computed if not requested) */
+  extras: {
+    scope: NonNullable<CacheControlDirective['scope']>;
+    metadata: {
+      privateProperty?: string;
+    };
+  };
 }) => MaybePromise<string>;
 
 export type GetDocumentStringFunction = (executionArgs: ExecutionArgs) => string;
@@ -295,10 +304,28 @@ const getDocumentWithMetadataAndTTL = memoize4(function addTypeNameToDocument(
   return [visit(document, visitWithTypeInfo(typeInfo, visitor)), ttl];
 });
 
-type CacheControlDirective = {
+export type CacheControlDirective = {
   maxAge?: number;
   scope?: 'PUBLIC' | 'PRIVATE';
 };
+
+export let schema: GraphQLSchema;
+let ttlPerSchemaCoordinate: Record<string, CacheControlDirective['maxAge']> = {};
+let scopePerSchemaCoordinate: Record<string, CacheControlDirective['scope']> = {};
+
+export function isPrivate(
+  typeName: string,
+  data?: Record<string, NonNullable<CacheControlDirective['scope']>>,
+): boolean {
+  if (scopePerSchemaCoordinate[typeName] === 'PRIVATE') {
+    return true;
+  }
+  return data
+    ? Object.keys(data).some(
+        fieldName => scopePerSchemaCoordinate[`${typeName}.${fieldName}`] === 'PRIVATE',
+      )
+    : false;
+}
 
 export function useResponseCache<PluginContext extends Record<string, any> = {}>({
   cache = createInMemoryCache(),
@@ -307,8 +334,8 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   enabled,
   ignoredTypes = [],
   ttlPerType,
-  ttlPerSchemaCoordinate = {},
-  scopePerSchemaCoordinate = {},
+  ttlPerSchemaCoordinate: localTtlPerSchemaCoordinate = {},
+  scopePerSchemaCoordinate: localScopePerSchemaCoordinate = {},
   idFields = ['id'],
   invalidateViaMutation = true,
   buildResponseCacheKey = defaultBuildResponseCacheKey,
@@ -326,7 +353,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   enabled = enabled ? memoize1(enabled) : enabled;
 
   // never cache Introspections
-  ttlPerSchemaCoordinate = { 'Query.__schema': 0, ...ttlPerSchemaCoordinate };
+  ttlPerSchemaCoordinate = { 'Query.__schema': 0, ...localTtlPerSchemaCoordinate };
   if (ttlPerType) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -341,8 +368,8 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
     queries: { invalidateViaMutation, ttlPerSchemaCoordinate },
     mutations: { invalidateViaMutation }, // remove ttlPerSchemaCoordinate for mutations to skip TTL calculation
   };
+  scopePerSchemaCoordinate = { ...localScopePerSchemaCoordinate };
   const idFieldByTypeName = new Map<string, string>();
-  let schema: any;
 
   function isPrivate(typeName: string, data: Record<string, unknown>): boolean {
     if (scopePerSchemaCoordinate[typeName] === 'PRIVATE') {
@@ -558,13 +585,26 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
 
       return handleMaybePromise(
         () =>
-          buildResponseCacheKey({
-            documentString: getDocumentString(onExecuteParams.args),
-            variableValues: onExecuteParams.args.variableValues,
-            operationName: onExecuteParams.args.operationName,
-            sessionId,
-            context: onExecuteParams.args.contextValue,
-          }),
+          buildResponseCacheKey(
+            new Proxy(
+              {
+                documentString: getDocumentString(onExecuteParams.args),
+                variableValues: onExecuteParams.args.variableValues,
+                operationName: onExecuteParams.args.operationName,
+                sessionId,
+                context: onExecuteParams.args.contextValue,
+                extras: undefined as any,
+              },
+              {
+                get: (obj, prop) => {
+                  if (prop === 'extras') {
+                    return getScopeFromQuery(schema, onExecuteParams.args.document.loc.source.body);
+                  }
+                  return obj[prop as keyof typeof obj];
+                },
+              },
+            ),
+          ),
         cacheKey => {
           const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
           if (cacheInstance == null) {

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -3586,6 +3586,7 @@ describe('useResponseCache', () => {
           [
             useResponseCache({
               session: () => null,
+              includeExtensionMetadata: true,
               buildResponseCacheKey: ({ extras, ...rest }) => {
                 const { scope, metadata } = extras(schema);
                 expect(scope).toEqual('PRIVATE');
@@ -3674,11 +3675,12 @@ describe('useResponseCache', () => {
         [
           useResponseCache({
             session: () => null,
+            includeExtensionMetadata: true,
             buildResponseCacheKey: ({ extras, ...rest }) => {
               const { scope, metadata } = extras(schema);
               expect(scope).toEqual('PRIVATE');
-              expect(metadata.privateProperty).toEqual('User.name');
-              expect(metadata.hitCache).toEqual(multipleCalls ? true : undefined);
+              expect(metadata?.privateProperty).toEqual('User.name');
+              expect(metadata?.hitCache).toEqual(multipleCalls ? true : undefined);
               return defaultBuildResponseCacheKey(rest);
             },
             ttl: 200,

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -3285,7 +3285,7 @@ describe('useResponseCache', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    it('should not cache response with a type with a PRIVATE scope for request without session using @cachControl directive', async () => {
+    it('should not cache response with a type with a PRIVATE scope for request without session using @cacheControl directive', async () => {
       jest.useFakeTimers();
       const spy = jest.fn(() => [
         {
@@ -3445,7 +3445,7 @@ describe('useResponseCache', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    it('should not cache response with a field with PRIVATE scope for request without session using @cachControl directive', async () => {
+    it('should not cache response with a field with PRIVATE scope for request without session using @cacheControl directive', async () => {
       jest.useFakeTimers();
       const spy = jest.fn(() => [
         {
@@ -3522,6 +3522,186 @@ describe('useResponseCache', () => {
       await testInstance.execute(query);
       await testInstance.execute(query);
       expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    ['query', 'field', 'subfield'].forEach(type => {
+      it(`should return PRIVATE scope in buildResponseCacheKey when putting @cacheControl scope on ${type}`, async () => {
+        jest.useFakeTimers();
+        const spy = jest.fn(() => [
+          {
+            id: 1,
+            name: 'User 1',
+            comments: [
+              {
+                id: 1,
+                text: 'Comment 1 of User 1',
+              },
+            ],
+          },
+          {
+            id: 2,
+            name: 'User 2',
+            comments: [
+              {
+                id: 2,
+                text: 'Comment 2 of User 2',
+              },
+            ],
+          },
+        ]);
+
+        const schema = makeExecutableSchema({
+          typeDefs: /* GraphQL */ `
+            ${cacheControlDirective}
+            type Query {
+              users: [User!]! ${type === 'query' ? '@cacheControl(scope: PRIVATE)' : ''}
+            }
+
+            type User ${type === 'field' ? '@cacheControl(scope: PRIVATE)' : ''} {
+              id: ID!
+              name: String! ${type === 'subfield' ? '@cacheControl(scope: PRIVATE)' : ''}
+              comments: [Comment!]!
+              recentComment: Comment
+            }
+
+            type Comment {
+              id: ID!
+              text: String!
+            }
+          `,
+          resolvers: {
+            Query: {
+              users: spy,
+            },
+          },
+        });
+
+        function getPrivateProperty() {
+          if (type === 'query') return 'Query.users';
+          if (type === 'field') return 'User';
+          return 'User.name';
+        }
+
+        const testInstance = createTestkit(
+          [
+            useResponseCache({
+              session: () => null,
+              buildResponseCacheKey: ({ extras: { scope, metadata }, ...rest }) => {
+                expect(scope).toEqual('PRIVATE');
+                expect(metadata?.privateProperty).toEqual(getPrivateProperty());
+                return defaultBuildResponseCacheKey(rest);
+              },
+              ttl: 200,
+            }),
+          ],
+          schema,
+        );
+
+        const query = /* GraphQL */ `
+          query test {
+            users {
+              id
+              name
+              comments {
+                id
+                text
+              }
+            }
+          }
+        `;
+
+        await testInstance.execute(query);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should return PRIVATE scope in buildResponseCacheKey even when requesting property from a fragment', async () => {
+      jest.useFakeTimers();
+      const spy = jest.fn(() => [
+        {
+          id: 1,
+          name: 'User 1',
+          comments: [
+            {
+              id: 1,
+              text: 'Comment 1 of User 1',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'User 2',
+          comments: [
+            {
+              id: 2,
+              text: 'Comment 2 of User 2',
+            },
+          ],
+        },
+      ]);
+
+      const schema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          ${cacheControlDirective}
+          type Query {
+            users: [User!]!
+          }
+
+          type User {
+            id: ID!
+            name: String! @cacheControl(scope: PRIVATE)
+            comments: [Comment!]!
+            recentComment: Comment
+          }
+
+          type Comment {
+            id: ID!
+            text: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            users: spy,
+          },
+        },
+      });
+
+      const testInstance = createTestkit(
+        [
+          useResponseCache({
+            session: () => null,
+            buildResponseCacheKey: ({ extras: { scope, metadata }, ...rest }) => {
+              expect(scope).toEqual('PRIVATE');
+              expect(metadata?.privateProperty).toEqual('User.name');
+              return defaultBuildResponseCacheKey(rest);
+            },
+            ttl: 200,
+          }),
+        ],
+        schema,
+      );
+
+      const query = /* GraphQL */ `
+        query test {
+          users {
+            ...user
+          }
+        }
+
+        fragment user on User {
+          id
+          name
+          comments {
+            id
+            text
+          }
+        }
+      `;
+
+      await testInstance.execute(query);
+
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should cache correctly for session with ttl being a valid number', async () => {


### PR DESCRIPTION
Issue related : https://github.com/n1ru4l/envelop/issues/2181

## Description

Include a new `extras` property to get `scope` (as a `Proxy` to avoid performance impact when unused) in `buildResponseCacheKey`, allowing more granularity over cache control.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

I added some unit tests to check that `PRIVATE` scope is correctly retrieved from a query, when directive `@cacheControl(scope: PRIVATE)` is put on query, field and subfield.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
