### PR TITLE
Refactor Generic Auth plugin

### DIFF
--- a/.changeset/@envelop_generic-auth-2281-dependencies.md
+++ b/.changeset/@envelop_generic-auth-2281-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@envelop/generic-auth": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/utils@^10.5.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.5.0) (from `^10.0.6`, in `dependencies`)

--- a/.changeset/@envelop_generic-auth-2281-dependencies.md
+++ b/.changeset/@envelop_generic-auth-2281-dependencies.md
@@ -2,4 +2,4 @@
 "@envelop/generic-auth": patch
 ---
 dependencies updates:
-  - Updated dependency [`@graphql-tools/utils@^10.5.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.5.0) (from `^10.0.6`, in `dependencies`)
+  - Updated dependency [`@graphql-tools/utils@^10.5.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.5.1) (from `^10.0.6`, in `dependencies`)

--- a/.changeset/sweet-apples-confess.md
+++ b/.changeset/sweet-apples-confess.md
@@ -3,4 +3,95 @@
 '@envelop/extended-validation': minor
 ---
 
-TODO
+Refactor Generic Auth plugin;
+
+- [BREAKING] - Now `@auth` directive is renamed to `@authenticated`. If you want to keep the old name you can configure the plugin to use the old name.
+
+```ts
+useGenericAuth({
+  // ...
+  authDirectiveName: 'auth',
+});
+```
+
+- [BREAKING] - Now `directiveOrExtensionFieldName` is renamed to `authDirectiveName`.
+
+```diff
+useGenericAuth({
+  // ...
+- directiveOrExtensionFieldName: 'auth',
++ authDirectiveName: 'auth',
+});
+```
+
+- Now auth directives support `OBJECT` and `INTERFACE` locations, so you can use the auth directive on types as well.
+
+```graphql
+directive @authenticated on OBJECT | INTERFACE
+
+type User @authenticated {
+    id: ID!
+    name: String!
+}
+```
+
+- `validateUser` function does not receive `fieldAuthDirectiveNode` and `fieldAuthExtension` anymore. Instead, it takes `fieldAuthArgs` which is an object that contains the arguments of the auth directive or extension. So you don't need to parse the arguments manually anymore.
+
+```ts
+const validateUser: ValidateUserFn = params => {
+  if (!params.fieldAuthArgs.roles.includes('admin')) {
+    return createUnauthorizedError(params);
+  }
+};
+```
+
+- `validateUser`'s `objectType` parameter is now renamed to `parentType`. And it takes the original composite type instead of the `GraphQLObjectType` instance. Now it can be `GraphQLInterfaceType` as well.
+
+- `validateUser`'s current parameters are now;
+
+```ts
+export type ValidateUserFnParams<UserType> = {
+  /** The user object. */
+  user: UserType;
+  /** The field node from the operation that is being validated. */
+  fieldNode: FieldNode;
+  /** The parent type which has the field that is being validated. */
+  parentType: GraphQLObjectType | GraphQLInterfaceType;
+  /** The auth directive arguments for the type */
+  typeAuthArgs?: Record<string, any>;
+  /** The directives for the type */
+  typeDirectives?: ReturnType<typeof getDirectiveExtensions>;
+  /** Scopes that type requires */
+  typeScopes?: string[][];
+  /** Policies that type requires */
+  typePolicies?: string[][];
+  /** The object field */
+  field: GraphQLField<any, any>;
+  /** The auth directive arguments for the field */
+  fieldAuthArgs?: Record<string, any>;
+  /** The directives for the field */
+  fieldDirectives?: ReturnType<typeof getDirectiveExtensions>;
+  /** Scopes that field requires */
+  fieldScopes?: string[][];
+  /** Policies that field requires */
+  fieldPolicies?: string[][];
+  /** Extracted scopes from the user object */
+  userScopes: string[];
+  /** Policies for the user */
+  userPolicies: string[];
+  /** The args passed to the execution function (including operation context and variables) **/
+  executionArgs: ExecutionArgs;
+  /** Resolve path */
+  path: ReadonlyArray<string | number>;
+};
+```
+
+- New directives for role-based auth are added `@requiresScopes` and `@policy` for more granular control over the auth logic.
+
+```graphql
+directive @requiresScopes(scopes: [String!]!) on OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @policy(policy: String!) on OBJECT | INTERFACE | FIELD_DEFINITION
+```
+
+Check README for more information.

