### PR TITLE
Pin to the latest compatibility date for Cloudflare workers

### DIFF
--- a/.changeset/healthy-hotels-design.md
+++ b/.changeset/healthy-hotels-design.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache-cloudflare-kv': minor
+---
+
+Pin response-cache-cloudflare-kv to the latest compatibility date for Cloudflare worker types

--- a/packages/plugins/response-cache-cloudflare-kv/package.json
+++ b/packages/plugins/response-cache-cloudflare-kv/package.json
@@ -50,7 +50,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.20231121.0",
+    "@cloudflare/workers-types": "^4.20240512.0",
     "@envelop/response-cache": "^6.1.2",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },

--- a/packages/plugins/response-cache-cloudflare-kv/src/index.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExecutionResult } from 'graphql';
-import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types/2023-07-01';
 import type { Cache, CacheEntityRecord } from '@envelop/response-cache';
 import { buildOperationKey } from './cache-key.js';
 import { invalidate } from './invalidate.js';

--- a/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult } from 'graphql';
-import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types/2023-07-01';
 import type { Cache } from '@envelop/response-cache';
 import { buildOperationKey } from '../src/cache-key.js';
 import { createKvCache, type KvCacheConfig } from '../src/index.js';

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult } from 'graphql';
-import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types/2023-07-01';
 import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
 import { KvCacheConfig } from '../src/index.js';
 import { getAllKvKeysForPrefix, invalidate } from '../src/invalidate.js';

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult } from 'graphql';
-import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types';
+import type { ExecutionContext, KVNamespace } from '@cloudflare/workers-types/2023-07-01';
 import { buildEntityKey, buildOperationKey } from '../src/cache-key.js';
 import { KvCacheConfig } from '../src/index.js';
 import { getAllKvKeysForPrefix } from '../src/invalidate.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1394,8 +1394,8 @@ importers:
   packages/plugins/response-cache-cloudflare-kv:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20231121.0
-        version: 4.20231121.0
+        specifier: ^4.20240512.0
+        version: 4.20240512.0
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -2654,11 +2654,11 @@ packages:
   '@changesets/write@0.1.9':
     resolution: {integrity: sha512-E90ZrsrfJVOOQaP3Mm5Xd7uDwBAqq3z5paVEavTHKA8wxi7NAL8CmjgbGxSFuiP7ubnJA2BuHlrdE4z86voGOg==}
 
-  '@cloudflare/workers-types@4.20231121.0':
-    resolution: {integrity: sha512-+kWfpCkqiepwAKXyHoE0gnkPgkLhz0/9HOBIGhHRsUvUKvhUtm3mbqqoGRWgF1qcjzrDUBbrrOq4MYHfFtc2RA==}
-
   '@cloudflare/workers-types@4.20240320.1':
     resolution: {integrity: sha512-CiYtVpQURPgQqtBKkmOAnfPElVZuD7Xyf1IxKtKp2B4aB9gnooapwJhzeY8c4Ls4u17SgMS0MprOkrgYwzZ6xg==}
+
+  '@cloudflare/workers-types@4.20240512.0':
+    resolution: {integrity: sha512-o2yTEWg+YK/I1t/Me+dA0oarO0aCbjibp6wSeaw52DSE9tDyKJ7S+Qdyw/XsMrKn4t8kF6f/YOba+9O4MJfW9w==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -9838,8 +9838,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.1:
-    resolution: {integrity: sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==}
+  semver@7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -12824,9 +12824,9 @@ snapshots:
       human-id: 1.0.2
       prettier: 1.19.1
 
-  '@cloudflare/workers-types@4.20231121.0': {}
-
   '@cloudflare/workers-types@4.20240320.1': {}
+
+  '@cloudflare/workers-types@4.20240512.0': {}
 
   '@colors/colors@1.5.0': {}
 
@@ -13767,7 +13767,7 @@ snapshots:
 
   '@miniflare/shared-test-environment@2.14.1':
     dependencies:
-      '@cloudflare/workers-types': 4.20240320.1
+      '@cloudflare/workers-types': 4.20240512.0
       '@miniflare/cache': 2.14.1
       '@miniflare/core': 2.14.1
       '@miniflare/d1': 2.14.1
@@ -19247,7 +19247,7 @@ snapshots:
       acorn: 8.11.3
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      semver: 7.6.1
+      semver: 7.6.2
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -22067,7 +22067,7 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.6.1: {}
+  semver@7.6.2: {}
 
   send@0.17.1:
     dependencies:


### PR DESCRIPTION
This change applies to the kv-response-cache plugin

## Description

The `@cloudflare/worker-types` package has multiple versions of its types that are pinned to different compatibility dates. The When you create a new cloudflare project using their CLI, they now default to the latest date whcih is `2023-07-01`.

This PR updates the imports for the kv response cache plugin to use the name compatibility dates as the default for new projects, this should incraese compatibility for users.

For issue #2104 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Testing this is a bit challenging. The types are correct locally, the hope is that when this package is imported there will be fewer conflicts with types.

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
