### PR TITLE
[useResponseCache] Ignore specfic schemaCoordinates for IdFields which are not the root of a subgraph

### DIFF
--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -115,6 +115,11 @@ export type UseResponseCacheParameter<PluginContext extends Record<string, any> 
    */
   idFields?: Array<string>;
   /**
+   * List of SchemaCoordinates which are ignored during scan for entities.
+   * Defaults to `[]`
+   */
+  ignoreIdFieldsBySchemaCoordinate?: Array<string>
+  /**
    * Whether the mutation execution result should be used for invalidating resources.
    * Defaults to `true`
    */
@@ -294,6 +299,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   ttlPerSchemaCoordinate = {},
   scopePerSchemaCoordinate = {},
   idFields = ['id'],
+  ignoreIdFieldsBySchemaCoordinate = [],
   invalidateViaMutation = true,
   buildResponseCacheKey = defaultBuildResponseCacheKey,
   getDocumentString = defaultGetDocumentString,
@@ -361,7 +367,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           const resultTypeNames = unwrapTypenames(fieldConfig.type);
           typePerSchemaCoordinateMap.set(schemaCoordinates, resultTypeNames);
 
-          if (idFields.includes(fieldName) && !idFieldByTypeName.has(typeName)) {
+          if (idFields.includes(fieldName) && !idFieldByTypeName.has(typeName) && !ignoreIdFieldsBySchemaCoordinate?.includes(schemaCoordinates)) {
             idFieldByTypeName.set(typeName, fieldName);
           }
 

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -115,7 +115,7 @@ export type UseResponseCacheParameter<PluginContext extends Record<string, any> 
    */
   idFields?: Array<string>;
   /**
-   * List of SchemaCoordinates which are ignored during scan for entities.
+   * List of SchemaCoordinates in format {ObjectType}.{FieldName} which are ignored during scan for entities.
    * Defaults to `[]`
    */
   ignoreIdFieldsBySchemaCoordinate?: Array<string>

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -118,7 +118,7 @@ export type UseResponseCacheParameter<PluginContext extends Record<string, any> 
    * List of SchemaCoordinates in format {ObjectType}.{FieldName} which are ignored during scan for entities.
    * Defaults to `[]`
    */
-  ignoreIdFieldsBySchemaCoordinate?: Array<string>
+  ignoreIdFieldsBySchemaCoordinate?: Array<string>;
   /**
    * Whether the mutation execution result should be used for invalidating resources.
    * Defaults to `true`
@@ -367,7 +367,11 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           const resultTypeNames = unwrapTypenames(fieldConfig.type);
           typePerSchemaCoordinateMap.set(schemaCoordinates, resultTypeNames);
 
-          if (idFields.includes(fieldName) && !idFieldByTypeName.has(typeName) && !ignoreIdFieldsBySchemaCoordinate?.includes(schemaCoordinates)) {
+          if (
+            idFields.includes(fieldName) &&
+            !idFieldByTypeName.has(typeName) &&
+            !ignoreIdFieldsBySchemaCoordinate?.includes(schemaCoordinates)
+          ) {
             idFieldByTypeName.set(typeName, fieldName);
           }
 

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -4107,16 +4107,16 @@ it('id field in body overwritten and request fails', async () => {
       },
       type SubgraphObject {
         id: String,
-        header: Header,
+        header: Header!,
       },
       type Header {
-        id: IdObject,
+        id: IdObject!,
         someField: String
       },
       type IdObject {
-        fieldA: String,
-        fieldB: String,
-        fieldC: String,
+        fieldA: String!,
+        fieldB: String!,
+        fieldC: String!,
       }
     `,
     resolvers: { Query: { subgraphObject: () => queryResult } },
@@ -4125,7 +4125,11 @@ it('id field in body overwritten and request fails', async () => {
       [
         useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
         useResponseCache({
-          session: () => null,
+          enabled(context: any): boolean {
+            return true;
+          }, session(context: any): string | undefined | null {
+            return "sessionString";
+          },
           ttl:0
         }),
       ],
@@ -4148,11 +4152,6 @@ it('id field in body overwritten and request fails', async () => {
     }
   `;
 
-  const result = await testkit.execute(document);
-  assertSingleExecutionValue(result);
-  expect(result).toMatchObject({
-    data: {
-      subgraphObject: queryResult,
-    },
-  });
+  await expect( testkit.execute(document)).rejects.toThrow(TypeError);
+
 });

--- a/packages/plugins/response-cache/test/response-cache.spec.ts
+++ b/packages/plugins/response-cache/test/response-cache.spec.ts
@@ -4035,39 +4035,40 @@ it('calls enabled fn after context building', async () => {
 it('id field in body is returned as is and not overwritten', async () => {
   expect.assertions(1);
   const queryResult = {
-  'id': "idString", 'header': {'id': {'fieldA': 'Tick', 'fieldB': 'Trick', 'fieldC': 'Track'}, 'someField': 'someData'}
-  }
+    id: 'idString',
+    header: { id: { fieldA: 'Tick', fieldB: 'Trick', fieldC: 'Track' }, someField: 'someData' },
+  };
   const schema = makeExecutableSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         subgraphObject: SubgraphObject
-      },
+      }
       type SubgraphObject {
-        id: String,
-        header: Header, 
-      },
+        id: String
+        header: Header
+      }
       type Header {
-        id: IdObject,
+        id: IdObject
         someField: String
-      },
+      }
       type IdObject {
-        fieldA: String,
-        fieldB: String,
-        fieldC: String,
+        fieldA: String
+        fieldB: String
+        fieldC: String
       }
     `,
     resolvers: { Query: { subgraphObject: () => queryResult } },
   });
   const testkit = createTestkit(
-      [
-        useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
-        useResponseCache({
-          session: () => null,
-          ttl:0,
-          ignoreIdFieldsBySchemaCoordinate:['Header.id']
-        }),
-      ],
-      schema,
+    [
+      useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+      useResponseCache({
+        session: () => null,
+        ttl: 0,
+        ignoreIdFieldsBySchemaCoordinate: ['Header.id'],
+      }),
+    ],
+    schema,
   );
 
   const document = /* GraphQL */ `
@@ -4098,42 +4099,44 @@ it('id field in body is returned as is and not overwritten', async () => {
 it('id field in body overwritten and request fails', async () => {
   expect.assertions(1);
   const queryResult = {
-    'id': "idString", 'header': {'id': {'fieldA': 'Tick', 'fieldB': 'Trick', 'fieldC': 'Track'}, 'someField': 'someData'}
-  }
+    id: 'idString',
+    header: { id: { fieldA: 'Tick', fieldB: 'Trick', fieldC: 'Track' }, someField: 'someData' },
+  };
   const schema = makeExecutableSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         subgraphObject: SubgraphObject
-      },
+      }
       type SubgraphObject {
-        id: String,
-        header: Header!,
-      },
+        id: String
+        header: Header!
+      }
       type Header {
-        id: IdObject!,
+        id: IdObject!
         someField: String
-      },
+      }
       type IdObject {
-        fieldA: String!,
-        fieldB: String!,
-        fieldC: String!,
+        fieldA: String!
+        fieldB: String!
+        fieldC: String!
       }
     `,
     resolvers: { Query: { subgraphObject: () => queryResult } },
   });
   const testkit = createTestkit(
-      [
-        useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
-        useResponseCache({
-          enabled(context: any): boolean {
-            return true;
-          }, session(context: any): string | undefined | null {
-            return "sessionString";
-          },
-          ttl:0
-        }),
-      ],
-      schema,
+    [
+      useEngine({ ...GraphQLJS, execute: normalizedExecutor, subscribe: normalizedExecutor }),
+      useResponseCache({
+        enabled(context: any): boolean {
+          return true;
+        },
+        session(context: any): string | undefined | null {
+          return 'sessionString';
+        },
+        ttl: 0,
+      }),
+    ],
+    schema,
   );
 
   const document = /* GraphQL */ `
@@ -4152,6 +4155,5 @@ it('id field in body overwritten and request fails', async () => {
     }
   `;
 
-  await expect( testkit.execute(document)).rejects.toThrow(TypeError);
-
+  await expect(testkit.execute(document)).rejects.toThrow(TypeError);
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Add a new optionalList of schemaCoordinates to the useResponseCacheParamters, which is used to exclude fields on specific objects in the mapSchema step.

Fixes #2247

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

Testet fix first on our case and environment by maintaining a parallel instance of this plugin. Further added Unit tests to first reproduce the Issue and proof the fix works. 

- [x] Added Test "'id field in body overwritten and request fails'"
- [x] Added Test "'id field in body is returned as is and not overwritten'"

**Test Environment**:

- OS: macOs: Sonoma 14.5
- `@envelop/response-cache`: 6.2.0
- NodeJS: 10.5.0

## Checklist:

- [ x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
