### PR TITLE
[response-cache] deprecate `ttlPerType` option in favor of `ttlPerSchemaCoordinate`

### DIFF
--- a/.changeset/twenty-camels-wonder.md
+++ b/.changeset/twenty-camels-wonder.md
@@ -1,0 +1,25 @@
+---
+'@envelop/response-cache': minor
+---
+
+Deprecate `ttlPerType` in favor of `ttlPerSchemaCoordinate`, for a more streamlined API
+
+## Migration instructions
+
+If you where using `ttlPerType`, you can merge the object into the `ttlPerSchemaCoordinate`, the
+syntax doesn't change.
+
+```diff
+useResponseCache({
+  session: null,
+- ttlPerType: {
+-   User: 10_000,
+-   Profile: 600_000,
+- },
+  ttlPerSchemaCoordinate: {
+    'Query.me': 0
++    User: 10_000,
++    Profile: 600_000,
+  }
+})
+```

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -328,6 +328,10 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
   // never cache Introspections
   ttlPerSchemaCoordinate = { 'Query.__schema': 0, ...ttlPerSchemaCoordinate };
   if (ttlPerType) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[useResponseCache] `ttlForType` is deprecated. To migrate, merge it with `ttlForSchemaCoordinate` option',
+    );
     for (const [typeName, ttl] of Object.entries(ttlPerType)) {
       ttlPerSchemaCoordinate[typeName] = ttl;
     }


### PR DESCRIPTION
## Description

There is an incoherence in the options API. TTL is configured using 2 parameters: `ttlPerType` and `ttlPerSchemaCoordinate` while scope is configured only via `scopeBySchemaCoordinate` which can contain typeName only or typeName+fieldName keys.

This PR is deprecating the `ttlPerType` in favor of `ttlPerSchemaCoordinate` to be more coherent.
`ttlPerType` is still supported but will be removed in future major release.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
