### PR TITLE
[response-cache] avoid aliased  when present

### DIFF
--- a/.changeset/khaki-mice-kiss.md
+++ b/.changeset/khaki-mice-kiss.md
@@ -1,0 +1,6 @@
+---
+'@envelop/response-cache': patch
+---
+
+The plugin now try to reduce the size of the resulting query by not adding a `__typename` aliased
+selection if `__typename` is already selected.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9550,8 +9550,8 @@ packages:
     resolution: {integrity: sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==}
     engines: {node: '>=0.6'}
 
-  qs@6.12.2:
-    resolution: {integrity: sha512-x+NLUpx9SYrcwXtX7ob1gnkSems4i/mGZX5SlYxwIau6RrUSODO89TR/XDGGpn5RPWSYIB+aSfuSlV5+CmbTBg==}
+  qs@6.12.3:
+    resolution: {integrity: sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==}
     engines: {node: '>=0.6'}
 
   qs@6.7.0:
@@ -21882,7 +21882,7 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
-  qs@6.12.2:
+  qs@6.12.3:
     dependencies:
       side-channel: 1.0.6
 
@@ -23705,7 +23705,7 @@ snapshots:
   url@0.11.3:
     dependencies:
       punycode: 1.4.1
-      qs: 6.12.2
+      qs: 6.12.3
 
   urlpattern-polyfill@10.0.0: {}
 


### PR DESCRIPTION
## Description

To achieve automatique cache invalidation, the plugins needs `__typename` and `id` (or equivalent) fields to be present in the response. To ensure this rule, it adds an aliased `__typename` selection on the fly to the operation document.

While this works well, it have the down side of adding a lot of noise to the resulting document, making it sometimes significantly bigger than the original one. This can lead to exceed HTTP body limits in some cases when used on Mesh.

This PR mitigate this issue by adding aliased fields only when they are not already selected, reducing the noise in most cases since the `__typename` is often already selected by most graphql client for caching purpose.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
