### PR TITLE
enhance(response-cache/cfw-kv): simplify cache init

### DIFF
--- a/.changeset/unlucky-pillows-retire.md
+++ b/.changeset/unlucky-pillows-retire.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+Accept a factory function to `cache` that takes the context and returns the cache implementation

--- a/.changeset/young-bears-tease.md
+++ b/.changeset/young-bears-tease.md
@@ -2,8 +2,8 @@
 '@envelop/response-cache-cloudflare-kv': minor
 ---
 
-BREAKING: Now the cache implementation does not require the `ExecutionContext` but the `waitUntil`
-method from it;
+BREAKING: Now the cache implementation does not require the `ExecutionContext` or `KVNamespace`
+instance but only the name of the namespace
 
 ```ts
 import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'

--- a/.changeset/young-bears-tease.md
+++ b/.changeset/young-bears-tease.md
@@ -15,9 +15,8 @@ import { typeDefs } from './graphql-schema/typeDefs.generated'
 export type Env = {
   GRAPHQL_RESPONSE_CACHE: KVNamespace
 }
-export type GraphQLContext = YogaInitialContext & Env & ExecutionContext
 
-const graphqlServer = createYoga<GraphQLContext>({
+const graphqlServer = createYoga<Env & ExecutionContext>({
   schema: createSchema({ typeDefs, resolvers }),
   plugins: [
     useResponseCache({

--- a/.changeset/young-bears-tease.md
+++ b/.changeset/young-bears-tease.md
@@ -1,27 +1,9 @@
-## `@envelop/response-cache-cloudflare-kv`
+---
+'@envelop/response-cache-cloudflare-kv': minor
+---
 
-- Supports [Cloudflare KV](https://developers.cloudflare.com/kv/) cache for
-  `@envelop/response-cache` plugin
-- Suitable for graphql servers running on [Cloudflare Workers](https://workers.cloudflare.com/)
-
-[Check out the GraphQL Response Cache Guide for more information](https://envelop.dev/docs/guides/adding-a-graphql-response-cache)
-
-## Getting Started
-
-```bash
-yarn add @envelop/response-cache
-yarn add @envelop/response-cache-cloudflare-kv
-```
-
-## Usage Example
-
-In order to use the Cloudflare KV cache, you need to:
-
-- Create a Cloudflare KV namespace
-- Add that namespace to your `wrangler.toml` in order to access it from your worker. Read the
-  [KV docs](https://developers.cloudflare.com/kv/get-started/) to get started.
-- Pass the KV namespace to the `createKvCache` function and set to the `useResponseCache` plugin
-  options. See the example below.
+BREAKING: Now the cache implementation does not require the `ExecutionContext` but the `waitUntil`
+method from it;
 
 ```ts
 import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'

