### PR TITLE
feat: Make it possible to get the active span in the GraphQL resolver

### DIFF
--- a/.changeset/clever-rice-perform.md
+++ b/.changeset/clever-rice-perform.md
@@ -1,0 +1,19 @@
+---
+'@envelop/sentry': major
+---
+
+Make it possible to get the active span in the GraphQL resolver
+
+**Breaking Change:** With this change, this plugin now wraps the execute function.
+This plugin should be placed last so that the execute function is not overwritten by another plugin.
+
+```ts
+const yoga = createYoga({
+  plugins: [
+    ...otherPlugins,
+    useSentry({
+      // ...
+    })
+  ]
+})
+```

--- a/benchmark/app.js
+++ b/benchmark/app.js
@@ -143,7 +143,7 @@ app.route({
   },
 });
 
-app.listen(3000, (error, address) => {
+app.listen({ port: 3000 }, (error, address) => {
   if (error) {
     console.error(error);
     process.exit(1);

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -108,7 +108,7 @@ export const useSentry = <PluginContext extends Record<string, any> = {}>(
   }
 
   return {
-    onExecute({ args }) {
+    onExecute({ args, executeFn, setExecuteFn }) {
       if (skipOperation(args)) {
         return;
       }
@@ -151,6 +151,9 @@ export const useSentry = <PluginContext extends Record<string, any> = {}>(
           if (options.configureScope) {
             options.configureScope(args, Sentry.getCurrentScope());
           }
+
+          // Give access to the span during resolvers execution
+          setExecuteFn(args => Sentry.withActiveSpan(rootSpan, () => executeFn(args)));
 
           return {
             onExecuteDone(payload) {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes #2322

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added test to run getActiveSpan within a GraphQL resolver.

**Test Environment**:

- OS: MacOS 14.6.1
- NodeJS: 22.11.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules