### PR TITLE
Add support for all graphql-rate-limit options

### DIFF
--- a/.changeset/red-cameras-help.md
+++ b/.changeset/red-cameras-help.md
@@ -1,0 +1,6 @@
+---
+'@envelop/rate-limiter': patch
+---
+
+useRateLimiter will now accept all options available to graphql-rate-limit getGraphQLRateLimiter
+function so that they are usable.

--- a/packages/plugins/rate-limiter/README.md
+++ b/packages/plugins/rate-limiter/README.md
@@ -65,7 +65,7 @@ type Query {
 
 ## Notes
 
-The prop graphQLRateLimitConfig with an object of any options available to the graphql-rate-limit
-getGraphQLRateLimiter function may also be passed into useRateLimiter.
+All options available to the graphql-rate-limit getGraphQLRateLimiter function may also be passed
+into useRateLimiter.
 
 You can find more details here: https://github.com/teamplanes/graphql-rate-limit#readme

--- a/packages/plugins/rate-limiter/README.md
+++ b/packages/plugins/rate-limiter/README.md
@@ -65,4 +65,7 @@ type Query {
 
 ## Notes
 
+The prop graphQLRateLimitConfig with an object of any options available to the graphql-rate-limit
+getGraphQLRateLimiter function may also be passed into useRateLimiter.
+
 You can find more details here: https://github.com/teamplanes/graphql-rate-limit#readme

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -45,7 +45,7 @@ interface RateLimiterContext {
 
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
   const rateLimiterFn = getGraphQLRateLimiter({
-    ...options.graphQLRateLimitConfig,
+    ...options.graphQLRateLimitConfig, // Pass through all available options
     identifyContext: options.identifyFn,
   });
 

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -6,6 +6,18 @@ import { getDirective } from './utils.js';
 
 export * from './utils.js';
 
+export {
+  FormatErrorInput,
+  GraphQLRateLimitConfig,
+  GraphQLRateLimitDirectiveArgs,
+  Identity,
+  InMemoryStore,
+  Options,
+  RateLimitError,
+  RedisStore,
+  Store,
+} from 'graphql-rate-limit';
+
 export class UnauthenticatedError extends Error {}
 
 export type IdentifyFn<ContextType = unknown> = (context: ContextType) => string;

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -33,8 +33,8 @@ interface RateLimiterContext {
 
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
   const rateLimiterFn = getGraphQLRateLimiter({
-    identifyContext: options.identifyFn,
     ...options.graphQLRateLimitConfig,
+    identifyContext: options.identifyFn,
   });
 
   return {

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo, IntValueNode, StringValueNode } from 'graphql';
-import { getGraphQLRateLimiter, Store } from 'graphql-rate-limit';
+import { getGraphQLRateLimiter, GraphQLRateLimitConfig } from 'graphql-rate-limit';
 import { Plugin } from '@envelop/core';
 import { useOnResolve } from '@envelop/on-resolve';
 import { getDirective } from './utils.js';
@@ -16,7 +16,6 @@ export const DIRECTIVE_SDL = /* GraphQL */ `
 
 export type RateLimiterPluginOptions = {
   identifyFn: IdentifyFn;
-  store: Store;
   rateLimitDirectiveName?: 'rateLimit' | string;
   transformError?: (message: string) => Error;
   onRateLimitError?: (event: {
@@ -25,6 +24,7 @@ export type RateLimiterPluginOptions = {
     context: unknown;
     info: GraphQLResolveInfo;
   }) => void;
+  graphQLRateLimitConfig?: GraphQLRateLimitConfig;
 };
 
 interface RateLimiterContext {
@@ -34,7 +34,7 @@ interface RateLimiterContext {
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
   const rateLimiterFn = getGraphQLRateLimiter({
     identifyContext: options.identifyFn,
-    store: options.store,
+    ...options.graphQLRateLimitConfig,
   });
 
   return {

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -44,7 +44,7 @@ interface RateLimiterContext {
 
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
   const rateLimiterFn = getGraphQLRateLimiter({
-    ...options.graphQLRateLimitConfig, // Pass through all available options
+    ...options, // Pass through all available options
     identifyContext: options.identifyFn,
   });
 

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -36,8 +36,7 @@ export type RateLimiterPluginOptions = {
     context: unknown;
     info: GraphQLResolveInfo;
   }) => void;
-  graphQLRateLimitConfig?: GraphQLRateLimitConfig;
-};
+} & Omit<GraphQLRateLimitConfig, 'identifyContext'>;
 
 interface RateLimiterContext {
   rateLimiterFn: ReturnType<typeof getGraphQLRateLimiter>;

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo, IntValueNode, StringValueNode } from 'graphql';
-import { getGraphQLRateLimiter } from 'graphql-rate-limit';
+import { getGraphQLRateLimiter, Store } from 'graphql-rate-limit';
 import { Plugin } from '@envelop/core';
 import { useOnResolve } from '@envelop/on-resolve';
 import { getDirective } from './utils.js';
@@ -16,6 +16,7 @@ export const DIRECTIVE_SDL = /* GraphQL */ `
 
 export type RateLimiterPluginOptions = {
   identifyFn: IdentifyFn;
+  store: Store;
   rateLimitDirectiveName?: 'rateLimit' | string;
   transformError?: (message: string) => Error;
   onRateLimitError?: (event: {
@@ -31,7 +32,10 @@ interface RateLimiterContext {
 }
 
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
-  const rateLimiterFn = getGraphQLRateLimiter({ identifyContext: options.identifyFn });
+  const rateLimiterFn = getGraphQLRateLimiter({
+    identifyContext: options.identifyFn,
+    store: options.store,
+  });
 
   return {
     onPluginInit({ addPlugin }) {


### PR DESCRIPTION
## Description

Exposes all possible configuration fields and types to the rate-limiter plugin and forwards them to the underlying graphql-rate-limit function. This is as discussed in issue #2273. I've designed it to be backwards compatible so that it shouldn't break past versions, but all config should now be available through the graphQLRateLimitConfig prop.

Primary motivation is to expose the "store" prop so that Redis can be used.

Fixes #2273

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

This is a fairly simple change that shouldn't be breaking. I've tested locally by copying the plugin to my project and using the Redis store option. It seems to be working as expected.

**Test Environment**:

- OS: macOS 14.6
- `@envelop/rate-limiter`: 6.1.0
- NodeJS: 18.17.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
