### PR TITLE
Make it possible to conditionally skip any histogram observation

### DIFF
--- a/.changeset/ninety-melons-learn.md
+++ b/.changeset/ninety-melons-learn.md
@@ -1,0 +1,5 @@
+---
+'@envelop/prometheus': minor
+---
+
+Make it possible for a user to conditionally escape histogram/summary observations on a per request basis.

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -187,11 +187,12 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
       }
 
       if (fillLabelsFnParams) {
-        parseHistogram?.histogram.observe(
-          parseHistogram.fillLabelsFn(fillLabelsFnParams, context),
-          totalTime,
-        );
-
+        if (parseHistogram?.shouldRecordFn(fillLabelsFnParams, context)) {
+          parseHistogram.histogram.observe(
+            parseHistogram.fillLabelsFn(fillLabelsFnParams, context),
+            totalTime,
+          );
+        }
         if (deprecationCounter && typeInfo) {
           const deprecatedFields = extractDeprecatedFields(fillLabelsFnParams.document!, typeInfo);
 
@@ -234,7 +235,9 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
         return ({ valid }) => {
           const totalTime = (Date.now() - startTime) / 1000;
           const labels = validateHistogram.fillLabelsFn(fillLabelsFnParams, context);
-          validateHistogram.histogram.observe(labels, totalTime);
+          if (validateHistogram?.shouldRecordFn(fillLabelsFnParams, context)) {
+            validateHistogram.histogram.observe(labels, totalTime);
+          }
 
           if (!valid) {
             errorsCounter?.counter
@@ -258,11 +261,13 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
         const startTime = Date.now();
 
         return () => {
-          const totalTime = (Date.now() - startTime) / 1000;
-          contextBuildingHistogram.histogram.observe(
-            contextBuildingHistogram.fillLabelsFn(fillLabelsFnParams, context),
-            totalTime,
-          );
+          if (contextBuildingHistogram.shouldRecordFn(fillLabelsFnParams, context)) {
+            const totalTime = (Date.now() - startTime) / 1000;
+            contextBuildingHistogram.histogram.observe(
+              contextBuildingHistogram.fillLabelsFn(fillLabelsFnParams, context),
+              totalTime,
+            );
+          }
         };
       }
     : undefined;
@@ -303,23 +308,29 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
             const execStartTime = execStartTimeMap.get(args.contextValue);
             const handleEnd = () => {
               const totalTime = (Date.now() - startTime) / 1000;
-              executeHistogram.histogram.observe(
-                executeHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                totalTime,
-              );
+              if (executeHistogram.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                executeHistogram.histogram.observe(
+                  executeHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                  totalTime,
+                );
+              }
 
-              requestTotalHistogram?.histogram.observe(
-                requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                totalTime,
-              );
+              if (requestTotalHistogram?.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                requestTotalHistogram.histogram.observe(
+                  requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                  totalTime,
+                );
+              }
 
               if (requestSummary && execStartTime) {
                 const summaryTime = (Date.now() - execStartTime) / 1000;
 
-                requestSummary.summary.observe(
-                  requestSummary.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                  summaryTime,
-                );
+                if (requestSummary.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                  requestSummary.summary.observe(
+                    requestSummary.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                    summaryTime,
+                  );
+                }
               }
             };
             if (!isAsyncIterable(result)) {
@@ -379,23 +390,29 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
             const execStartTime = execStartTimeMap.get(args.contextValue);
             const handleEnd = () => {
               const totalTime = (Date.now() - startTime) / 1000;
-              subscribeHistogram.histogram.observe(
-                subscribeHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                totalTime,
-              );
+              if (subscribeHistogram.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                subscribeHistogram.histogram.observe(
+                  subscribeHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                  totalTime,
+                );
+              }
 
-              requestTotalHistogram?.histogram.observe(
-                requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                totalTime,
-              );
+              if (requestTotalHistogram?.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                requestTotalHistogram.histogram.observe(
+                  requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                  totalTime,
+                );
+              }
 
               if (requestSummary && execStartTime) {
                 const summaryTime = (Date.now() - execStartTime) / 1000;
 
-                requestSummary.summary.observe(
-                  requestSummary.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                  summaryTime,
-                );
+                if (requestSummary.shouldRecordFn(fillLabelsFnParams, args.contextValue)) {
+                  requestSummary.summary.observe(
+                    requestSummary.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                    summaryTime,
+                  );
+                }
               }
             };
             if (!isAsyncIterable(result)) {
@@ -445,10 +462,12 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
                 ...fillLabelsFnParams,
                 info,
               };
-              resolversHistogram.histogram.observe(
-                resolversHistogram.fillLabelsFn(paramsCtx, context),
-                totalTime,
-              );
+              if (resolversHistogram.shouldRecordFn(paramsCtx, context)) {
+                resolversHistogram.histogram.observe(
+                  resolversHistogram.fillLabelsFn(paramsCtx, context),
+                  totalTime,
+                );
+              }
             };
           }),
         );


### PR DESCRIPTION
## Description

Make it possible for a user to conditionally escape histogram/summary observations on a per request basis.

Fixes #2312

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Should allow user to decide if an observation should be made

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

