### PR TITLE
[plugins/prometheus] Fix registry metrics duplication

### DIFF
--- a/.changeset/spotty-files-jam.md
+++ b/.changeset/spotty-files-jam.md
@@ -2,4 +2,83 @@
 '@envelop/prometheus': major
 ---
 
-TODO
+Adds a cache for metrics definition (Summary, Histogram and Counter).
+
+Fixes an issue preventing this plugin to be initialized multiple times, leading to metrics
+duplication error (https://github.com/ardatan/graphql-mesh/issues/6545).
+
+## Behavior Breaking Change:
+
+Due to Prometheus client API limitations, a metric is only defined once for a given registry. This
+means that if the configuration of the metrics, it will be silently ignored on plugin
+re-initialization.
+
+This is to avoid potential loss of metrics data produced between the plugin re-initialization and
+the last pull by the prometheus agent.
+
+If you need to be sure metrics configuration is up to date after a plugin re-initialization, you can
+either:
+
+- restart the whole node process instead of just recreating a graphql server at runtime
+- clear the registry using `registry.clear()` before plugin re-initialization:
+  ```ts
+  function usePrometheusWithReset() {
+    registry.clear()
+    return usePrometheus({ ... })
+  }
+  ```
+- use a new registry for each plugin instance:
+  ```ts
+  function usePrometheusWithRegistry() {
+    const registry = new Registry()
+    return usePrometheus({
+      registry,
+      ...
+    })
+  }
+  ```
+
+Keep in mind that this implies potential data loss in pull mode.
+
+## API Breaking Change:
+
+To ensure metrics from being registered multiple times on the same registry, the signature of
+`createHistogram`, `createSummary` and `createCounter` have been changed to now include the registry
+as a mandatory parameter.
+
+If you were customizing metrics parameters, you will need to update the metric definitions
+
+```diff
+usePrometheus({
+  execute: createHistogram({
++   registry: registry
+    histogram: new Histogram({
+      name: 'my_custom_name',
+      help: 'HELP ME',
+      labelNames: ['opText'] as const,
+-     registers: [registry],
+    }),
+    fillLabelsFn: () => {}
+  }),
+  requestCount: createCounter({
++   registry: registry
+    histogram: new Histogram({
+      name: 'my_custom_name',
+      help: 'HELP ME',
+      labelNames: ['opText'] as const,
+-     registers: [registry],
+    }),
+    fillLabelsFn: () => {}
+  }),
+  requestSummary: createSummary({
++   registry: registry
+    histogram: new Histogram({
+      name: 'my_custom_name',
+      help: 'HELP ME',
+      labelNames: ['opText'] as const,
+-     registers: [registry],
+    }),
+    fillLabelsFn: () => {}
+  }),
+})
+```

--- a/.changeset/spotty-files-jam.md
+++ b/.changeset/spotty-files-jam.md
@@ -1,0 +1,5 @@
+---
+'@envelop/prometheus': major
+---
+
+TODO

--- a/packages/plugins/prometheus/README.md
+++ b/packages/plugins/prometheus/README.md
@@ -106,14 +106,14 @@ const getEnveloped = envelop({
     usePrometheus({
       // all optional, and by default, all set to false, please opt-in to the metrics you wish to get
       parse: createHistogram({
+        registry: registry // make sure to add your custom registry, if you are not using the default one
         histogram: new Histogram({
           name: 'my_custom_name',
           help: 'HELP ME',
           labelNames: ['opText'] as const,
-          registers: [registry] // make sure to add your custom registry, if you are not using the default one
         }),
         fillLabelsFn: params => {
-          // if you wish to fill your `lables` with metadata, you can use the params in order to get access to things like DocumentNode, operationName, operationType, `error` (for error metrics) and `info` (for resolvers metrics)
+          // if you wish to fill your `labels` with metadata, you can use the params in order to get access to things like DocumentNode, operationName, operationType, `error` (for error metrics) and `info` (for resolvers metrics)
           return {
             opText: print(params.document)
           }

--- a/packages/plugins/prometheus/README.md
+++ b/packages/plugins/prometheus/README.md
@@ -95,7 +95,7 @@ create a custom extraction function for every `Histogram` / `Summary` / `Counter
 
 ```ts
 import { execute, parse, specifiedRules, subscribe, validate } from 'graphql'
-import { Histogram } from 'prom-client'
+import { Histogram, register as registry } from 'prom-client'
 import { envelop, useEngine } from '@envelop/core'
 import { createHistogram, usePrometheus } from '@envelop/prometheus'
 
@@ -123,3 +123,24 @@ const getEnveloped = envelop({
   ]
 })
 ```
+
+## Caveats
+
+Due to Prometheus client API limitations, if this plugin is initialized multiple times, only the
+metrics configuration of the first initialization will be applied.
+
+If necessary, use a different registry instance for each plugin instance, or clear the registry
+before plugin initialization.
+
+```ts
+function usePrometheusWithRegistry() {
+  const registry = new Registry()
+  return usePrometheus({
+    registry,
+    ...
+  })
+}
+```
+
+Keep in mind that this implies potential data loss in pull mode if some data is produced between
+last pull and the re-initialization of the plugin.

--- a/packages/plugins/prometheus/README.md
+++ b/packages/plugins/prometheus/README.md
@@ -134,7 +134,12 @@ before plugin initialization.
 
 ```ts
 function usePrometheusWithRegistry() {
+  // create a new registry instance for each plugin instance
   const registry = new Registry()
+
+  // or just clear the registry if you use only on plugin instance at a time
+  registry.clear()
+
   return usePrometheus({
     registry,
     ...

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import { ExecutionResult, GraphQLSchema, TypeInfo } from 'graphql';
-import { Counter, register as defaultRegistry, Histogram, Summary } from 'prom-client';
+import { Counter, register as defaultRegistry, Summary } from 'prom-client';
 import {
   isAsyncIterable,
   isIntrospectionOperationString,
@@ -29,11 +29,11 @@ import {
 } from './utils.js';
 
 export {
+  FillLabelsFnParams,
   PrometheusTracingPluginConfig,
   createCounter,
   createHistogram,
   createSummary,
-  FillLabelsFnParams,
 };
 
 export const fillLabelsFnParamsMap = new WeakMap<any, FillLabelsFnParams | null>();
@@ -80,7 +80,8 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.resolvers
       : config.resolvers === true || typeof config.resolvers === 'string'
         ? createHistogram({
-            histogram: new Histogram({
+            registry: config.registry || defaultRegistry,
+            histogram: {
               name:
                 typeof config.resolvers === 'string'
                   ? config.resolvers
@@ -93,8 +94,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
                 'typeName',
                 'returnType',
               ].filter(label => labelExists(config, label)),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,
@@ -111,7 +111,8 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.requestTotalDuration
       : config.requestTotalDuration === true || typeof config.requestTotalDuration === 'string'
         ? createHistogram({
-            histogram: new Histogram({
+            registry: config.registry || defaultRegistry,
+            histogram: {
               name:
                 typeof config.requestTotalDuration === 'string'
                   ? config.requestTotalDuration
@@ -120,8 +121,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
               labelNames: ['operationType', 'operationName'].filter(label =>
                 labelExists(config, label),
               ),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -27,11 +27,17 @@ import {
   instrumentRegistry,
   labelExists,
   shouldTraceFieldResolver,
+  type CounterAndLabels,
+  type HistogramAndLabels,
+  type SummaryAndLabels,
 } from './utils.js';
 
 export {
+  CounterAndLabels,
   FillLabelsFnParams,
+  HistogramAndLabels,
   PrometheusTracingPluginConfig,
+  SummaryAndLabels,
   createCounter,
   createHistogram,
   createSummary,

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import { ExecutionResult, GraphQLSchema, TypeInfo } from 'graphql';
-import { Counter, register as defaultRegistry, Summary } from 'prom-client';
+import { register as defaultRegistry } from 'prom-client';
 import {
   isAsyncIterable,
   isIntrospectionOperationString,
@@ -41,6 +41,7 @@ export const execStartTimeMap = new WeakMap<any, number>();
 
 export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugin => {
   let typeInfo: TypeInfo | null = null;
+  const registry = config.registry || defaultRegistry;
 
   const parseHistogram = getHistogramFromConfig(
     config,
@@ -80,7 +81,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.resolvers
       : config.resolvers === true || typeof config.resolvers === 'string'
         ? createHistogram({
-            registry: config.registry || defaultRegistry,
+            registry,
             histogram: {
               name:
                 typeof config.resolvers === 'string'
@@ -111,7 +112,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.requestTotalDuration
       : config.requestTotalDuration === true || typeof config.requestTotalDuration === 'string'
         ? createHistogram({
-            registry: config.registry || defaultRegistry,
+            registry,
             histogram: {
               name:
                 typeof config.requestTotalDuration === 'string'
@@ -135,7 +136,8 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.requestSummary
       : config.requestSummary === true || typeof config.requestSummary === 'string'
         ? createSummary({
-            summary: new Summary({
+            registry,
+            summary: {
               name:
                 typeof config.requestSummary === 'string'
                   ? config.requestSummary
@@ -144,8 +146,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
               labelNames: ['operationType', 'operationName'].filter(label =>
                 labelExists(config, label),
               ),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,
@@ -159,15 +160,15 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.errors
       : config.errors === true || typeof config.errors === 'string'
         ? createCounter({
-            counter: new Counter({
+            registry,
+            counter: {
               name:
                 typeof config.errors === 'string' ? config.errors : 'graphql_envelop_error_result',
               help: 'Counts the amount of errors reported from all phases',
               labelNames: ['operationType', 'operationName', 'path', 'phase'].filter(label =>
                 labelExists(config, label),
               ),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,
@@ -183,7 +184,8 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.requestCount
       : config.requestCount === true || typeof config.requestCount === 'string'
         ? createCounter({
-            counter: new Counter({
+            registry,
+            counter: {
               name:
                 typeof config.requestCount === 'string'
                   ? config.requestCount
@@ -192,8 +194,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
               labelNames: ['operationType', 'operationName'].filter(label =>
                 labelExists(config, label),
               ),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,
@@ -207,7 +208,8 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.deprecatedFields
       : config.deprecatedFields === true || typeof config.deprecatedFields === 'string'
         ? createCounter({
-            counter: new Counter({
+            registry,
+            counter: {
               name:
                 typeof config.deprecatedFields === 'string'
                   ? config.deprecatedFields
@@ -216,8 +218,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
               labelNames: ['operationType', 'operationName', 'fieldName', 'typeName'].filter(
                 label => labelExists(config, label),
               ),
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: params =>
               filterFillParamsFnParams(config, {
                 operationName: params.operationName!,
@@ -233,14 +234,14 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugi
       ? config.schemaChangeCount
       : config.schemaChangeCount === true || typeof config.schemaChangeCount === 'string'
         ? createCounter({
-            counter: new Counter({
+            registry,
+            counter: {
               name:
                 typeof config.schemaChangeCount === 'string'
                   ? config.schemaChangeCount
                   : 'graphql_envelop_schema_change',
               help: 'Counts the amount of schema changes',
-              registers: [config.registry || defaultRegistry],
-            }),
+            },
             fillLabelsFn: () => ({}),
           })
         : undefined;

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -24,6 +24,7 @@ import {
   FillLabelsFnParams,
   filterFillParamsFnParams,
   getHistogramFromConfig,
+  instrumentRegistry,
   labelExists,
   shouldTraceFieldResolver,
 } from './utils.js';
@@ -41,7 +42,7 @@ export const execStartTimeMap = new WeakMap<any, number>();
 
 export const usePrometheus = (config: PrometheusTracingPluginConfig = {}): Plugin => {
   let typeInfo: TypeInfo | null = null;
-  const registry = config.registry || defaultRegistry;
+  const registry = instrumentRegistry(config.registry || defaultRegistry);
 
   const parseHistogram = getHistogramFromConfig(
     config,

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -78,14 +78,14 @@ export function createFillLabelFnParams(
   });
 }
 
-export type FillLabelsFn<LabelNames extends string> = (
-  params: FillLabelsFnParams,
+export type FillLabelsFn<LabelNames extends string, Params extends Record<string, any>> = (
+  params: Params,
   rawContext: any,
-) => Record<LabelNames, string>;
+) => Record<LabelNames, string | number>;
 
-export type HistogramAndLabels<LabelNames extends string> = {
+export type HistogramAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   histogram: Histogram<LabelNames>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
 };
 
 export function registerHistogram<LabelNames extends string>(
@@ -103,11 +103,14 @@ export function registerHistogram<LabelNames extends string>(
   return registryHistograms.get(conf.name)!;
 }
 
-export function createHistogram<LabelNames extends string>(options: {
+export function createHistogram<
+  LabelNames extends string,
+  Params extends Record<string, any> = FillLabelsFnParams,
+>(options: {
   registry: Registry;
   histogram: Omit<HistogramConfiguration<LabelNames>, 'registers'>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
-}): HistogramAndLabels<LabelNames> {
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+}): HistogramAndLabels<LabelNames, Params> {
   return {
     histogram: registerHistogram(options.registry, options.histogram),
     // histogram: new Histogram(options.histogram),
@@ -115,9 +118,9 @@ export function createHistogram<LabelNames extends string>(options: {
   };
 }
 
-export type SummaryAndLabels<LabelNames extends string> = {
+export type SummaryAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   summary: Summary<LabelNames>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
 };
 
 export function registerSummary<LabelNames extends string>(
@@ -135,20 +138,23 @@ export function registerSummary<LabelNames extends string>(
   return registrySummaries.get(conf.name)!;
 }
 
-export function createSummary<LabelNames extends string>(options: {
+export function createSummary<
+  LabelNames extends string,
+  Params extends Record<string, any> = FillLabelsFnParams,
+>(options: {
   registry: Registry;
   summary: Omit<SummaryConfiguration<LabelNames>, 'registers'>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
-}): SummaryAndLabels<LabelNames> {
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+}): SummaryAndLabels<LabelNames, Params> {
   return {
     summary: registerSummary(options.registry, options.summary),
     fillLabelsFn: options.fillLabelsFn,
   };
 }
 
-export type CounterAndLabels<LabelNames extends string> = {
+export type CounterAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   counter: Counter<LabelNames>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
 };
 
 export function registerCounter<LabelNames extends string>(
@@ -166,11 +172,14 @@ export function registerCounter<LabelNames extends string>(
   return registryCounters.get(conf.name)!;
 }
 
-export function createCounter<LabelNames extends string>(options: {
+export function createCounter<
+  LabelNames extends string,
+  Params extends Record<string, any> = FillLabelsFnParams,
+>(options: {
   registry: Registry;
   counter: Omit<CounterConfiguration<LabelNames>, 'registers'>;
-  fillLabelsFn: FillLabelsFn<LabelNames>;
-}): CounterAndLabels<LabelNames> {
+  fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+}): CounterAndLabels<LabelNames, Params> {
   return {
     counter: registerCounter(options.registry, options.counter),
     fillLabelsFn: options.fillLabelsFn,

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -257,3 +257,17 @@ export function filterFillParamsFnParams(
 ) {
   return Object.fromEntries(Object.entries(params).filter(([key]) => labelExists(config, key)));
 }
+
+const clearRegistry = new WeakMap<Registry, () => void>();
+export function instrumentRegistry(registry: Registry) {
+  if (!clearRegistry.has(registry)) {
+    clearRegistry.set(registry, registry.clear.bind(registry));
+  }
+  registry.clear = () => {
+    histograms.delete(registry);
+    summaries.delete(registry);
+    counters.delete(registry);
+    clearRegistry.get(registry)!();
+  };
+  return registry;
+}

--- a/packages/plugins/prometheus/test/prom.spec.ts
+++ b/packages/plugins/prometheus/test/prom.spec.ts
@@ -729,10 +729,24 @@ describe('Prom Metrics plugin', () => {
 
   it('should be able to be initialized multiple times', async () => {
     const registry = new Registry();
+    const allMetrics = {
+      parse: true,
+      requestCount: true,
+      requestSummary: true,
+      errors: true,
+      contextBuilding: true,
+      deprecatedFields: true,
+      execute: true,
+      requestTotalDuration: true,
+      resolvers: true,
+      schemaChangeCount: true,
+      subscribe: true,
+      validate: true,
+    };
 
-    prepare({ parse: true }, registry); // fake initialization to make sure it doesn't break
+    prepare(allMetrics, registry); // fake initialization to make sure it doesn't break
 
-    const { execute } = prepare({ parse: true }, registry);
+    const { execute } = prepare(allMetrics, registry);
     const result = await execute('{ regularField }');
     assertSingleExecutionValue(result);
 

--- a/packages/plugins/prometheus/test/prom.spec.ts
+++ b/packages/plugins/prometheus/test/prom.spec.ts
@@ -1,5 +1,5 @@
 import { ASTNode, buildSchema, print as graphQLPrint } from 'graphql';
-import { Counter, Registry } from 'prom-client';
+import { Registry } from 'prom-client';
 import { useExtendContext } from '@envelop/core';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -484,12 +484,12 @@ describe('Prom Metrics plugin', () => {
         {
           execute: true,
           errors: createCounter({
-            counter: new Counter({
+            registry,
+            counter: {
               name: 'test_error',
               help: 'HELP ME',
               labelNames: ['opText', 'errorMessage'] as const,
-              registers: [registry],
-            }),
+            },
             fillLabelsFn: params => {
               return {
                 opText: print(params.document!),

--- a/packages/plugins/prometheus/test/prom.spec.ts
+++ b/packages/plugins/prometheus/test/prom.spec.ts
@@ -748,4 +748,17 @@ describe('Prom Metrics plugin', () => {
 
     expect(h1 === h2).toBe(false);
   });
+
+  it('should allow to clear the registry between initializations', async () => {
+    const registry = new Registry();
+
+    prepare({ parse: true }, registry); // fake initialization to make sure it doesn't break
+    registry.clear();
+    const { execute, allMetrics } = prepare({ parse: true }, registry);
+    const result = await execute('{ regularField }');
+    assertSingleExecutionValue(result);
+
+    expect(result.errors).toBeUndefined();
+    expect(await allMetrics()).toContain('graphql_envelop_phase_parse_count{');
+  });
 });


### PR DESCRIPTION
## Description

Is this plugin is initialized multiple times with the same registry (which can happen in the context of Mesh when polling is enabled for example).

This PR aims to fix this.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

## Further comments

Current solution rely on caching Histograms with a Map to reuse them instead of creating them each time.

But this has a drawback: if the configuration of those Histograms changes, this changement will be silently ignored and the old configuration will be kept in use.
