### PR TITLE
feat: [plugin/prometheus] allow to skip observation based on context

### DIFF
--- a/.changeset/cold-seals-play.md
+++ b/.changeset/cold-seals-play.md
@@ -1,0 +1,73 @@
+---
+'@envelop/prometheus': major
+---
+
+Allow to explicitly control which events and timing should be observe.
+
+Each metric can now be configured to observe events and timings only for certain GraphQL pipeline
+phases, or depending on the request context.
+
+```ts
+import { execute, parse, specifiedRules, subscribe, validate } from 'graphql'
+import { envelop, useEngine } from '@envelop/core'
+import { usePrometheus } from '@envelop/prometheus'
+
+const TRACKED_OPERATION_NAMES = [
+  // make a list of operation that you want to monitor
+]
+
+const getEnveloped = envelop({
+  plugins: [
+    useEngine({ parse, validate, specifiedRules, execute, subscribe }),
+    usePrometheus({
+      metrics: {
+
+        // only trace errors of execute and subscribe phases
+        graphql_envelop_phase_error: ['execute', 'subscribe']
+
+        // only monitor timing of some operations
+        graphql_yoga_http_duration: createHistogram({
+          registry,
+          histogram: {
+            name: 'graphql_yoga_http_duration',
+            help: 'Time spent on HTTP connection',
+            labelNames: ['operation_name']
+          },
+          fillLabelsFn: ({ operationName }, _rawContext) => ({
+            operation_name: operationName,
+          }),
+
+          // Here `shouldObserve` control if the request timing should be observed, based on context
+          shouldObserve: context => TRACKED_OPERATIONS.includes(context?.params?.operationName),
+        })
+      },
+    })
+  ]
+})
+```
+
+**Breaking Change**: A metric is enabled using `true` value in metrics options will observe in every
+phases available.
+
+Previously, which phase was observe was depending on which other metric were enabled. For example,
+this config would only trace validation error:
+
+```ts
+usePrometheus({
+  metrics: {
+    graphql_envelop_phase_error: true,
+    graphql_envelop_phase_validate: true,
+  },
+})
+```
+
+This is no longer the case. If you were relying on this behavior, please use an array of string to
+restrict observed phases.
+
+```ts
+usePrometheus({
+  metrics: {
+    graphql_envelop_phase_error: ['validate'],
+  },
+})
+```

--- a/packages/plugins/prometheus/src/config.ts
+++ b/packages/plugins/prometheus/src/config.ts
@@ -1,5 +1,5 @@
 import { Registry } from 'prom-client';
-import { createCounter, createHistogram, createSummary } from './utils.js';
+import { createCounter, createHistogram, createSummary, type AtLeastOne } from './utils.js';
 
 export type PrometheusTracingPluginConfig = {
   /**
@@ -48,7 +48,7 @@ export type MetricsConfig = {
    * It counts all operations, either failed or successful, including subscriptions.
    * It is exposed as a counter.
    */
-  graphql_envelop_request?: boolean | string | ReturnType<typeof createCounter>;
+  graphql_envelop_request?: CounterMetricOption<AtLeastOne<'execute' | 'subscribe'>>;
 
   /**
    * Tracks the duration of the complete GraphQL operation execution.
@@ -60,16 +60,12 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_request_duration?:
-    | boolean
-    | string
-    | number[]
-    | ReturnType<typeof createHistogram>;
+  graphql_envelop_request_duration?: HistogramMetricOption<AtLeastOne<'execute' | 'subscribe'>>;
   /**
    * Provides a summary of the time spent on the GraphQL operation execution.
    * It reports the same timing than graphql_envelop_request_duration but as a summary.
    */
-  graphql_envelop_request_time_summary?: boolean | string | ReturnType<typeof createSummary>;
+  graphql_envelop_request_time_summary?: SummaryMetricOption<AtLeastOne<'execute' | 'subscribe'>>;
   /**
    * Tracks the duration of the parse phase of the GraphQL execution.
    * It reports the time spent parsing the incoming GraphQL operation.
@@ -81,7 +77,7 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_phase_parse?: boolean | string | number[] | ReturnType<typeof createHistogram>;
+  graphql_envelop_phase_parse?: HistogramMetricOption<['parse']>;
   /**
    * Tracks the duration of the validate phase of the GraphQL execution.
    * It reports the time spent validating the incoming GraphQL operation.
@@ -93,7 +89,7 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_phase_validate?: boolean | string | number[] | ReturnType<typeof createHistogram>;
+  graphql_envelop_phase_validate?: HistogramMetricOption<['validate']>;
   /**
    * Tracks the duration of the context phase of the GraphQL execution.
    * It reports the time spent building the context object that will be passed to the executors.
@@ -105,7 +101,7 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_phase_context?: boolean | string | number[] | ReturnType<typeof createHistogram>;
+  graphql_envelop_phase_context?: HistogramMetricOption<['context']>;
   /**
    * Tracks the duration of the execute phase of the GraphQL execution.
    * It reports the time spent actually resolving the response of the incoming operation.
@@ -118,7 +114,7 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_phase_execute?: boolean | string | number[] | ReturnType<typeof createHistogram>;
+  graphql_envelop_phase_execute?: HistogramMetricOption<['execute']>;
   /**
    * This metric tracks the duration of the subscribe phase of the GraphQL execution.
    * It reports the time spent initiating a subscription (which doesn’t include actually sending the first response).
@@ -130,23 +126,21 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_phase_subscribe?:
-    | boolean
-    | string
-    | number[]
-    | ReturnType<typeof createHistogram>;
+  graphql_envelop_phase_subscribe?: HistogramMetricOption<['subscribe']>;
   /**
    * This metric tracks the number of errors that returned by the GraphQL execution.
    * It counts all errors found in response, but it also includes errors from other GraphQL
    * processing phases (parsing, validation and context building).
    * It is exposed as a counter.
    */
-  graphql_envelop_error_result?: boolean | string | ReturnType<typeof createCounter>;
+  graphql_envelop_error_result?: CounterMetricOption<
+    AtLeastOne<'parse' | 'validate' | 'context' | 'execute' | 'subscribe'>
+  >;
   /**
    * This metric tracks the number of deprecated fields used in the GraphQL operation.
    * It is exposed as a counter.
    */
-  graphql_envelop_deprecated_field?: boolean | string | ReturnType<typeof createCounter>;
+  graphql_envelop_deprecated_field?: CounterMetricOption<['parse']>;
   /**
    * This metric tracks the number of schema changes that have occurred since the gateway started.
    * If you are using a plugin that modifies the schema on the fly,
@@ -154,7 +148,7 @@ export type MetricsConfig = {
    * Which means that one schema update can actually trigger multiple schema changes.
    * It is exposed as a counter.
    */
-  graphql_envelop_schema_change?: boolean | string | ReturnType<typeof createCounter>;
+  graphql_envelop_schema_change?: CounterMetricOption<[]>;
   /**
    * This metric tracks the duration of each resolver execution.
    *
@@ -168,11 +162,7 @@ export type MetricsConfig = {
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
-  graphql_envelop_execute_resolver?:
-    | boolean
-    | string
-    | number[]
-    | ReturnType<typeof createHistogram>;
+  graphql_envelop_execute_resolver?: HistogramMetricOption<AtLeastOne<'subscribe' | 'execute'>>;
 };
 
 export type LabelsConfig = {
@@ -219,3 +209,23 @@ export type LabelsConfig = {
    */
   phase?: boolean;
 };
+
+export type HistogramMetricOption<Phases extends string[], LabelNames extends string = string> =
+  | boolean
+  | string
+  | BucketsConfig
+  | Phases
+  | ReturnType<typeof createHistogram<Phases, LabelNames>>;
+export type BucketsConfig = AtLeastOne<number>;
+
+export type CounterMetricOption<Phases extends string[], LabelNames extends string = string> =
+  | boolean
+  | string
+  | Phases
+  | ReturnType<typeof createCounter<Phases, LabelNames>>;
+
+export type SummaryMetricOption<Phases extends string[], LabelNames extends string = string> =
+  | boolean
+  | string
+  | Phases
+  | ReturnType<typeof createSummary<Phases, LabelNames>>;