--- a/.changeset/sweet-apples-confess.md
+++ b/.changeset/sweet-apples-confess.md
@@ -1,0 +1,6 @@
+---
+'@envelop/generic-auth': major
+'@envelop/extended-validation': minor
+---
+
+TODO

--- a/packages/plugins/extended-validation/src/plugin.ts
+++ b/packages/plugins/extended-validation/src/plugin.ts
@@ -164,10 +164,17 @@ function buildHandler(
                 for (const pathItemIndex in path.slice(0, -1)) {
                   const pathItem = path[pathItemIndex];
                   currentData = currentData[pathItem] ||=
-                    typeof path[Number(pathItemIndex) + 1] === 'number' ? [] : {};
+                    typeof path[Number(pathItemIndex) + 1] === 'number' ||
+                    path[Number(pathItemIndex) + 1]
+                      ? []
+                      : {};
                   if (Array.isArray(currentData)) {
+                    let pathItemIndexInArray = Number(pathItemIndex) + 1;
+                    if (path[pathItemIndexInArray] === '@') {
+                      pathItemIndexInArray = Number(pathItemIndex) + 2;
+                    }
                     currentData = currentData.map((c, i) =>
-                      visitPath(path.slice(Number(pathItemIndex) + 1), c),
+                      visitPath(path.slice(pathItemIndexInArray), c),
                     );
                   }
                 }

--- a/packages/plugins/extended-validation/src/plugin.ts
+++ b/packages/plugins/extended-validation/src/plugin.ts
@@ -8,7 +8,15 @@ import {
   visitInParallel,
   visitWithTypeInfo,
 } from 'graphql';
-import { Plugin, TypedSubscriptionArgs } from '@envelop/core';
+import {
+  AsyncIterableIteratorOrValue,
+  isAsyncIterable,
+  OnExecuteEventPayload,
+  OnExecuteHookResult,
+  OnSubscribeEventPayload,
+  OnSubscribeHookResult,
+  Plugin,
+} from '@envelop/core';
 import { ExtendedValidationRule } from './common.js';
 
 const symbolExtendedValidationRules = Symbol('extendedValidationContext');
@@ -30,6 +38,12 @@ export const useExtendedValidation = <PluginContext extends Record<string, any> 
    * Callback that is invoked if the extended validation yields any errors.
    */
   onValidationFailed?: OnValidationFailedCallback;
+  /**
+   * Reject the execution if the validation fails.
+   *
+   * @default true
+   */
+  rejectOnErrors?: boolean;
 }): Plugin<PluginContext & { [symbolExtendedValidationRules]?: ExtendedValidationContext }> => {
   let schemaTypeInfo: TypeInfo;
 
@@ -57,8 +71,18 @@ export const useExtendedValidation = <PluginContext extends Record<string, any> 
       }
       validationRulesContext.rules.push(...options.rules);
     },
-    onSubscribe: buildHandler('subscribe', getTypeInfo, options.onValidationFailed),
-    onExecute: buildHandler('execute', getTypeInfo, options.onValidationFailed),
+    onSubscribe: buildHandler(
+      'subscribe',
+      getTypeInfo,
+      options.onValidationFailed,
+      options.rejectOnErrors !== false,
+    ),
+    onExecute: buildHandler(
+      'execute',
+      getTypeInfo,
+      options.onValidationFailed,
+      options.rejectOnErrors !== false,
+    ),
   };
 };
 