--- a/.changeset/young-bears-tease.md
+++ b/.changeset/young-bears-tease.md
@@ -20,12 +20,10 @@ const graphqlServer = createYoga<Env & ExecutionContext>({
   schema: createSchema({ typeDefs, resolvers }),
   plugins: [
     useResponseCache({
-      cache: ctx =>
-        createKvCache({
-          KV: ctx.GRAPHQL_RESPONSE_CACHE,
-          waitUntil: ctx.waitUntil,
-          keyPrefix: 'graphql' // optional
-        }),
+      cache: createKvCache({
+        KVName: 'GRAPHQL_RESPONSE_CACHE',
+        keyPrefix: 'graphql' // optional
+      }),
       session: () => null,
       includeExtensionMetadata: true,
       ttl: 1000 * 10 // 10 seconds

--- a/packages/plugins/response-cache-cloudflare-kv/README.md
+++ b/packages/plugins/response-cache-cloudflare-kv/README.md
@@ -33,9 +33,8 @@ import { typeDefs } from './graphql-schema/typeDefs.generated'
 export type Env = {
   GRAPHQL_RESPONSE_CACHE: KVNamespace
 }
-export type GraphQLContext = YogaInitialContext & Env & ExecutionContext
 
-const graphqlServer = createYoga<GraphQLContext>({
+const graphqlServer = createYoga<Env & ExecutionContext>({
   schema: createSchema({ typeDefs, resolvers }),
   plugins: [
     useResponseCache({

--- a/packages/plugins/response-cache-cloudflare-kv/README.md
+++ b/packages/plugins/response-cache-cloudflare-kv/README.md
@@ -38,12 +38,10 @@ const graphqlServer = createYoga<Env & ExecutionContext>({
   schema: createSchema({ typeDefs, resolvers }),
   plugins: [
     useResponseCache({
-      cache: ctx =>
-        createKvCache({
-          KV: ctx.GRAPHQL_RESPONSE_CACHE,
-          waitUntil: ctx.waitUntil,
-          keyPrefix: 'graphql' // optional
-        }),
+      cache: createKvCache({
+        KVName: 'GRAPHQL_RESPONSE_CACHE',
+        keyPrefix: 'graphql' // optional
+      }),
       session: () => null,
       includeExtensionMetadata: true,
       ttl: 1000 * 10 // 10 seconds

--- a/packages/plugins/response-cache-cloudflare-kv/src/index.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/index.ts
@@ -110,7 +110,7 @@ export function createKvCache<
           return invalidatePromise;
         }
         // Do not block execution of the worker while invalidating the cache
-        ctx.waitUntil(invalidate(entities, ctx[config.KVName], config.keyPrefix));
+        ctx.waitUntil(invalidatePromise);
       },
     };
   };

--- a/packages/plugins/response-cache-cloudflare-kv/src/index.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/index.ts
@@ -36,7 +36,7 @@ export function createKvCache<
   TServerContext extends {
     [TKey in TKVNamespaceName]: KVNamespace;
   } & {
-    waitUntil(fn: Promise<unknown>): void;
+    waitUntil(promise: Promise<unknown>): void;
   },
 >(config: KvCacheConfig<TKVNamespaceName>): (ctx: TServerContext) => Cache {
   if (config.cacheReadTTL && config.cacheReadTTL < 60000) {

--- a/packages/plugins/response-cache-cloudflare-kv/src/set.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/src/set.ts
@@ -1,7 +1,7 @@
 import type { ExecutionResult } from 'graphql';
+import { KVNamespace } from '@cloudflare/workers-types';
 import type { CacheEntityRecord } from '@envelop/response-cache';
 import { buildEntityKey, buildOperationKey } from './cache-key.js';
-import type { KvCacheConfig } from './index.js';
 
 export async function set(
   /** id/hash of the operation */
@@ -12,15 +12,16 @@ export async function set(
   entities: Iterable<CacheEntityRecord>,
   /** how long the operation should be cached (in milliseconds) */
   ttl: number,
-  config: KvCacheConfig,
+  KV: KVNamespace,
+  keyPrefix?: string,
 ): Promise<void> {
   const ttlInSeconds = Math.max(Math.floor(ttl / 1000), 60); // KV TTL must be at least 60 seconds
-  const operationKey = buildOperationKey(id, config.keyPrefix);
+  const operationKey = buildOperationKey(id, keyPrefix);
   const operationKeyWithoutPrefix = buildOperationKey(id);
   const kvPromises: Promise<unknown>[] = []; // Collecting all the KV operations so we can await them all at once
 
   kvPromises.push(
-    config.KV.put(operationKey, JSON.stringify(data), {
+    KV.put(operationKey, JSON.stringify(data), {
       expirationTtl: ttlInSeconds,
       metadata: { operationKey },
     }),
@@ -29,9 +30,9 @@ export async function set(
   // Store connections between the entities and the operation key
   // E.g if the entities are User:1 and User:2, we need to know that the operation key is connected to both of them
   for (const entity of entities) {
-    const entityKey = buildEntityKey(entity.typename, entity.id, config.keyPrefix);
+    const entityKey = buildEntityKey(entity.typename, entity.id, keyPrefix);
     kvPromises.push(
-      config.KV.put(`${entityKey}:${operationKeyWithoutPrefix}`, operationKey, {
+      KV.put(`${entityKey}:${operationKeyWithoutPrefix}`, operationKey, {
         expirationTtl: ttlInSeconds,
         metadata: { operationKey },
       }),

--- a/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
@@ -60,7 +60,7 @@ describe('@envelop/response-cache-cloudflare-kv integration tests', () => {
 
   test('should return null when calling get() on a non-existent key', async () => {
     const result = await cache.get(dataKey);
-    expect(result).toBeUndefined();
+    expect(result).toBeFalsy();
   });
 
   test('should return null when calling get() on an invalidated key', async () => {
@@ -78,7 +78,7 @@ describe('@envelop/response-cache-cloudflare-kv integration tests', () => {
     await getMiniflareWaitUntil(executionContext);
 
     const result = await cache.get(dataKey);
-    expect(result).toBeUndefined();
+    expect(result).toBeFalsy();
 
     const allKeys = await KV.list();
     expect(allKeys.keys.length).toEqual(0);

--- a/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/index.spec.ts
@@ -29,7 +29,7 @@ describe('@envelop/response-cache-cloudflare-kv integration tests', () => {
     executionContext = new ExecutionContext();
     config = {
       KV: env.GRAPHQL_RESPONSE_CACHE,
-      ctx: executionContext,
+      waitUntil: executionContext.waitUntil,
       keyPrefix: 'vitest',
     };
     maxTtl = 60 * 1000; // 1 minute

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -25,7 +25,7 @@ describe('invalidate.test.ts', () => {
       executionContext = new ExecutionContext();
       config = {
         KV: env.GRAPHQL_RESPONSE_CACHE,
-        ctx: executionContext,
+        waitUntil: executionContext.waitUntil,
         keyPrefix,
       };
       maxTtl = 60 * 1000; // 1 minute
@@ -102,7 +102,7 @@ describe('invalidate.test.ts', () => {
       executionContext = new ExecutionContext();
       config = {
         KV: env.GRAPHQL_RESPONSE_CACHE,
-        ctx: executionContext,
+        waitUntil: executionContext.waitUntil,
         keyPrefix,
       };
       maxTtl = 60 * 1000; // 1 minute

--- a/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/invalidate.spec.ts
@@ -10,31 +10,30 @@ type Env = {
   GRAPHQL_RESPONSE_CACHE: KVNamespace;
 };
 
+const keyPrefix = 'vitest';
+let maxTtl: number;
+let KV: KVNamespace;
+
+async function collectAllKeys(prefix: string) {
+  const keys = [];
+  for await (const kvKey of getAllKvKeysForPrefix(prefix, KV)) {
+    keys.push(kvKey);
+  }
+  return keys;
+}
+
 describe('invalidate.test.ts', () => {
-  let env: Env;
-  let maxTtl: number;
-  let executionContext: ExecutionContext;
-  let config: KvCacheConfig;
-  const keyPrefix = 'vitest';
-
+  beforeEach(() => {
+    // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
+    const env = getMiniflareBindings<Env>();
+    KV = env.GRAPHQL_RESPONSE_CACHE;
+    maxTtl = 60 * 1000; // 1 minute
+  });
   describe('_getAllKvKeysForPrefix()', () => {
-    beforeEach(() => {
-      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      env = getMiniflareBindings<Env>();
-      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      executionContext = new ExecutionContext();
-      config = {
-        KV: env.GRAPHQL_RESPONSE_CACHE,
-        waitUntil: executionContext.waitUntil,
-        keyPrefix,
-      };
-      maxTtl = 60 * 1000; // 1 minute
-    });
-
     test('should successfully iterate over a KV namespace with no keys', async () => {
       // kv cache has no keys at this point
       const keys = [];
-      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix(keyPrefix, KV)) {
         keys.push(kvKey);
       }
       expect(keys).toEqual([]);
@@ -43,17 +42,17 @@ describe('invalidate.test.ts', () => {
     test('should successfully iterate over a KV namespace with less than 1000 keys', async () => {
       // setup kv cache
       for (let i = 0; i < 500; i++) {
-        await env.GRAPHQL_RESPONSE_CACHE.put(`vitest:entity:User:${i}`, 'value', {
-          metadata: { operationKey: `vitest:operation:${i}` },
+        await KV.put(`${keyPrefix}:entity:User:${i}`, 'value', {
+          metadata: { operationKey: `${keyPrefix}:operation:${i}` },
         });
       }
 
       const keys = [];
-      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix(keyPrefix, KV)) {
         keys.push(kvKey);
         const userId = kvKey.name.split(':')[3];
         expect(kvKey.metadata).toEqual({
-          operationKey: `vitest:operation:${userId}`,
+          operationKey: `${keyPrefix}:operation:${userId}`,
         });
       }
       expect(keys.length).toEqual(500);
@@ -62,23 +61,22 @@ describe('invalidate.test.ts', () => {
     test('should successfully iterate over a KV namespace with more than 1000 keys', async () => {
       // setup kv cache
       for (let i = 0; i < 1500; i++) {
-        await env.GRAPHQL_RESPONSE_CACHE.put(`vitest:entity:User:${i}`, 'value', {
-          metadata: { operationKey: `vitest:operation:${i}` },
+        await KV.put(`${keyPrefix}:entity:User:${i}`, 'value', {
+          metadata: { operationKey: `${keyPrefix}:operation:${i}` },
         });
       }
 
       const keys = [];
-      for await (const kvKey of getAllKvKeysForPrefix('vitest', config)) {
+      for await (const kvKey of getAllKvKeysForPrefix(keyPrefix, KV)) {
         keys.push(kvKey);
         const indexId = kvKey.name.split(':')[3];
         expect(kvKey.metadata).toEqual({
-          operationKey: `vitest:operation:${indexId}`,
+          operationKey: `${keyPrefix}:operation:${indexId}`,
         });
       }
       expect(keys.length).toEqual(1500);
     });
   });
-
   describe('invalidate()', () => {
     const dataValue: ExecutionResult<{ key: string }, { extensions: string }> = {
       errors: [],
@@ -87,37 +85,17 @@ describe('invalidate.test.ts', () => {
     };
     const dataKey = '1B9502F92EFA53AFF0AC650794AA79891E4B6900';
 
-    async function collectAllKeys(prefix: string) {
-      const keys = [];
-      for await (const kvKey of getAllKvKeysForPrefix(prefix, config)) {
-        keys.push(kvKey);
-      }
-      return keys;
-    }
-
-    beforeEach(() => {
-      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      env = getMiniflareBindings<Env>();
-      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      executionContext = new ExecutionContext();
-      config = {
-        KV: env.GRAPHQL_RESPONSE_CACHE,
-        waitUntil: executionContext.waitUntil,
-        keyPrefix,
-      };
-      maxTtl = 60 * 1000; // 1 minute
-    });
-
     test('should invalidate all entity keys given only a type', async () => {
       await set(
         dataKey,
         dataValue,
         [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
         maxTtl,
-        config,
+        KV,
+        keyPrefix,
       );
 
-      await invalidate([{ typename: 'User' }], config);
+      await invalidate([{ typename: 'User' }], KV, keyPrefix);
 
       const allKeys = await collectAllKeys(keyPrefix);
       expect(allKeys.length).toEqual(0);
@@ -129,19 +107,20 @@ describe('invalidate.test.ts', () => {
         dataValue,
         [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
         maxTtl,
-        config,
+        KV,
+        keyPrefix,
       );
 
-      await invalidate([{ typename: 'User', id: 1 }], config);
+      await invalidate([{ typename: 'User', id: 1 }], KV, keyPrefix);
 
       const allKeys = await collectAllKeys(keyPrefix);
       expect(allKeys.length).toEqual(2);
 
-      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      const operationKey = buildOperationKey(dataKey, keyPrefix);
       const operationKeyWithoutPrefix = buildOperationKey(dataKey);
-      const entityTypeKey = buildEntityKey('User', undefined, config.keyPrefix);
-      const entityKey1 = buildEntityKey('User', 1, config.keyPrefix);
-      const entityKey2 = buildEntityKey('User', 2, config.keyPrefix);
+      const entityTypeKey = buildEntityKey('User', undefined, keyPrefix);
+      const entityKey1 = buildEntityKey('User', 1, keyPrefix);
+      const entityKey2 = buildEntityKey('User', 2, keyPrefix);
 
       expect(allKeys.find(k => k.name === operationKey)).not.toBeDefined();
 

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -39,7 +39,7 @@ describe('set.test.ts', () => {
       executionContext = new ExecutionContext();
       config = {
         KV: env.GRAPHQL_RESPONSE_CACHE,
-        ctx: executionContext,
+        waitUntil: executionContext.waitUntil,
         keyPrefix: 'vitest',
       };
       maxTtl = 60 * 1000; // 1 minute

--- a/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
+++ b/packages/plugins/response-cache-cloudflare-kv/test/set.spec.ts
@@ -11,10 +11,8 @@ type Env = {
 };
 
 describe('set.test.ts', () => {
-  let env: Env;
   let maxTtl: number;
-  let executionContext: ExecutionContext;
-  let config: KvCacheConfig;
+  let KV: KVNamespace;
   const keyPrefix = 'vitest';
   const dataValue: ExecutionResult<{ key: string }, { extensions: string }> = {
     errors: [],
@@ -25,7 +23,7 @@ describe('set.test.ts', () => {
 
   async function collectAllKeys(prefix: string) {
     const keys = [];
-    for await (const kvKey of getAllKvKeysForPrefix(prefix, config)) {
+    for await (const kvKey of getAllKvKeysForPrefix(prefix, KV)) {
       keys.push(kvKey);
     }
     return keys;
@@ -34,14 +32,8 @@ describe('set.test.ts', () => {
   describe('set()', () => {
     beforeEach(() => {
       // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      env = getMiniflareBindings<Env>();
-      // @ts-expect-error - Unable to get jest-environment-miniflare/globals working the test/build setup
-      executionContext = new ExecutionContext();
-      config = {
-        KV: env.GRAPHQL_RESPONSE_CACHE,
-        waitUntil: executionContext.waitUntil,
-        keyPrefix: 'vitest',
-      };
+      const env = getMiniflareBindings<Env>();
+      KV = env.GRAPHQL_RESPONSE_CACHE;
       maxTtl = 60 * 1000; // 1 minute
     });
 
@@ -51,13 +43,14 @@ describe('set.test.ts', () => {
         dataValue,
         [{ typename: 'User' }, { typename: 'User', id: 1 }, { typename: 'User', id: 2 }],
         maxTtl,
-        config,
+        KV,
+        keyPrefix,
       );
-      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      const operationKey = buildOperationKey(dataKey, keyPrefix);
       const operationKeyWithoutPrefix = buildOperationKey(dataKey);
-      const entityTypeKey = buildEntityKey('User', undefined, config.keyPrefix);
-      const entityKey1 = buildEntityKey('User', 1, config.keyPrefix);
-      const entityKey2 = buildEntityKey('User', 2, config.keyPrefix);
+      const entityTypeKey = buildEntityKey('User', undefined, keyPrefix);
+      const entityKey1 = buildEntityKey('User', 1, keyPrefix);
+      const entityKey2 = buildEntityKey('User', 2, keyPrefix);
 
       const allKeys = await collectAllKeys(keyPrefix);
       expect(allKeys.length).toEqual(4);
@@ -88,8 +81,8 @@ describe('set.test.ts', () => {
     });
 
     test('should function even if there are no entities', async () => {
-      await set(dataKey, dataValue, [], maxTtl, config);
-      const operationKey = buildOperationKey(dataKey, config.keyPrefix);
+      await set(dataKey, dataValue, [], maxTtl, KV, keyPrefix);
+      const operationKey = buildOperationKey(dataKey, keyPrefix);
       const operationKeyWithoutPrefix = buildOperationKey(dataKey);
 
       const allKeys = await collectAllKeys(keyPrefix);
@@ -102,7 +95,7 @@ describe('set.test.ts', () => {
         allKeys.find(
           k =>
             k.name ===
-            `${buildEntityKey('User', undefined, config.keyPrefix)}:${operationKeyWithoutPrefix}`,
+            `${buildEntityKey('User', undefined, keyPrefix)}:${operationKeyWithoutPrefix}`,
         ),
       ).toBeUndefined();
     });

--- a/packages/plugins/response-cache/README.md
+++ b/packages/plugins/response-cache/README.md
@@ -215,12 +215,10 @@ const graphqlServer = createYoga<Env & ExecutionContext>({
   schema: createSchema({ typeDefs, resolvers }),
   plugins: [
     useResponseCache({
-      cache: ctx =>
-        createKvCache({
-          KV: ctx.GRAPHQL_RESPONSE_CACHE,
-          waitUntil: ctx.waitUntil,
-          keyPrefix: 'graphql' // optional
-        }),
+      cache: createKvCache({
+        KVName: 'GRAPHQL_RESPONSE_CACHE',
+        keyPrefix: 'graphql' // optional
+      }),
       session: () => null,
       includeExtensionMetadata: true,
       ttl: 1000 * 10 // 10 seconds

--- a/packages/plugins/response-cache/README.md
+++ b/packages/plugins/response-cache/README.md
@@ -210,33 +210,28 @@ import { typeDefs } from './graphql-schema/typeDefs.generated'
 export type Env = {
   GRAPHQL_RESPONSE_CACHE: KVNamespace
 }
-export type GraphQLContext = YogaInitialContext & Env & ExecutionContext
+
+const graphqlServer = createYoga<Env & ExecutionContext>({
+  schema: createSchema({ typeDefs, resolvers }),
+  plugins: [
+    useResponseCache({
+      cache: ctx =>
+        createKvCache({
+          KV: ctx.GRAPHQL_RESPONSE_CACHE,
+          waitUntil: ctx.waitUntil,
+          keyPrefix: 'graphql' // optional
+        }),
+      session: () => null,
+      includeExtensionMetadata: true,
+      ttl: 1000 * 10 // 10 seconds
+    })
+  ]
+})
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const cache = createKvCache({
-      KV: env.GRAPHQL_RESPONSE_CACHE,
-      ctx,
-      keyPrefix: 'graphql' // optional
-    })
-
-    const graphqlServer = createYoga<GraphQLContext>({
-      schema: createSchema({ typeDefs, resolvers }),
-      plugins: [
-        useResponseCache({
-          cache,
-          session: () => null
-        })
-      ]
-    })
-
-    return graphqlServer.fetch(request, env, ctx)
-  }
+  fetch: graphqlServer
 }
 ```
-
-> Note: In the Recipes below, be sure to provide your Cloudflare KV `cache` instance with
-> `useResponseCache({ cache })`.
 
 ## Recipes
 

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -303,6 +303,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
       process.env['NODE_ENV'] === 'development' || !!process.env['DEBUG']
     : false,
 }: UseResponseCacheParameter<PluginContext>): Plugin<PluginContext> {
+  const cacheFactory = typeof cache === 'function' ? memoize1(cache) : () => cache;
   const ignoredTypesMap = new Set<string>(ignoredTypes);
   const typePerSchemaCoordinateMap = new Map<string, string[]>();
   enabled = enabled ? memoize1(enabled) : enabled;
@@ -478,8 +479,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
       ): void {
         processResult(result.data);
 
-        const cacheInstance =
-          typeof cache === 'function' ? cache(onExecuteParams.args.contextValue) : cache;
+        const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
         cacheInstance.invalidate(identifier.values());
         if (includeExtensionMetadata) {
           setResult(
@@ -526,8 +526,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
         context: onExecuteParams.args.contextValue,
       });
 
-      const cacheInstance =
-        typeof cache === 'function' ? cache(onExecuteParams.args.contextValue) : cache;
+      const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
       const cachedResponse = (await cacheInstance.get(cacheKey)) as ResponseCacheExecutionResult;
 
       if (cachedResponse != null) {
@@ -554,8 +553,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           return;
         }
 
-        const cacheInstance =
-          typeof cache === 'function' ? cache(onExecuteParams.args.contextValue) : cache;
+        const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
         cacheInstance.set(cacheKey, result, identifier.values(), finalTtl);
         if (includeExtensionMetadata) {
           setResult(resultWithMetadata(result, { hit: false, didCache: true, ttl: finalTtl }));

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -480,6 +480,13 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
         processResult(result.data);
 
         const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
+        if (cacheInstance == null) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[useResponseCache] Cache instance is not available for the context. Skipping invalidation.',
+          );
+          return;
+        }
         cacheInstance.invalidate(identifier.values());
         if (includeExtensionMetadata) {
           setResult(
@@ -527,6 +534,12 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
       });
 
       const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
+      if (cacheInstance == null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[useResponseCache] Cache instance is not available for the context. Skipping cache lookup.',
+        );
+      }
       const cachedResponse = (await cacheInstance.get(cacheKey)) as ResponseCacheExecutionResult;
 
       if (cachedResponse != null) {
@@ -553,7 +566,6 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           return;
         }
 
-        const cacheInstance = cacheFactory(onExecuteParams.args.contextValue);
         cacheInstance.set(cacheKey, result, identifier.values(), finalTtl);
         if (includeExtensionMetadata) {
           setResult(resultWithMetadata(result, { hit: false, didCache: true, ttl: finalTtl }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1664,7 +1664,6 @@ packages:
   '@apollo/server-plugin-landing-page-graphql-playground@4.0.0':
     resolution: {integrity: sha512-PBDtKI/chJ+hHeoJUUH9Kuqu58txQl00vUGuxqiC9XcReulIg7RjsyD0G1u3drX4V709bxkL5S0nTeXfRHD0qA==}
     engines: {node: '>=14.0'}
-    deprecated: The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.
     peerDependencies:
       '@apollo/server': ^4.0.0
 
@@ -2195,7 +2194,6 @@ packages:
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -4767,15 +4765,15 @@ packages:
   apollo-datasource@3.3.2:
     resolution: {integrity: sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==}
     engines: {node: '>=12.0'}
-    deprecated: The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
 
   apollo-reporting-protobuf@0.8.0:
     resolution: {integrity: sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==}
-    deprecated: The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
 
   apollo-reporting-protobuf@3.2.0:
     resolution: {integrity: sha512-2v/5IRJeTGakCJo8kS2LeKUcLsgqxO/HpEyu1EaW79F0CsvrIk10tOIGxouoOgtVl5e1wfGePJ849CUWWczx2A==}
-    deprecated: The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
 
   apollo-reporting-protobuf@3.4.0:
     resolution: {integrity: sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==}
@@ -4800,24 +4798,24 @@ packages:
   apollo-server-env@3.2.0:
     resolution: {integrity: sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==}
     engines: {node: '>=6'}
-    deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
 
   apollo-server-env@4.2.1:
     resolution: {integrity: sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==}
     engines: {node: '>=12.0'}
-    deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
 
   apollo-server-errors@3.3.1:
     resolution: {integrity: sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==}
     engines: {node: '>=12.0'}
-    deprecated: The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     peerDependencies:
       graphql: 16.6.0
 
   apollo-server-plugin-base@0.14.0:
     resolution: {integrity: sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==}
     engines: {node: '>=6'}
-    deprecated: The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     peerDependencies:
       graphql: 16.6.0
 
@@ -4831,14 +4829,14 @@ packages:
   apollo-server-types@0.10.0:
     resolution: {integrity: sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==}
     engines: {node: '>=6'}
-    deprecated: The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     peerDependencies:
       graphql: 16.6.0
 
   apollo-server-types@3.4.0:
     resolution: {integrity: sha512-iFNRENtxDoFWoY+KxpGP+TYyRnqUPqUTubMJVgiXPDvOPFL8dzqGGmqq1g/VCeWFHRJTPBLWhOfQU7ktwDEjnQ==}
     engines: {node: '>=12.0'}
-    deprecated: The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
+    deprecated: The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     peerDependencies:
       graphql: 16.6.0
 
@@ -9629,7 +9627,6 @@ packages:
 
   reflect-metadata@0.2.1:
     resolution: {integrity: sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==}
-    deprecated: This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.
 
   regenerate-unicode-properties@10.1.0:
     resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
@@ -14257,7 +14254,7 @@ snapshots:
 
   '@npmcli/fs@3.1.0':
     dependencies:
-      semver: 7.6.2
+      semver: 7.6.1
     optional: true
 
   '@npmcli/move-file@2.0.1':
@@ -15127,7 +15124,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.0
+      semver: 7.6.1
       ts-api-utils: 1.0.3(typescript@5.1.3)
     optionalDependencies:
       typescript: 5.1.3
@@ -15143,7 +15140,7 @@ snapshots:
       '@typescript-eslint/types': 7.3.1
       '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.1.3)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16037,7 +16034,7 @@ snapshots:
 
   builtins@5.0.1:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.1
 
   bundle-require@4.0.1(esbuild@0.17.7):
     dependencies:
@@ -19057,7 +19054,7 @@ snapshots:
       '@babel/parser': 7.24.1
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.6.2
+      semver: 7.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21025,7 +21022,7 @@ snapshots:
     dependencies:
       execa: 6.1.0
       parse-package-name: 1.0.0
-      semver: 7.6.0
+      semver: 7.6.1
       validate-npm-package-name: 4.0.0
 
   nth-check@2.1.1:


### PR DESCRIPTION
This PR introduces the following changes;

- Now `cache` parameter accepts a factory function that takes the context and returns the cache implementation
- Now the cache implementation does not require any ctx value, but only the name of the KV namespace.

See the changes in the README for details

```ts
import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'
import { useResponseCache } from '@envelop/response-cache'
import { createKvCache } from '@envelop/response-cache-cloudflare-kv'
import { resolvers } from './graphql-schema/resolvers.generated'
import { typeDefs } from './graphql-schema/typeDefs.generated'

export type Env = {
  GRAPHQL_RESPONSE_CACHE: KVNamespace
}

const graphqlServer = createYoga<Env & ExecutionContext>({
  schema: createSchema({ typeDefs, resolvers }),
  plugins: [
    useResponseCache({
      cache: createKvCache({
        KVName: 'GRAPHQL_RESPONSE_CACHE',
        keyPrefix: 'graphql' // optional
      }),
      session: () => null,
      includeExtensionMetadata: true,
      ttl: 1000 * 10 // 10 seconds
    })
  ]
})

export default {
  fetch: graphqlServer
}
```