--- a/packages/plugins/prometheus/src/config.ts
+++ b/packages/plugins/prometheus/src/config.ts
@@ -148,7 +148,7 @@ export type MetricsConfig = {
    * Which means that one schema update can actually trigger multiple schema changes.
    * It is exposed as a counter.
    */
-  graphql_envelop_schema_change?: CounterMetricOption<[]>;
+  graphql_envelop_schema_change?: CounterMetricOption<['schema']>;
   /**
    * This metric tracks the duration of each resolver execution.
    *

--- a/packages/plugins/prometheus/src/config.ts
+++ b/packages/plugins/prometheus/src/config.ts
@@ -47,6 +47,12 @@ export type MetricsConfig = {
    * Tracks the number of GraphQL operations executed.
    * It counts all operations, either failed or successful, including subscriptions.
    * It is exposed as a counter.
+   *
+   * You can pass multiple type of values:
+   *  - boolean: Disable or Enable the metric with default configuration
+   *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
+   *  - ReturnType<typeof createCounter>: Enable the metric with custom configuration
    */
   graphql_envelop_request?: CounterMetricOption<AtLeastOne<'execute' | 'subscribe'>>;
 
@@ -57,6 +63,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -64,6 +71,12 @@ export type MetricsConfig = {
   /**
    * Provides a summary of the time spent on the GraphQL operation execution.
    * It reports the same timing than graphql_envelop_request_duration but as a summary.
+   *
+   * You can pass multiple type of values:
+   *  - boolean: Disable or Enable the metric with default configuration
+   *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
+   *  - ReturnType<typeof createSummary>: Enable the metric with custom configuration
    */
   graphql_envelop_request_time_summary?: SummaryMetricOption<AtLeastOne<'execute' | 'subscribe'>>;
   /**
@@ -74,6 +87,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -86,6 +100,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -98,6 +113,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -111,6 +127,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -123,6 +140,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */
@@ -132,6 +150,12 @@ export type MetricsConfig = {
    * It counts all errors found in response, but it also includes errors from other GraphQL
    * processing phases (parsing, validation and context building).
    * It is exposed as a counter.
+   *
+   * You can pass multiple type of values:
+   *  - boolean: Disable or Enable the metric with default configuration
+   *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
+   *  - ReturnType<typeof createCounter>: Enable the metric with custom configuration
    */
   graphql_envelop_error_result?: CounterMetricOption<
     AtLeastOne<'parse' | 'validate' | 'context' | 'execute' | 'subscribe'>
@@ -139,6 +163,12 @@ export type MetricsConfig = {
   /**
    * This metric tracks the number of deprecated fields used in the GraphQL operation.
    * It is exposed as a counter.
+   *
+   * You can pass multiple type of values:
+   *  - boolean: Disable or Enable the metric with default configuration
+   *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
+   *  - ReturnType<typeof createCounter>: Enable the metric with custom configuration
    */
   graphql_envelop_deprecated_field?: CounterMetricOption<['parse']>;
   /**
@@ -147,6 +177,12 @@ export type MetricsConfig = {
    * be aware that this metric will also include updates made by those plugins.
    * Which means that one schema update can actually trigger multiple schema changes.
    * It is exposed as a counter.
+   *
+   * You can pass multiple type of values:
+   *  - boolean: Disable or Enable the metric with default configuration
+   *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
+   *  - ReturnType<typeof createCounter>: Enable the metric with custom configuration
    */
   graphql_envelop_schema_change?: CounterMetricOption<['schema']>;
   /**
@@ -159,6 +195,7 @@ export type MetricsConfig = {
    * You can pass multiple type of values:
    *  - boolean: Disable or Enable the metric with default configuration
    *  - string: Enable the metric with custom name
+   *  - string[]: Enable the metric on a list of phases
    *  - number[]: Enable the metric with custom buckets
    *  - ReturnType<typeof createHistogram>: Enable the metric with custom configuration
    */

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -12,6 +12,8 @@ import {
   OnSubscribeHookResult,
   OnValidateHook,
   Plugin,
+  type OnEnvelopedHook,
+  type OnPluginInitHook,
 } from '@envelop/core';
 import { useOnResolve } from '@envelop/on-resolve';
 import { PrometheusTracingPluginConfig, type MetricsConfig } from './config.js';
@@ -54,45 +56,51 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
   let typeInfo: TypeInfo | null = null;
   config.registry = instrumentRegistry(config.registry || defaultRegistry);
 
-  const parseHistogram = getHistogramFromConfig<MetricsConfig>(
+  const parseHistogram = getHistogramFromConfig<['parse'], MetricsConfig>(
     config,
     'graphql_envelop_phase_parse',
+    ['parse'],
     {
       help: 'Time spent on running GraphQL "parse" function',
     },
   );
-  const validateHistogram = getHistogramFromConfig<MetricsConfig>(
+  const validateHistogram = getHistogramFromConfig<['validate'], MetricsConfig>(
     config,
     'graphql_envelop_phase_validate',
+    ['validate'],
     {
       help: 'Time spent on running GraphQL "validate" function',
     },
   );
-  const contextBuildingHistogram = getHistogramFromConfig<MetricsConfig>(
+  const contextBuildingHistogram = getHistogramFromConfig<['context'], MetricsConfig>(
     config,
     'graphql_envelop_phase_context',
+    ['context'],
     {
       help: 'Time spent on building the GraphQL context',
     },
   );
-  const executeHistogram = getHistogramFromConfig<MetricsConfig>(
+  const executeHistogram = getHistogramFromConfig<['execute'], MetricsConfig>(
     config,
     'graphql_envelop_phase_execute',
+    ['execute'],
     {
       help: 'Time spent on running the GraphQL "execute" function',
     },
   );
-  const subscribeHistogram = getHistogramFromConfig<MetricsConfig>(
+  const subscribeHistogram = getHistogramFromConfig<['subscribe'], MetricsConfig>(
     config,
     'graphql_envelop_phase_subscribe',
+    ['subscribe'],
     {
       help: 'Time spent on running the GraphQL "subscribe" function',
     },
   );
 
-  const resolversHistogram = getHistogramFromConfig<MetricsConfig>(
+  const resolversHistogram = getHistogramFromConfig<['execute', 'subscribe'], MetricsConfig>(
     config,
     'graphql_envelop_execute_resolver',
+    ['execute', 'subscribe'],
     {
       help: 'Time spent on running the GraphQL resolvers',
       labelNames: ['operationType', 'operationName', 'fieldName', 'typeName', 'returnType'],
@@ -107,45 +115,63 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
       }),
   );
 
-  const requestTotalHistogram = getHistogramFromConfig<MetricsConfig>(
+  const requestTotalHistogram = getHistogramFromConfig<['execute', 'subscribe'], MetricsConfig>(
     config,
     'graphql_envelop_request_duration',
+    ['execute', 'subscribe'],
     {
       help: 'Time spent on running the GraphQL operation from parse to execute',
     },
   );
 
-  const requestSummary = getSummaryFromConfig<MetricsConfig>(
+  const requestSummary = getSummaryFromConfig<['execute', 'subscribe'], MetricsConfig>(
     config,
     'graphql_envelop_request_time_summary',
+    ['execute', 'subscribe'],
     {
       help: 'Summary to measure the time to complete GraphQL operations',
     },
   );
 
-  const errorsCounter = getCounterFromConfig<MetricsConfig>(
+  const errorsCounter = getCounterFromConfig<
+    ['parse', 'validate', 'context', 'execute', 'subscribe'],
+    MetricsConfig
+  >(
     config,
     'graphql_envelop_error_result',
+    ['parse', 'validate', 'context', 'execute', 'subscribe'],
     {
       help: 'Counts the amount of errors reported from all phases',
       labelNames: ['operationType', 'operationName', 'path', 'phase'],
     },
-    params =>
-      filterFillParamsFnParams(config, {
+    params => {
+      const labels: Record<string, string> = {
         operationName: params.operationName!,
         operationType: params.operationType!,
-        path: params.error?.path?.join('.')!,
         phase: params.errorPhase!,
-      }),
+      };
+
+      if (params.error?.path) {
+        labels.path = params.error.path?.join('.');
+      }
+
+      return filterFillParamsFnParams(config, labels);
+    },
   );
 
-  const reqCounter = getCounterFromConfig<MetricsConfig>(config, 'graphql_envelop_request', {
-    help: 'Counts the amount of GraphQL requests executed through Envelop',
-  });
+  const reqCounter = getCounterFromConfig<['execute', 'subscribe'], MetricsConfig>(
+    config,
+    'graphql_envelop_request',
+    ['execute', 'subscribe'],
+    {
+      help: 'Counts the amount of GraphQL requests executed through Envelop',
+    },
+  );
 
-  const deprecationCounter = getCounterFromConfig<MetricsConfig>(
+  const deprecationCounter = getCounterFromConfig<['parse'], MetricsConfig>(
     config,
     'graphql_envelop_deprecated_field',
+    ['parse'],
     {
       help: 'Counts the amount of deprecated fields used in selection sets',
       labelNames: ['operationType', 'operationName', 'fieldName', 'typeName'],
@@ -159,15 +185,35 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
       }),
   );
 
-  const schemaChangeCounter = getCounterFromConfig<MetricsConfig>(
+  const schemaChangeCounter = getCounterFromConfig<['schema'], MetricsConfig>(
     config,
     'graphql_envelop_schema_change',
+    ['schema'],
     {
       help: 'Counts the amount of schema changes',
       labelNames: [],
     },
     () => ({}),
   );
+
+  // parse is mandatory, because it sets up label params for the whole request.
+  const phasesToHook = new Set(['parse']);
+  for (const metric of [
+    parseHistogram,
+    validateHistogram,
+    contextBuildingHistogram,
+    executeHistogram,
+    subscribeHistogram,
+    resolversHistogram,
+    requestTotalHistogram,
+    requestSummary,
+    errorsCounter,
+    reqCounter,
+    deprecationCounter,
+    schemaChangeCounter,
+  ]) {
+    metric?.phases.forEach(phase => phasesToHook.add(phase));
+  }
 
   const onParse: OnParseHook<{}> = ({ context, params }) => {
     if (config.skipIntrospection && isIntrospectionOperationString(params.source)) {
@@ -220,353 +266,353 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
     };
   };
 
-  const onValidate: OnValidateHook<{}> | undefined =
-    validateHistogram || errorsCounter
-      ? ({ context }) => {
-          const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
-          if (!fillLabelsFnParams) {
-            return undefined;
-          }
+  const onValidate: OnValidateHook<{}> = ({ context }) => {
+    const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
+    if (!fillLabelsFnParams) {
+      return undefined;
+    }
 
-          const startTime = Date.now();
+    const startTime = Date.now();
 
-          return ({ valid }) => {
-            const totalTime = (Date.now() - startTime) / 1000;
-            let labels;
-            if (validateHistogram?.shouldObserve(fillLabelsFnParams, context)) {
-              labels = validateHistogram.fillLabelsFn(fillLabelsFnParams, context);
-              validateHistogram.histogram.observe(labels, totalTime);
-            }
-
-            if (!valid && errorsCounter?.shouldObserve(fillLabelsFnParams, context)) {
-              // TODO: we should probably iterate over validation errors to report each error.
-              errorsCounter?.counter
-                // TODO: Use fillLabelsFn
-                .labels({
-                  ...(labels ?? validateHistogram?.fillLabelsFn(fillLabelsFnParams, context)),
-                  phase: 'validate',
-                })
-                .inc();
-            }
-          };
-        }
-      : undefined;
-
-  const onContextBuilding: OnContextBuildingHook<{}> | undefined = contextBuildingHistogram
-    ? ({ context }) => {
-        const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
-        if (
-          !fillLabelsFnParams ||
-          !contextBuildingHistogram.shouldObserve(fillLabelsFnParams, context)
-        ) {
-          return;
-        }
-
-        const startTime = Date.now();
-
-        return () => {
-          const totalTime = (Date.now() - startTime) / 1000;
-          contextBuildingHistogram.histogram.observe(
-            contextBuildingHistogram.fillLabelsFn(fillLabelsFnParams, context),
-            totalTime,
-          );
-        };
+    return ({ valid }) => {
+      const totalTime = (Date.now() - startTime) / 1000;
+      let labels;
+      if (validateHistogram?.shouldObserve(fillLabelsFnParams, context)) {
+        labels = validateHistogram.fillLabelsFn(fillLabelsFnParams, context);
+        validateHistogram.histogram.observe(labels, totalTime);
       }
-    : undefined;
 
-  const onExecute: OnExecuteHook<{}> | undefined =
-    executeHistogram || reqCounter || requestTotalHistogram || requestSummary || errorsCounter
-      ? ({ args }) => {
-          const fillLabelsFnParams = fillLabelsFnParamsMap.get(args.contextValue);
-          if (!fillLabelsFnParams) {
-            return;
-          }
+      if (
+        !valid &&
+        errorsCounter?.phases.includes('validate') &&
+        errorsCounter?.shouldObserve(fillLabelsFnParams, context)
+      ) {
+        // TODO: we should probably iterate over validation errors to report each error.
+        errorsCounter?.counter
+          // TODO: Use fillLabelsFn
+          .labels(
+            errorsCounter.fillLabelsFn({ ...fillLabelsFnParams, errorPhase: 'validate' }, context),
+          )
+          .inc();
+      }
+    };
+  };
 
-          const shouldObserveRequsets = reqCounter?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveExecute = executeHistogram?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveSummary = requestSummary?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
+  const onContextBuilding: OnContextBuildingHook<{}> | undefined = ({ context }) => {
+    const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
+    if (
+      !fillLabelsFnParams ||
+      !contextBuildingHistogram?.shouldObserve(fillLabelsFnParams, context)
+    ) {
+      return;
+    }
 
-          const shouldHandleEnd =
-            shouldObserveRequsets ||
-            shouldObserveExecute ||
-            shouldObserveRequestTotal ||
-            shouldObserveSummary;
+    const startTime = Date.now();
 
-          const shouldHandleResult = errorsCounter !== undefined;
+    return () => {
+      const totalTime = (Date.now() - startTime) / 1000;
+      contextBuildingHistogram.histogram.observe(
+        contextBuildingHistogram.fillLabelsFn(fillLabelsFnParams, context),
+        totalTime,
+      );
+    };
+  };
 
-          if (!shouldHandleEnd && !shouldHandleResult) {
-            return;
-          }
+  const onExecute: OnExecuteHook<{}> | undefined = ({ args }) => {
+    const fillLabelsFnParams = fillLabelsFnParamsMap.get(args.contextValue);
+    if (!fillLabelsFnParams) {
+      return;
+    }
 
-          const startTime = Date.now();
-          if (shouldObserveRequsets) {
-            reqCounter?.counter
-              .labels(reqCounter.fillLabelsFn(fillLabelsFnParams, args.contextValue))
+    const shouldObserveRequsets = reqCounter?.shouldObserve(fillLabelsFnParams, args.contextValue);
+    const shouldObserveExecute = executeHistogram?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+    const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+    const shouldObserveSummary = requestSummary?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+
+    const shouldHandleEnd =
+      shouldObserveRequsets ||
+      shouldObserveExecute ||
+      shouldObserveRequestTotal ||
+      shouldObserveSummary;
+
+    const shouldHandleResult = errorsCounter !== undefined;
+
+    if (!shouldHandleEnd && !shouldHandleResult) {
+      return;
+    }
+
+    const startTime = Date.now();
+    if (shouldObserveRequsets) {
+      reqCounter?.counter
+        .labels(reqCounter.fillLabelsFn(fillLabelsFnParams, args.contextValue))
+        .inc();
+    }
+
+    function handleResult(result: ExecutionResult) {
+      if (result.errors && result.errors.length > 0) {
+        for (const error of result.errors) {
+          const labelParams = {
+            ...fillLabelsFnParams,
+            errorPhase: 'execute',
+            error,
+          };
+
+          if (errorsCounter!.shouldObserve(labelParams, args.contextValue)) {
+            errorsCounter!.counter
+              .labels(errorsCounter!.fillLabelsFn(labelParams, args.contextValue))
               .inc();
           }
+        }
+      }
+    }
 
-          function handleResult(result: ExecutionResult) {
-            if (result.errors && result.errors.length > 0) {
-              for (const error of result.errors) {
-                const labelParams = {
+    const result: OnExecuteHookResult<{}> = {
+      onExecuteDone: ({ result }) => {
+        const handleEnd = () => {
+          const totalTime = (Date.now() - startTime) / 1000;
+          if (shouldObserveExecute) {
+            executeHistogram!.histogram.observe(
+              executeHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+              totalTime,
+            );
+          }
+
+          if (shouldObserveRequestTotal) {
+            requestTotalHistogram!.histogram.observe(
+              requestTotalHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+              totalTime,
+            );
+          }
+
+          if (shouldObserveSummary) {
+            const execStartTime = execStartTimeMap.get(args.contextValue);
+            if (execStartTime) {
+              const summaryTime = (Date.now() - execStartTime) / 1000;
+
+              requestSummary!.summary.observe(
+                requestSummary!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                summaryTime,
+              );
+            }
+          }
+        };
+
+        if (!isAsyncIterable(result)) {
+          shouldHandleResult && handleResult(result);
+          shouldHandleEnd && handleEnd();
+          return undefined;
+        } else {
+          return {
+            onNext: shouldHandleResult
+              ? ({ result }) => {
+                  handleResult(result);
+                }
+              : undefined,
+            onEnd: shouldHandleEnd ? handleEnd : undefined,
+          };
+        }
+      },
+    };
+
+    return result;
+  };
+
+  const onSubscribe: OnSubscribeHook<{}> | undefined = ({ args }) => {
+    const fillLabelsFnParams = fillLabelsFnParamsMap.get(args.contextValue);
+    if (!fillLabelsFnParams) {
+      return undefined;
+    }
+
+    const shouldObserveRequsets = reqCounter?.shouldObserve(fillLabelsFnParams, args.contextValue);
+    const shouldObserveExecute = executeHistogram?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+    const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+    const shouldObserveSummary = requestSummary?.shouldObserve(
+      fillLabelsFnParams,
+      args.contextValue,
+    );
+
+    const shouldHandleEnd =
+      shouldObserveRequsets ||
+      shouldObserveExecute ||
+      shouldObserveRequestTotal ||
+      shouldObserveSummary;
+
+    const shouldHandleResult = errorsCounter !== undefined;
+
+    const startTime = Date.now();
+    if (shouldObserveRequsets) {
+      reqCounter?.counter
+        .labels(reqCounter.fillLabelsFn(fillLabelsFnParams, args.contextValue))
+        .inc();
+    }
+
+    function handleResult(result: ExecutionResult) {
+      if (errorsCounter && result.errors && result.errors.length > 0) {
+        for (const error of result.errors) {
+          errorsCounter.counter
+            .labels(
+              errorsCounter.fillLabelsFn(
+                {
                   ...fillLabelsFnParams,
                   errorPhase: 'execute',
                   error,
-                };
+                },
+                args.contextValue,
+              ),
+            )
+            .inc();
+        }
+      }
+    }
 
-                if (errorsCounter!.shouldObserve(labelParams, args.contextValue)) {
-                  errorsCounter!.counter
-                    .labels(errorsCounter!.fillLabelsFn(labelParams, args.contextValue))
-                    .inc();
-                }
-              }
-            }
+    if (!shouldHandleEnd && !shouldHandleResult) {
+      return;
+    }
+
+    const result: OnSubscribeHookResult<{}> = {
+      onSubscribeResult: ({ result }) => {
+        const handleEnd = () => {
+          const totalTime = (Date.now() - startTime) / 1000;
+          if (shouldObserveExecute) {
+            subscribeHistogram!.histogram.observe(
+              subscribeHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+              totalTime,
+            );
+          }
+          if (shouldObserveRequestTotal) {
+            requestTotalHistogram?.histogram.observe(
+              requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+              totalTime,
+            );
           }
 
-          const result: OnExecuteHookResult<{}> = {
-            onExecuteDone: ({ result }) => {
-              const handleEnd = () => {
-                const totalTime = (Date.now() - startTime) / 1000;
-                if (shouldObserveExecute) {
-                  executeHistogram!.histogram.observe(
-                    executeHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                    totalTime,
-                  );
+          if (shouldObserveSummary) {
+            const execStartTime = execStartTimeMap.get(args.contextValue);
+            if (execStartTime) {
+              const summaryTime = (Date.now() - execStartTime) / 1000;
+
+              requestSummary!.summary.observe(
+                requestSummary!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
+                summaryTime,
+              );
+            }
+          }
+        };
+        if (!isAsyncIterable(result)) {
+          shouldHandleResult && handleResult(result);
+          shouldHandleEnd && handleEnd();
+          return undefined;
+        } else {
+          return {
+            onNext: shouldHandleResult
+              ? ({ result }) => {
+                  handleResult(result);
                 }
-
-                if (shouldObserveRequestTotal) {
-                  requestTotalHistogram!.histogram.observe(
-                    requestTotalHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                    totalTime,
-                  );
-                }
-
-                if (shouldObserveSummary) {
-                  const execStartTime = execStartTimeMap.get(args.contextValue);
-                  if (execStartTime) {
-                    const summaryTime = (Date.now() - execStartTime) / 1000;
-
-                    requestSummary!.summary.observe(
-                      requestSummary!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                      summaryTime,
-                    );
-                  }
-                }
-              };
-
-              if (!isAsyncIterable(result)) {
-                shouldHandleResult && handleResult(result);
-                shouldHandleEnd && handleEnd();
-                return undefined;
-              } else {
-                return {
-                  onNext: shouldHandleResult
-                    ? ({ result }) => {
-                        handleResult(result);
-                      }
-                    : undefined,
-                  onEnd: shouldHandleEnd ? handleEnd : undefined,
-                };
-              }
-            },
+              : undefined,
+            onEnd: shouldHandleEnd ? handleEnd : undefined,
           };
-
-          return result;
         }
-      : undefined;
+      },
+    };
 
-  const onSubscribe: OnSubscribeHook<{}> | undefined =
-    subscribeHistogram || reqCounter || errorsCounter || requestTotalHistogram || requestSummary
-      ? ({ args }) => {
-          const fillLabelsFnParams = fillLabelsFnParamsMap.get(args.contextValue);
-          if (!fillLabelsFnParams) {
+    return result;
+  };
+
+  const onPluginInit: OnPluginInitHook<{}> = ({ addPlugin, registerContextErrorHandler }) => {
+    if (resolversHistogram) {
+      addPlugin(
+        useOnResolve(({ info, context }) => {
+          const shouldTrace = shouldTraceFieldResolver(info, config.resolversWhitelist);
+
+          if (!shouldTrace) {
             return undefined;
           }
 
-          const shouldObserveRequsets = reqCounter?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveExecute = executeHistogram?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-          const shouldObserveSummary = requestSummary?.shouldObserve(
-            fillLabelsFnParams,
-            args.contextValue,
-          );
-
-          const shouldHandleEnd =
-            shouldObserveRequsets ||
-            shouldObserveExecute ||
-            shouldObserveRequestTotal ||
-            shouldObserveSummary;
-
-          const shouldHandleResult = errorsCounter !== undefined;
-
           const startTime = Date.now();
-          if (shouldObserveRequsets) {
-            reqCounter?.counter
-              .labels(reqCounter.fillLabelsFn(fillLabelsFnParams, args.contextValue))
-              .inc();
-          }
 
-          function handleResult(result: ExecutionResult) {
-            if (errorsCounter && result.errors && result.errors.length > 0) {
-              for (const error of result.errors) {
-                errorsCounter.counter
-                  .labels(
-                    errorsCounter.fillLabelsFn(
-                      {
-                        ...fillLabelsFnParams,
-                        errorPhase: 'execute',
-                        error,
-                      },
-                      args.contextValue,
-                    ),
-                  )
-                  .inc();
-              }
-            }
-          }
-
-          if (!shouldHandleEnd && !shouldHandleResult) {
-            return;
-          }
-
-          const result: OnSubscribeHookResult<{}> = {
-            onSubscribeResult: ({ result }) => {
-              const handleEnd = () => {
-                const totalTime = (Date.now() - startTime) / 1000;
-                if (shouldObserveExecute) {
-                  subscribeHistogram!.histogram.observe(
-                    subscribeHistogram!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                    totalTime,
-                  );
-                }
-                if (shouldObserveRequestTotal) {
-                  requestTotalHistogram?.histogram.observe(
-                    requestTotalHistogram.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                    totalTime,
-                  );
-                }
-
-                if (shouldObserveSummary) {
-                  const execStartTime = execStartTimeMap.get(args.contextValue);
-                  if (execStartTime) {
-                    const summaryTime = (Date.now() - execStartTime) / 1000;
-
-                    requestSummary!.summary.observe(
-                      requestSummary!.fillLabelsFn(fillLabelsFnParams, args.contextValue),
-                      summaryTime,
-                    );
-                  }
-                }
-              };
-              if (!isAsyncIterable(result)) {
-                shouldHandleResult && handleResult(result);
-                shouldHandleEnd && handleEnd();
-                return undefined;
-              } else {
-                return {
-                  onNext: shouldHandleResult
-                    ? ({ result }) => {
-                        handleResult(result);
-                      }
-                    : undefined,
-                  onEnd: shouldHandleEnd ? handleEnd : undefined,
-                };
-              }
-            },
+          return () => {
+            const totalTime = (Date.now() - startTime) / 1000;
+            const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
+            const paramsCtx = {
+              ...fillLabelsFnParams,
+              info,
+            };
+            resolversHistogram.histogram.observe(
+              resolversHistogram.fillLabelsFn(paramsCtx, context),
+              totalTime,
+            );
           };
-
-          return result;
+        }),
+      );
+    }
+    if (errorsCounter) {
+      registerContextErrorHandler(({ context, error }) => {
+        const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
+        if (
+          errorsCounter.shouldObserve(
+            { error: error as GraphQLError, errorPhase: 'context', ...fillLabelsFnParamsMap },
+            context,
+          )
+        ) {
+          errorsCounter.counter
+            .labels(
+              errorsCounter?.fillLabelsFn(
+                // FIXME: unsafe cast here, but it's ok, fillabelfn is doing duck typing anyway
+                { ...fillLabelsFnParams, errorPhase: 'context', error: error as GraphQLError },
+                context,
+              ),
+            )
+            .inc();
         }
-      : undefined;
+      });
+    }
+  };
+
+  const onEnveloped: OnEnvelopedHook<{}> = ({ context }) => {
+    if (!execStartTimeMap.has(context)) {
+      execStartTimeMap.set(context, Date.now());
+    }
+  };
+
+  function hookIf<T>(phase: string, hook: T): T | undefined {
+    if (phasesToHook.has(phase)) {
+      return hook;
+    }
+    return undefined;
+  }
 
   const countedSchemas = new WeakSet<GraphQLSchema>();
   return {
-    onEnveloped({ context }) {
-      if (!execStartTimeMap.has(context)) {
-        execStartTimeMap.set(context, Date.now());
-      }
-    },
-    onPluginInit({ addPlugin, registerContextErrorHandler }) {
-      if (resolversHistogram) {
-        addPlugin(
-          useOnResolve(({ info, context }) => {
-            const shouldTrace = shouldTraceFieldResolver(info, config.resolversWhitelist);
-
-            if (!shouldTrace) {
-              return undefined;
-            }
-
-            const startTime = Date.now();
-
-            return () => {
-              const totalTime = (Date.now() - startTime) / 1000;
-              const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
-              const paramsCtx = {
-                ...fillLabelsFnParams,
-                info,
-              };
-              resolversHistogram.histogram.observe(
-                resolversHistogram.fillLabelsFn(paramsCtx, context),
-                totalTime,
-              );
-            };
-          }),
-        );
-      }
-      if (errorsCounter) {
-        registerContextErrorHandler(({ context, error }) => {
-          const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
-          if (
-            errorsCounter.shouldObserve(
-              { error: error as GraphQLError, errorPhase: 'context', ...fillLabelsFnParamsMap },
-              context,
-            )
-          ) {
-            errorsCounter.counter
-              // TODO: use fillLabelsFn
-              .labels({
-                ...(fillLabelsFnParams &&
-                  contextBuildingHistogram?.fillLabelsFn(fillLabelsFnParams, context)),
-                phase: 'context',
-              })
-              .inc();
-          }
-        });
-      }
-    },
     onSchemaChange({ schema }) {
       typeInfo = new TypeInfo(schema);
+
       if (schemaChangeCounter?.shouldObserve({}, null) && !countedSchemas.has(schema)) {
         schemaChangeCounter.counter.inc();
         countedSchemas.add(schema);
       }
     },
-    onParse,
-    onValidate,
-    onContextBuilding,
-    onExecute,
-    onSubscribe,
+    onEnveloped: hookIf('execute', onEnveloped) ?? hookIf('subscribe', onEnveloped),
+    onPluginInit:
+      errorsCounter?.phases.includes('context') || resolversHistogram ? onPluginInit : undefined,
+    onParse: hookIf('parse', onParse),
+    onValidate: hookIf('validate', onValidate),
+    onContextBuilding: hookIf('context', onContextBuilding),
+    onExecute: hookIf('execute', onExecute),
+    onSubscribe: hookIf('subscribe', onSubscribe),
   };
 };

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -184,9 +184,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
 
       if (!fillLabelsFnParams) {
         // means that we got a parse error
-        if (
-          errorsCounter?.shouldObserve?.({ error: params.result, errorPhase: 'parse' }, context)
-        ) {
+        if (errorsCounter?.shouldObserve({ error: params.result, errorPhase: 'parse' }, context)) {
           // TODO: use fillLabelsFn
           errorsCounter?.counter.labels({ phase: 'parse' }).inc();
         }
@@ -196,7 +194,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
 
       const totalTime = (Date.now() - startTime) / 1000;
 
-      if (parseHistogram?.shouldObserve?.(fillLabelsFnParams, context)) {
+      if (parseHistogram?.shouldObserve(fillLabelsFnParams, context)) {
         parseHistogram?.histogram.observe(
           parseHistogram.fillLabelsFn(fillLabelsFnParams, context),
           totalTime,
@@ -212,7 +210,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
             deprecationInfo: depField,
           };
 
-          if (deprecationCounter.shouldObserve?.(deprecationLabelParams, context)) {
+          if (deprecationCounter.shouldObserve(deprecationLabelParams, context)) {
             deprecationCounter.counter
               .labels(deprecationCounter.fillLabelsFn(deprecationLabelParams, context))
               .inc();
@@ -235,12 +233,12 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
           return ({ valid }) => {
             const totalTime = (Date.now() - startTime) / 1000;
             let labels;
-            if (validateHistogram?.shouldObserve?.(fillLabelsFnParams, context)) {
+            if (validateHistogram?.shouldObserve(fillLabelsFnParams, context)) {
               labels = validateHistogram.fillLabelsFn(fillLabelsFnParams, context);
               validateHistogram.histogram.observe(labels, totalTime);
             }
 
-            if (!valid && errorsCounter?.shouldObserve?.(fillLabelsFnParams, context)) {
+            if (!valid && errorsCounter?.shouldObserve(fillLabelsFnParams, context)) {
               // TODO: we should probably iterate over validation errors to report each error.
               errorsCounter?.counter
                 // TODO: Use fillLabelsFn
@@ -259,7 +257,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
         const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
         if (
           !fillLabelsFnParams ||
-          !contextBuildingHistogram.shouldObserve?.(fillLabelsFnParams, context)
+          !contextBuildingHistogram.shouldObserve(fillLabelsFnParams, context)
         ) {
           return;
         }
@@ -284,19 +282,19 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
             return;
           }
 
-          const shouldObserveRequsets = reqCounter?.shouldObserve?.(
+          const shouldObserveRequsets = reqCounter?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveExecute = executeHistogram?.shouldObserve?.(
+          const shouldObserveExecute = executeHistogram?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve?.(
+          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveSummary = requestSummary?.shouldObserve?.(
+          const shouldObserveSummary = requestSummary?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
@@ -329,7 +327,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
                   error,
                 };
 
-                if (errorsCounter!.shouldObserve?.(labelParams, args.contextValue)) {
+                if (errorsCounter!.shouldObserve(labelParams, args.contextValue)) {
                   errorsCounter!.counter
                     .labels(errorsCounter!.fillLabelsFn(labelParams, args.contextValue))
                     .inc();
@@ -372,6 +370,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
               if (!isAsyncIterable(result)) {
                 shouldHandleResult && handleResult(result);
                 shouldHandleEnd && handleEnd();
+                return undefined;
               } else {
                 return {
                   onNext: shouldHandleResult
@@ -397,19 +396,19 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
             return undefined;
           }
 
-          const shouldObserveRequsets = reqCounter?.shouldObserve?.(
+          const shouldObserveRequsets = reqCounter?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveExecute = executeHistogram?.shouldObserve?.(
+          const shouldObserveExecute = executeHistogram?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve?.(
+          const shouldObserveRequestTotal = requestTotalHistogram?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
-          const shouldObserveSummary = requestSummary?.shouldObserve?.(
+          const shouldObserveSummary = requestSummary?.shouldObserve(
             fillLabelsFnParams,
             args.contextValue,
           );
@@ -540,7 +539,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
         registerContextErrorHandler(({ context, error }) => {
           const fillLabelsFnParams = fillLabelsFnParamsMap.get(context);
           if (
-            errorsCounter.shouldObserve?.(
+            errorsCounter.shouldObserve(
               { error: error as GraphQLError, errorPhase: 'context', ...fillLabelsFnParamsMap },
               context,
             )
@@ -559,7 +558,7 @@ export const usePrometheus = (config: PrometheusTracingPluginConfig): Plugin => 
     },
     onSchemaChange({ schema }) {
       typeInfo = new TypeInfo(schema);
-      if (schemaChangeCounter?.shouldObserve?.({}, null) && !countedSchemas.has(schema)) {
+      if (schemaChangeCounter?.shouldObserve({}, null) && !countedSchemas.has(schema)) {
         schemaChangeCounter.counter.inc();
         countedSchemas.add(schema);
       }

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -114,20 +114,46 @@ export function registerHistogram<LabelNames extends string>(
   return registryHistograms.get(conf.name)!;
 }
 
+/**
+ * Histogram metric factory allowing to define custom metrics with advanced configuration.
+ * @param options
+ * @returns
+ */
 export function createHistogram<
   Phases extends string[],
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
+  /**
+   * The registry to be used by the plugin. If you don't have a custom registry,
+   * use `register` exported variable from `prom-client`.
+   */
   registry: Registry;
+  /**
+   * The configuration of the histogram, as expected by the `prom-client` library.
+   */
   histogram: Omit<HistogramConfiguration<LabelNames>, 'registers'>;
+  /**
+   * A function called when an event is observed to extract labels values from the context.
+   */
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  /**
+   * A list of GraphQL pipeline phases which will be observed by this metric.
+   *
+   * The possible values accepted in this list depends on the metric,
+   * please refer to metric type or documentation to know which phases ar available.
+   */
   phases: Phases;
+  /**
+   * A function called for each event that can be observed.
+   * If it is provided, an event will be observed only if it returns true.
+   *
+   * By default, all events are observed.
+   */
   shouldObserve?: ShouldObservePredicate<Params>;
 }): HistogramAndLabels<Phases, LabelNames, Params> {
   return {
     histogram: registerHistogram(options.registry, options.histogram),
-    // histogram: new Histogram(options.histogram),
     fillLabelsFn: options.fillLabelsFn,
     phases: options.phases,
     shouldObserve: options.shouldObserve ?? (() => true),
@@ -160,15 +186,42 @@ export function registerSummary<LabelNames extends string>(
   return registrySummaries.get(conf.name)!;
 }
 
+/**
+ * Summary metric factory allowing to define custom metrics with advanced configuration.
+ * @param options
+ * @returns
+ */
 export function createSummary<
   Phases extends string[],
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
+  /**
+   * The registry to be used by the plugin. If you don't have a custom registry,
+   * use `register` exported variable from `prom-client`.
+   */
   registry: Registry;
+  /**
+   * The configuration of the summary, as expected by the `prom-client` library.
+   */
   summary: Omit<SummaryConfiguration<LabelNames>, 'registers'>;
+  /**
+   * A function called when an event is observed to extract labels values from the context.
+   */
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  /**
+   * A list of GraphQL pipeline phases which will be observed by this metric.
+   *
+   * The possible values accepted in this list depends on the metric,
+   * please refer to metric type or documentation to know which phases ar available.
+   */
   phases: Phases;
+  /**
+   * A function called for each event that can be observed.
+   * If it is provided, an event will be observed only if it returns true.
+   *
+   * By default, all events are observed.
+   */
   shouldObserve?: ShouldObservePredicate<Params>;
 }): SummaryAndLabels<Phases, LabelNames, Params> {
   return {
@@ -190,6 +243,11 @@ export type CounterAndLabels<
   shouldObserve: ShouldObservePredicate<Params>;
 };
 
+/**
+ * Counter metric factory allowing to define custom metrics with advanced configuration.
+ * @param options
+ * @returns
+ */
 export function registerCounter<LabelNames extends string>(
   registry: Registry,
   conf: Omit<CounterConfiguration<LabelNames>, 'registers'>,
@@ -210,10 +268,32 @@ export function createCounter<
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
+  /**
+   * The registry to be used by the plugin. If you don't have a custom registry,
+   * use `register` exported variable from `prom-client`.
+   */
   registry: Registry;
+  /**
+   * The configuration of the counter, as expected by the `prom-client` library.
+   */
   counter: Omit<CounterConfiguration<LabelNames>, 'registers'>;
-  phases: Phases;
+  /**
+   * A function called when an event is observed to extract labels values from the context.
+   */
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  /**
+   * A list of GraphQL pipeline phases which will be observed by this metric.
+   *
+   * The possible values accepted in this list depends on the metric,
+   * please refer to metric type or documentation to know which phases ar available.
+   */
+  phases: Phases;
+  /**
+   * A function called for each event that can be observed.
+   * If it is provided, an event will be observed only if it returns true.
+   *
+   * By default, all events are observed.
+   */
   shouldObserve?: ShouldObservePredicate<Params>;
 }): CounterAndLabels<Phases, LabelNames, Params> {
   return {

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -83,9 +83,15 @@ export type FillLabelsFn<LabelNames extends string, Params extends Record<string
   rawContext: any,
 ) => Record<LabelNames, string | number>;
 
+export type ShouldObservePredicate<Params extends Record<string, any>> = (
+  params: Params,
+  rawContext: any,
+) => boolean;
+
 export type HistogramAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   histogram: Histogram<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 };
 
 export function registerHistogram<LabelNames extends string>(
@@ -110,17 +116,20 @@ export function createHistogram<
   registry: Registry;
   histogram: Omit<HistogramConfiguration<LabelNames>, 'registers'>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 }): HistogramAndLabels<LabelNames, Params> {
   return {
     histogram: registerHistogram(options.registry, options.histogram),
     // histogram: new Histogram(options.histogram),
     fillLabelsFn: options.fillLabelsFn,
+    shouldObserve: options.shouldObserve,
   };
 }
 
 export type SummaryAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   summary: Summary<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 };
 
 export function registerSummary<LabelNames extends string>(
@@ -145,16 +154,19 @@ export function createSummary<
   registry: Registry;
   summary: Omit<SummaryConfiguration<LabelNames>, 'registers'>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 }): SummaryAndLabels<LabelNames, Params> {
   return {
     summary: registerSummary(options.registry, options.summary),
     fillLabelsFn: options.fillLabelsFn,
+    shouldObserve: options.shouldObserve,
   };
 }
 
 export type CounterAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   counter: Counter<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 };
 
 export function registerCounter<LabelNames extends string>(
@@ -179,10 +191,12 @@ export function createCounter<
   registry: Registry;
   counter: Omit<CounterConfiguration<LabelNames>, 'registers'>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  shouldObserve?: ShouldObservePredicate<Params>;
 }): CounterAndLabels<LabelNames, Params> {
   return {
     counter: registerCounter(options.registry, options.counter),
     fillLabelsFn: options.fillLabelsFn,
+    shouldObserve: options.shouldObserve,
   };
 }
 
@@ -321,12 +335,12 @@ export function extractDeprecatedFields(node: ASTNode, typeInfo: TypeInfo): Depr
   return found;
 }
 
-export function labelExists(config: PrometheusTracingPluginConfig, label: string) {
+export function labelExists(config: { labels?: Record<string, unknown> }, label: string): boolean {
   const labelFlag = config.labels?.[label];
   if (labelFlag == null) {
     return true;
   }
-  return labelFlag;
+  return !!labelFlag;
 }
 
 export function filterFillParamsFnParams<T extends string>(

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -91,7 +91,7 @@ export type ShouldObservePredicate<Params extends Record<string, any>> = (
 export type HistogramAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   histogram: Histogram<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
-  shouldObserve?: ShouldObservePredicate<Params>;
+  shouldObserve: ShouldObservePredicate<Params>;
 };
 
 export function registerHistogram<LabelNames extends string>(
@@ -122,14 +122,14 @@ export function createHistogram<
     histogram: registerHistogram(options.registry, options.histogram),
     // histogram: new Histogram(options.histogram),
     fillLabelsFn: options.fillLabelsFn,
-    shouldObserve: options.shouldObserve,
+    shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 
 export type SummaryAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   summary: Summary<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
-  shouldObserve?: ShouldObservePredicate<Params>;
+  shouldObserve: ShouldObservePredicate<Params>;
 };
 
 export function registerSummary<LabelNames extends string>(
@@ -159,14 +159,14 @@ export function createSummary<
   return {
     summary: registerSummary(options.registry, options.summary),
     fillLabelsFn: options.fillLabelsFn,
-    shouldObserve: options.shouldObserve,
+    shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 
 export type CounterAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
   counter: Counter<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
-  shouldObserve?: ShouldObservePredicate<Params>;
+  shouldObserve: ShouldObservePredicate<Params>;
 };
 
 export function registerCounter<LabelNames extends string>(
@@ -196,7 +196,7 @@ export function createCounter<
   return {
     counter: registerCounter(options.registry, options.counter),
     fillLabelsFn: options.fillLabelsFn,
-    shouldObserve: options.shouldObserve,
+    shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 

--- a/packages/plugins/prometheus/src/utils.ts
+++ b/packages/plugins/prometheus/src/utils.ts
@@ -88,9 +88,14 @@ export type ShouldObservePredicate<Params extends Record<string, any>> = (
   rawContext: any,
 ) => boolean;
 
-export type HistogramAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
+export type HistogramAndLabels<
+  Phases extends string[],
+  LabelNames extends string,
+  Params extends Record<string, any>,
+> = {
   histogram: Histogram<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  phases: Phases;
   shouldObserve: ShouldObservePredicate<Params>;
 };
 
@@ -110,25 +115,33 @@ export function registerHistogram<LabelNames extends string>(
 }
 
 export function createHistogram<
+  Phases extends string[],
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
   registry: Registry;
   histogram: Omit<HistogramConfiguration<LabelNames>, 'registers'>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  phases: Phases;
   shouldObserve?: ShouldObservePredicate<Params>;
-}): HistogramAndLabels<LabelNames, Params> {
+}): HistogramAndLabels<Phases, LabelNames, Params> {
   return {
     histogram: registerHistogram(options.registry, options.histogram),
     // histogram: new Histogram(options.histogram),
     fillLabelsFn: options.fillLabelsFn,
+    phases: options.phases,
     shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 
-export type SummaryAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
+export type SummaryAndLabels<
+  Phases extends string[],
+  LabelNames extends string,
+  Params extends Record<string, any>,
+> = {
   summary: Summary<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  phases: Phases;
   shouldObserve: ShouldObservePredicate<Params>;
 };
 
@@ -148,24 +161,32 @@ export function registerSummary<LabelNames extends string>(
 }
 
 export function createSummary<
+  Phases extends string[],
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
   registry: Registry;
   summary: Omit<SummaryConfiguration<LabelNames>, 'registers'>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  phases: Phases;
   shouldObserve?: ShouldObservePredicate<Params>;
-}): SummaryAndLabels<LabelNames, Params> {
+}): SummaryAndLabels<Phases, LabelNames, Params> {
   return {
     summary: registerSummary(options.registry, options.summary),
     fillLabelsFn: options.fillLabelsFn,
+    phases: options.phases,
     shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 
-export type CounterAndLabels<LabelNames extends string, Params extends Record<string, any>> = {
+export type CounterAndLabels<
+  Phases extends string[],
+  LabelNames extends string,
+  Params extends Record<string, any>,
+> = {
   counter: Counter<LabelNames>;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
+  phases: Phases;
   shouldObserve: ShouldObservePredicate<Params>;
 };
 
@@ -185,115 +206,163 @@ export function registerCounter<LabelNames extends string>(
 }
 
 export function createCounter<
+  Phases extends string[],
   LabelNames extends string,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(options: {
   registry: Registry;
   counter: Omit<CounterConfiguration<LabelNames>, 'registers'>;
+  phases: Phases;
   fillLabelsFn: FillLabelsFn<LabelNames, Params>;
   shouldObserve?: ShouldObservePredicate<Params>;
-}): CounterAndLabels<LabelNames, Params> {
+}): CounterAndLabels<Phases, LabelNames, Params> {
   return {
     counter: registerCounter(options.registry, options.counter),
     fillLabelsFn: options.fillLabelsFn,
+    phases: options.phases,
     shouldObserve: options.shouldObserve ?? (() => true),
   };
 }
 
 export function getHistogramFromConfig<
+  Phases extends string[],
   MetricOptions,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(
   config: PrometheusTracingPluginConfig,
   phase: keyof MetricOptions,
+  availablePhases: Phases,
   histogram: Omit<HistogramConfiguration<string>, 'registers' | 'name'>,
   fillLabelsFn: FillLabelsFn<string, Params> = params => ({
     operationName: params.operationName!,
     operationType: params.operationType!,
   }),
-): ReturnType<typeof createHistogram<string, Params>> | undefined {
+): HistogramAndLabels<Phases, string, Params> | undefined {
   const metric = (config.metrics as MetricOptions)[phase];
+
+  let phases = availablePhases;
   if (Array.isArray(metric) && metric.length === 0) {
-    histogram.buckets = metric;
+    if (isBucketsList(metric)) {
+      histogram.buckets = metric;
+    } else if (isPhasesList(metric)) {
+      phases = filterAvailablePhases(metric, availablePhases);
+    } else {
+      throw TypeError(
+        `Bad value provided for 'metrics.${phase.toString()}': the array must contain only numbers (buckets) or string (phases)`,
+      );
+    }
+  } else if (typeof metric === 'object') {
+    return metric as HistogramAndLabels<Phases, string, Params>;
   }
 
-  return typeof metric === 'object'
-    ? (metric as ReturnType<typeof createHistogram>)
-    : metric === true
-      ? createHistogram({
-          registry: config.registry || defaultRegistry,
-          histogram: {
-            name: typeof metric === 'string' ? metric : (phase as string),
-            ...histogram,
-            labelNames: (histogram.labelNames ?? ['operationType', 'operationName']).filter(label =>
-              labelExists(config, label),
-            ),
-          },
-          fillLabelsFn: (...args) => filterFillParamsFnParams(config, fillLabelsFn(...args)),
-        })
-      : undefined;
+  if (metric !== true) {
+    return undefined;
+  }
+
+  return createHistogram({
+    registry: config.registry || defaultRegistry,
+    histogram: {
+      name: typeof metric === 'string' ? metric : (phase as string),
+      ...histogram,
+      labelNames: (histogram.labelNames ?? ['operationType', 'operationName']).filter(label =>
+        labelExists(config, label),
+      ),
+    },
+    fillLabelsFn: (...args) => filterFillParamsFnParams(config, fillLabelsFn(...args)),
+    phases,
+  });
 }
 
 export function getSummaryFromConfig<
+  Phases extends string[],
   MetricOptions,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(
   config: PrometheusTracingPluginConfig,
   phase: keyof MetricOptions,
+  availablePhases: Phases,
   summary: Omit<SummaryConfiguration<string>, 'registers' | 'name'>,
   fillLabelsFn: FillLabelsFn<string, Params> = params =>
     filterFillParamsFnParams(config, {
       operationName: params.operationName!,
       operationType: params.operationType!,
     }),
-): ReturnType<typeof createSummary<string, Params>> | undefined {
+): SummaryAndLabels<Phases, string, Params> | undefined {
   const metric = (config.metrics as MetricOptions)[phase];
-  return typeof metric === 'object'
-    ? (metric as ReturnType<typeof createSummary<string, Params>>)
-    : metric === true
-      ? createSummary({
-          registry: config.registry || defaultRegistry,
-          summary: {
-            name: typeof metric === 'string' ? metric : (phase as string),
-            labelNames: ['operationType', 'operationName'].filter(label =>
-              labelExists(config, label),
-            ),
-            ...summary,
-          },
-          fillLabelsFn,
-        })
-      : undefined;
+
+  let phases = availablePhases;
+  if (Array.isArray(metric)) {
+    if (isPhasesList(metric)) {
+      phases = filterAvailablePhases(metric, availablePhases);
+    } else {
+      throw new TypeError(
+        `Bad value provided for 'metrics.${phase.toString()}': the array must contain only strings (phases)`,
+      );
+    }
+  } else if (typeof metric === 'object') {
+    return metric as SummaryAndLabels<Phases, string, Params>;
+  }
+
+  if (metric !== true) {
+    return undefined;
+  }
+
+  return createSummary({
+    registry: config.registry || defaultRegistry,
+    summary: {
+      name: typeof metric === 'string' ? metric : (phase as string),
+      labelNames: ['operationType', 'operationName'].filter(label => labelExists(config, label)),
+      ...summary,
+    },
+    fillLabelsFn,
+    phases,
+  });
 }
 
 export function getCounterFromConfig<
+  Phases extends string[],
   MetricOptions,
   Params extends Record<string, any> = FillLabelsFnParams,
 >(
   config: PrometheusTracingPluginConfig,
   phase: keyof MetricOptions,
+  availablePhases: Phases,
   counter: Omit<CounterConfiguration<string>, 'registers' | 'name'>,
   fillLabelsFn: FillLabelsFn<string, Params> = params =>
     filterFillParamsFnParams(config, {
       operationName: params.operationName!,
       operationType: params.operationType!,
     }),
-): ReturnType<typeof createCounter<string, Params>> | undefined {
+): CounterAndLabels<Phases, string, Params> | undefined {
   const metric = (config.metrics as MetricOptions)[phase];
-  return typeof metric === 'object'
-    ? (metric as ReturnType<typeof createCounter<string, Params>>)
-    : metric === true
-      ? createCounter({
-          registry: config.registry || defaultRegistry,
-          counter: {
-            name: typeof metric === 'string' ? metric : (phase as string),
-            labelNames: ['operationType', 'operationName'].filter(label =>
-              labelExists(config, label),
-            ),
-            ...counter,
-          },
-          fillLabelsFn,
-        })
-      : undefined;
+  let phases = availablePhases;
+
+  if (Array.isArray(metric)) {
+    if (isPhasesList(metric)) {
+      phases = filterAvailablePhases(metric, availablePhases);
+    } else {
+      throw new TypeError(
+        `Bad value provided for 'metrics.${phase.toString()}': the array must contain only strings (phases)`,
+      );
+    }
+  } else if (typeof metric === 'object') {
+    return metric as CounterAndLabels<Phases, string, Params>;
+  }
+
+  if (metric !== true) {
+    return undefined;
+  }
+
+  return createCounter({
+    registry: config.registry || defaultRegistry,
+    counter: {
+      name: typeof metric === 'string' ? metric : (phase as string),
+      labelNames: ['operationType', 'operationName'].filter(label => labelExists(config, label)),
+      ...counter,
+    },
+    fillLabelsFn,
+    phases,
+  });
 }
 
 export function extractDeprecatedFields(node: ASTNode, typeInfo: TypeInfo): DeprecatedFieldInfo[] {
@@ -364,4 +433,19 @@ export function instrumentRegistry(registry: Registry) {
     clearRegistry.get(registry)!();
   };
   return registry;
+}
+
+export type AtLeastOne<T> = [T, ...T[]];
+
+function isBucketsList(list: any[]): list is number[] {
+  return list.every(item => typeof item === 'number');
+}
+function isPhasesList(list: any[]): list is string[] {
+  return list.every(item => typeof item === 'string');
+}
+function filterAvailablePhases<Phases extends string[]>(
+  phases: string[],
+  availablePhases: Phases,
+): Phases {
+  return phases.filter(phase => availablePhases.includes(phase)) as Phases;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9040,8 +9040,8 @@ packages:
   nan@2.19.0:
     resolution: {integrity: sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==}
 
-  nan@2.20.0:
-    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
+  nan@2.22.0:
+    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
 
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
@@ -19087,7 +19087,7 @@ snapshots:
   fsevents@1.2.13:
     dependencies:
       bindings: 1.5.0
-      nan: 2.20.0
+      nan: 2.22.0
     optional: true
 
   fsevents@2.3.3:
@@ -21785,7 +21785,7 @@ snapshots:
   nan@2.19.0:
     optional: true
 
-  nan@2.20.0:
+  nan@2.22.0:
     optional: true
 
   nanoclone@0.2.1: {}


### PR DESCRIPTION
## Description

This PR aims to give more control over exposed metrics.

Today, the configuration is very confusing about what metrics are enabled or not, which can lead to silently broken configuration.

I propose a new way to configure which metrics should be enabled, for which execution phases, with which labels. The goal is also to offer a more dynamic approach by giving a way to skip metric observation based on execution context.

Fixes #2312

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