@@ -66,14 +90,14 @@ function buildHandler(
   name: 'execute' | 'subscribe',
   getTypeInfo: () => TypeInfo | undefined,
   onValidationFailed?: OnValidationFailedCallback,
+  rejectOnErrors = true,
 ) {
   return function handler({
     args,
     setResultAndStopExecution,
-  }: {
-    args: TypedSubscriptionArgs<any>;
-    setResultAndStopExecution: (newResult: ExecutionResult) => void;
-  }) {
+  }: OnExecuteEventPayload<any> | OnSubscribeEventPayload<any>):
+    | (OnExecuteHookResult<any> & OnSubscribeHookResult<any>)
+    | void {
     // We hook into onExecute/onSubscribe even though this is a validation pattern. The reasoning behind
     // it is that hooking right after validation and before execution has started is the
     // same as hooking into the validation step. The benefit of this approach is that
@@ -101,17 +125,56 @@ function buildHandler(
         const visitor = visitInParallel(
           validationRulesContext.rules.map(rule => rule(validationContext, args)),
         );
-        visit(args.document, visitWithTypeInfo(typeInfo, visitor));
+
+        args.document = visit(args.document, visitWithTypeInfo(typeInfo, visitor));
 
         if (errors.length > 0) {
-          let result: ExecutionResult = {
-            data: null,
-            errors,
-          };
-          if (onValidationFailed) {
-            onValidationFailed({ args, result, setResult: newResult => (result = newResult) });
+          if (rejectOnErrors) {
+            let result: ExecutionResult = {
+              data: null,
+              errors,
+            };
+            if (onValidationFailed) {
+              onValidationFailed({ args, result, setResult: newResult => (result = newResult) });
+            }
+            setResultAndStopExecution(result);
+          } else {
+            // eslint-disable-next-line no-inner-declarations
+            function onResult({
+              result,
+              setResult,
+            }: {
+              result: AsyncIterableIteratorOrValue<ExecutionResult>;
+              setResult: (result: AsyncIterableIteratorOrValue<ExecutionResult>) => void;
+            }) {
+              if (isAsyncIterable(result)) {
+                // rejectOnErrors is false doesn't work with async iterables
+                setResult({
+                  data: null,
+                  errors,
+                });
+                return;
+              }
+              const newResult = {
+                ...result,
+                errors: [...(result.errors || []), ...errors],
+              };
+              errors.forEach(e => {
+                if (e.path?.length) {
+                  let currentData: any = (newResult.data ||= {});
+                  for (const pathItem of e.path.slice(0, -1)) {
+                    currentData = currentData[pathItem] ||= {};
+                  }
+                  currentData[e.path[e.path.length - 1]] = null;
+                }
+              });
+              setResult(newResult);
+            }
+            return {
+              onSubscribeResult: onResult,
+              onExecuteDone: onResult,
+            };
           }
-          setResultAndStopExecution(result);
         }
       }
     }

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -149,7 +149,9 @@ const GraphQLQueryType = new GraphQLObjectType({
       type: GraphQLInt,
       resolve: () => 1,
       extensions: {
-        skipAuth: true
+        directives: {
+          skipAuth: true
+        }
       }
     }
   }
@@ -277,7 +279,9 @@ const GraphQLQueryType = new GraphQLObjectType({
       type: GraphQLInt,
       resolve: () => 1,
       extensions: {
-        authenticated: true
+        directives: {
+          authenticated: true
+        }
       }
     }
   }
@@ -371,8 +375,10 @@ const resolvers = {
     user: {
       me: (_, __, { currentUser }) => currentUser,
       extensions: {
-        authenticated: {
-          role: 'USER'
+        directives: {
+          authenticated: {
+            role: 'USER'
+          }
         }
       }
     }
@@ -410,11 +416,13 @@ const resolvers = {
     user: {
       resolve: (_, { userId }) => getUser(userId),
       extensions: {
-        authenticated: {
-          validate: ({ user, variables, context }) => {
-            // We can now have access to the operation and variables to decide if the user can execute the query
-            if (user.id !== variables.userId) {
-              return new Error(`Unauthorized`)
+        directives: {
+          authenticated: {
+            validate: ({ user, variables, context }) => {
+              // We can now have access to the operation and variables to decide if the user can execute the query
+              if (user.id !== variables.userId) {
+                return new Error(`Unauthorized`)
+              }
             }
           }
         }

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -4,8 +4,8 @@ This plugin allows you to implement custom authentication flow by providing a cu
 based on the original HTTP request. The resolved user is injected into the GraphQL execution
 `context`, and you can use it in your resolvers to fetch the current user.
 
-> The plugin also comes with an optional `@auth` directive that can be added to your GraphQL schema
-> and helps you to protect your GraphQL schema in a declarative way.
+> The plugin also comes with an optional `@authenticated` directive that can be added to your
+> GraphQL schema and helps you to protect your GraphQL schema in a declarative way.
 
 There are several possible flows for using this plugin (see below for setup examples):
 
@@ -15,8 +15,8 @@ There are several possible flows for using this plugin (see below for setup exam
 - **Option #2 - Manual Validation**: the plugin will just resolve the user and injects it into the
   `context` without validating access to schema field.
 - **Option #3 - Granular field access by using schema field directives or field extensions**: Look
-  for an `@auth` directive or `auth` extension field and automatically protect those specific
-  GraphQL fields.
+  for an `@authenticated` directive or `authenticated` extension field and automatically protect
+  those specific GraphQL fields.
 
 ## Getting Started
 
@@ -70,7 +70,7 @@ const validateUser: ValidateUserFn<UserType> = params => {
   // This method is being triggered in different flows, based on the mode you chose to implement.
 
   // If you are using the `protect-auth-directive` mode, you'll also get 2 additional parameters: the resolver parameters as object and the DirectiveNode of the auth directive.
-  // In `protect-auth-directive` mode, this function will always get called and you can use these parameters to check if the field has the `@auth` or `@skipAuth` directive
+  // In `protect-auth-directive` mode, this function will always get called and you can use these parameters to check if the field has the `@authenticated` or `@skipAuth` directive
 
   if (!user) {
     return new Error(`Unauthenticated!`)
@@ -213,8 +213,8 @@ const resolvers = {
 
 #### Option #3 - `protect-granular`
 
-This mode is similar to option #2, but it uses the `@auth` SDL directive or `auth` field extension
-for protecting specific GraphQL fields.
+This mode is similar to option #2, but it uses the `@authenticated` SDL directive or `auth` field
+extension for protecting specific GraphQL fields.
 
 ```ts
 import { execute, parse, specifiedRules, subscribe, validate } from 'graphql'
@@ -247,15 +247,15 @@ const getEnveloped = envelop({
 ##### Protect a field using a field `directive`
 
 > By default, we assume that you have the GraphQL directive definition as part of your GraphQL
-> schema (`directive @auth on FIELD_DEFINITION`).
+> schema (`directive @authenticated on FIELD_DEFINITION`).
 
-Then, in your GraphQL schema SDL, you can add `@auth` directive to your fields, and the
+Then, in your GraphQL schema SDL, you can add `@authenticated` directive to your fields, and the
 `validateUser` will get called only while resolving that specific field:
 
 ```graphql
 type Query {
-  me: User! @auth
-  protectedField: String @auth
+  me: User! @authenticated
+  protectedField: String @authenticated
   # publicField: String
 }
 ```
@@ -277,7 +277,7 @@ const GraphQLQueryType = new GraphQLObjectType({
       type: GraphQLInt,
       resolve: () => 1,
       extensions: {
-        auth: true
+        authenticated: true
       }
     }
   }
@@ -308,8 +308,8 @@ const validateUser: ValidateUserFn<UserType> = ({ user }) => {
 
 ##### With a custom directive with arguments
 
-It is possible to add custom parameters to your `@auth` directive. Here's an example for adding
-role-aware authentication:
+It is possible to add custom parameters to your `@authenticated` directive. Here's an example for
+adding role-aware authentication:
 
 ```graphql
 enum Role {
@@ -317,7 +317,7 @@ enum Role {
   MEMBER
 }
 
-directive @auth(role: Role!) on FIELD_DEFINITION
+directive @authenticated(role: Role!) on FIELD_DEFINITION
 ```
 
 Then, you use the `directiveNode` parameter to check the arguments:
@@ -371,7 +371,7 @@ const resolvers = {
     user: {
       me: (_, __, { currentUser }) => currentUser,
       extensions: {
-        auth: {
+        authenticated: {
           role: 'USER'
         }
       }
@@ -410,7 +410,7 @@ const resolvers = {
     user: {
       resolve: (_, { userId }) => getUser(userId),
       extensions: {
-        auth: {
+        authenticated: {
           validate: ({ user, variables, context }) => {
             // We can now have access to the operation and variables to decide if the user can execute the query
             if (user.id !== variables.userId) {

--- a/packages/plugins/generic-auth/README.md
+++ b/packages/plugins/generic-auth/README.md
@@ -134,8 +134,8 @@ type Query {
 
 > You can apply that directive to any GraphQL `field` definition, not only to root fields.
 
-> If you are using a different directive for authentication, you can pass
-> `directiveOrExtensionFieldName` configuration to customize it.
+> If you are using a different directive for authentication, you can pass `authDirectiveName`
+> configuration to customize it.
 
 ##### Allow unauthenticated access for specific fields using a field extension
 
@@ -158,8 +158,8 @@ const GraphQLQueryType = new GraphQLObjectType({
 })
 ```
 
-> If you want to use a different directive for authentication, you can use the
-> `directiveOrExtensionFieldName` configuration to customize it.
+> If you want to use a different directive for authentication, you can use the `authDirectiveName`
+> configuration to customize it.
 
 #### Option #2 - `resolve-only`
 
@@ -264,8 +264,8 @@ type Query {
 
 > You can apply that directive to any GraphQL `field` definition, not only to root fields.
 
-> If you are using a different directive for authentication, you can pass
-> `directiveOrExtensionFieldName` configuration to customize it.
+> If you are using a different directive for authentication, you can pass `authDirectiveName`
+> configuration to customize it.
 
 ##### Protect a field using a field extension
 
@@ -288,8 +288,8 @@ const GraphQLQueryType = new GraphQLObjectType({
 })
 ```
 
-> If you are using a different field extension for authentication, you can pass
-> `directiveOrExtensionFieldName` configuration to customize it.
+> If you are using a different field extension for authentication, you can pass `authDirectiveName`
+> configuration to customize it.
 
 #### Extend authentication with custom logic
 

--- a/packages/plugins/generic-auth/package.json
+++ b/packages/plugins/generic-auth/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@envelop/extended-validation": "^4.0.0",
-    "@graphql-tools/utils": "^10.0.6",
+    "@graphql-tools/utils": "^10.5.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/plugins/generic-auth/package.json
+++ b/packages/plugins/generic-auth/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@envelop/extended-validation": "^4.0.0",
-    "@graphql-tools/utils": "^10.5.0",
+    "@graphql-tools/utils": "^10.5.1",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -353,7 +353,8 @@ export const useGenericAuth = <
                   const fieldScopes = fieldDirectives[requiresScopesDirectiveName]?.[0]?.scopes;
                   const fieldPolicies = fieldDirectives[policyDirectiveName]?.[0]?.policies;
                   const userScopes = extractScopes(user);
-                  const policies = policiesByContext.get(context as unknown as ContextType) ?? [];
+                  const userPolicies =
+                    policiesByContext.get(args.contextValue as unknown as ContextType) ?? [];
 
                   const resolvePath: (string | number)[] = [];
 
@@ -381,7 +382,7 @@ export const useGenericAuth = <
                     fieldPolicies,
                     userScopes,
                     path: resolvePath,
-                    userPolicies: policies,
+                    userPolicies,
                   });
                 };
 

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -90,7 +90,7 @@ export type GenericAuthPluginOptions<
        * Overrides the default directive name or extension field for marking a field available for unauthorized users.
        * @default skipAuth
        */
-      directiveOrExtensionFieldName?: 'skipAuth' | string;
+      authDirectiveName?: 'skipAuth' | string;
       /**
        * Customize how the user is validated. E.g. apply authorization role based validation.
        * The validation is applied during the extended validation phase.
@@ -115,14 +115,13 @@ export type GenericAuthPluginOptions<
        * Overrides the default directive name or extension field for marking a field available only for authorized users.
        * @default authenticated
        */
-      directiveOrExtensionFieldName?: 'authenticated' | string;
+      authDirectiveName?: 'authenticated' | string;
       /**
        * Customize how the user is validated. E.g. apply authorization role based validation.
        * The validation is applied during the extended validation phase.
        * @default `defaultProtectSingleValidateFn`
        */
       validateUser?: ValidateUserFn<UserType>;
-
       /**
        * Reject on unauthenticated requests.
        * @default true
@@ -186,8 +185,7 @@ export const useGenericAuth = <
 
   if (options.mode === 'protect-all' || options.mode === 'protect-granular') {
     const directiveOrExtensionFieldName =
-      options.directiveOrExtensionFieldName ??
-      (options.mode === 'protect-all' ? 'skipAuth' : 'authenticated');
+      options.authDirectiveName ?? (options.mode === 'protect-all' ? 'skipAuth' : 'authenticated');
     const validateUser =
       options.validateUser ??
       (options.mode === 'protect-all'

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -318,7 +318,7 @@ export const useGenericAuth = <
           }),
         );
       },
-      onContextBuilding({ context, extendContext }) {
+      onContextBuilding({ context, extendContext }): PromiseOrValue<void> {
         const user$ = options.resolveUserFn(context as unknown as ContextType);
         if (isPromise(user$)) {
           return user$.then(user => {

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -65,19 +65,19 @@ export type ValidateUserFn<UserType> = (
 ) => void | GraphQLError;
 
 export const DIRECTIVE_SDL = /* GraphQL */ `
-  directive @authenticated on FIELD_DEFINITION
+  directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE
 `;
 
 export const SKIP_AUTH_DIRECTIVE_SDL = /* GraphQL */ `
-  directive @skipAuth on FIELD_DEFINITION
+  directive @skipAuth on FIELD_DEFINITION | OBJECT | INTERFACE
 `;
 
 export const REQUIRES_SCOPES_DIRECTIVE_SDL = /* GraphQL */ `
-  directive @requiresScopes(scopes: [[String!]!]!) on FIELD_DEFINITION
+  directive @requiresScopes(scopes: [[String!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE
 `;
 
 export const POLICY_DIRECTIVE_SDL = /* GraphQL */ `
-  directive @policy(policies: [String!]!) on FIELD_DEFINITION
+  directive @policy(policies: [String!]!) on FIELD_DEFINITION | OBJECT | INTERFACE
 `;
 
 export type GenericAuthPluginOptions<

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -1,8 +1,7 @@
-import { EnumValueNode, FieldNode, getIntrospectionQuery } from 'graphql';
+import { getIntrospectionQuery } from 'graphql';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
-import { Maybe } from '@envelop/types';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { createGraphQLError, shouldIncludeNode } from '@graphql-tools/utils';
+import { createGraphQLError } from '@graphql-tools/utils';
 import {
   DIRECTIVE_SDL,
   ResolveUserFn,

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -400,19 +400,12 @@ describe('useGenericAuth', () => {
           });
         }
 
-        if (params.fieldAuthDirectiveNode?.arguments) {
-          const valueNode = params.fieldAuthDirectiveNode.arguments.find(
-            arg => arg.name.value === 'role',
-          )?.value as EnumValueNode | undefined;
-          if (valueNode) {
-            const role = valueNode.value;
-
-            if (role !== params.user.role) {
-              return createGraphQLError(
-                `Missing permissions for accessing field '${schemaCoordinate}'. Requires role '${role}'. Request is authenticated with role '${params.user.role}'.`,
-                { nodes: [params.fieldNode] },
-              );
-            }
+        if (params.fieldAuthArgs) {
+          if (params.fieldAuthArgs.role !== params.user.role) {
+            return createGraphQLError(
+              `Missing permissions for accessing field '${schemaCoordinate}'. Requires role '${params.fieldAuthArgs.role}'. Request is authenticated with role '${params.user.role}'.`,
+              { nodes: [params.fieldNode] },
+            );
           }
         }
 

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -393,7 +393,7 @@ describe('useGenericAuth', () => {
     describe('auth directive with role', () => {
       type UserTypeWithRole = UserType & { role: 'ADMIN' | 'USER' };
       const validateUserFn: ValidateUserFn<UserTypeWithRole> = params => {
-        const schemaCoordinate = `${params.objectType.name}.${params.fieldNode.name.value}`;
+        const schemaCoordinate = `${params.parentType.name}.${params.fieldNode.name.value}`;
         if (!params.user) {
           return createGraphQLError(`Accessing '${schemaCoordinate}' requires authentication.`, {
             nodes: [params.fieldNode],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,8 +956,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(@envelop/core@packages+core+dist)(graphql@16.6.0)
       '@graphql-tools/utils':
-        specifier: ^10.0.6
-        version: 10.0.6(graphql@16.6.0)
+        specifier: ^10.5.0
+        version: 10.5.0(graphql@16.6.0)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
@@ -3160,8 +3160,8 @@ packages:
     peerDependencies:
       graphql: 16.6.0
 
-  '@graphql-tools/utils@10.0.6':
-    resolution: {integrity: sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==}
+  '@graphql-tools/utils@10.5.0':
+    resolution: {integrity: sha512-TtdmI5nKMl7QKWENudj7MnaE1skH9y7x2XuG//kHzIox9c6Q8Z2QiWoeD6EuDxCZ4nkRoQpn/YT7kT8FoaV/xQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: 16.6.0
@@ -13412,9 +13412,10 @@ snapshots:
       graphql: 16.6.0
       tslib: 2.5.0
 
-  '@graphql-tools/utils@10.0.6(graphql@16.6.0)':
+  '@graphql-tools/utils@10.5.0(graphql@16.6.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      cross-inspect: 1.0.1
       dset: 3.1.2
       graphql: 16.6.0
       tslib: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,8 +956,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(@envelop/core@packages+core+dist)(graphql@16.6.0)
       '@graphql-tools/utils':
-        specifier: ^10.5.0
-        version: 10.5.0(graphql@16.6.0)
+        specifier: ^10.5.1
+        version: 10.5.1(graphql@16.6.0)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0


### PR DESCRIPTION

Refactor Generic Auth plugin;

- [BREAKING] - Now `@auth` directive is renamed to `@authenticated`. If you want to keep the old name you can configure the plugin to use the old name.

```ts
useGenericAuth({
  // ...
  authDirectiveName: 'auth',
});
```

- [BREAKING] - Now `directiveOrExtensionFieldName` is renamed to `authDirectiveName`.

```diff
useGenericAuth({
  // ...
- directiveOrExtensionFieldName: 'auth',
+ authDirectiveName: 'auth',
});
```

- Now auth directives support `OBJECT` and `INTERFACE` locations;
```graphql
directive @authenticated on OBJECT | INTERFACE

type User @authenticated {
    id: ID!
    name: String!
}
```

- `validateUser` function does not receive `fieldAuthDirectiveNode` and `fieldAuthExtension` anymore. Instead, it takes `fieldAuthArgs` which is an object that contains the arguments of the auth directive or extension. So you don't need to parse the arguments manually anymore.

```ts
const validateUser: ValidateUserFn = params => {
  if (!params.fieldAuthArgs.roles.includes('admin')) {
    return createUnauthorizedError(params);
  }
};
```

- `validateUser`'s `objectType` parameter is now renamed to `parentType`. And it takes the original composite type instead of the `GraphQLObjectType` instance. Now it can be `GraphQLInterfaceType` as well.

- `validateUser`'s current parameters are now;

```ts
export type ValidateUserFnParams<UserType> = {
  /** The user object. */
  user: UserType;
  /** The field node from the operation that is being validated. */
  fieldNode: FieldNode;
  /** The parent type which has the field that is being validated. */
  parentType: GraphQLObjectType | GraphQLInterfaceType;
  /** The auth directive arguments for the type */
  typeAuthArgs?: Record<string, any>;
  /** The directives for the type */
  typeDirectives?: ReturnType<typeof getDirectiveExtensions>;
  /** Scopes that type requires */
  typeScopes?: string[][];
  /** Policies that type requires */
  typePolicies?: string[][];
  /** The object field */
  field: GraphQLField<any, any>;
  /** The auth directive arguments for the field */
  fieldAuthArgs?: Record<string, any>;
  /** The directives for the field */
  fieldDirectives?: ReturnType<typeof getDirectiveExtensions>;
  /** Scopes that field requires */
  fieldScopes?: string[][];
  /** Policies that field requires */
  fieldPolicies?: string[][];
  /** Extracted scopes from the user object */
  userScopes: string[];
  /** Policies for the user */
  userPolicies: string[];
  /** The args passed to the execution function (including operation context and variables) **/
  executionArgs: ExecutionArgs;
  /** Resolve path */
  path: ReadonlyArray<string | number>;
};
```

- New directives for role-based auth are added `@requiresScopes` and `@policy` for more granular control over the auth logic.

```graphql
directive @requiresScopes(scopes: [String!]!) on OBJECT | INTERFACE | FIELD_DEFINITION

directive @policy(policy: String!) on OBJECT | INTERFACE | FIELD_DEFINITION
```

Check README for more information.
