### PR TITLE
[useResponseCache] Ensure calls to cache are awaited

### DIFF
--- a/.changeset/old-moles-develop.md
+++ b/.changeset/old-moles-develop.md
@@ -1,0 +1,6 @@
+---
+'@envelop/response-cache': patch
+---
+
+Fixes an issue where rejected promises returned from the cache were not being handled correctly,
+causing an unhandled promise rejection which would terminate the process.


### PR DESCRIPTION
## Description

This change ensures that the calls to the supplied cache implementation are awaited and returned, in the case that the methods are async and return promises. This prevents "floating promises" from being created which will crash the Node process if they are rejected.

I believe this is not a breaking change since all supported Node versions have the behaviour of terminating on unhandled promise rejections, and that the behaviour without this change is not intentional or desired.

Fixes #2240.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests added for `set` and `invalidate` calls to the cache implementation, ensuring that sync errors and promise rejections don't result in process termination.

**Test Environment**:

- OS: macOS 14.4.1
- `@envelop/response-cache`: 6.1.2
- NodeJS: v20.11.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
