### PR TITLE
fix: [plugins/sentry] update to Sentry v8

### DIFF
--- a/.changeset/wet-spoons-remember.md
+++ b/.changeset/wet-spoons-remember.md
@@ -1,0 +1,9 @@
+---
+'@envelop/sentry': major
+---
+
+Fix: Update code to better feat the new Sentry v8 API
+
+**Breaking Change:** 
+ - `startTransaction` option has been removed.
+ - `forceTransaction` option has been added, disabled by default.

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -58,8 +58,11 @@ const getEnveloped = envelop({
 
 ### Configuration
 
-- `startTransaction` (default: `true`) - Starts a new transaction for every GraphQL Operation. When
-  disabled, an already existing Transaction will be used.
+- `forceTransaction` (default: `true`) - Force the creation of a new transaction for every GraphQL
+  Operation. By default, Sentry mange the creation of transactions automatically. By enabling this
+  option, you can ensure that the GraphQL execution pipeline is always wrapped in its own
+  transaction.
+
 - `renameTransaction` (default: `false`) - Renames Transaction.
 - `includeRawResult` (default: `false`) - Adds result of each resolver and operation to Span's data
   (available under "result")

--- a/packages/plugins/sentry/__tests__/sentry.spec.ts
+++ b/packages/plugins/sentry/__tests__/sentry.spec.ts
@@ -43,8 +43,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 100));
+    await Sentry.flush(100);
 
     const reports = sentryTestkit.reports();
     expect(reports).toHaveLength(1);
@@ -89,8 +88,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush(100);
 
     expect(sentryTestkit.reports()).toHaveLength(0);
   });
@@ -130,10 +128,10 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush(100);
 
     const reports = sentryTestkit.reports();
+    console.log(sentryTestkit.transactions());
     expect(reports).toHaveLength(1);
     expect(reports[0].error).toMatchObject({
       message: 'Unexpected Error, ok?',
@@ -176,8 +174,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush(100);
 
     expect(sentryTestkit.reports()).toHaveLength(0);
   });
@@ -246,8 +243,7 @@ describe('sentry', () => {
       }
     `);
 
-    // run sentry flush
-    await new Promise(res => setTimeout(res, 10));
+    await Sentry.flush(100);
 
     const reports = sentryTestkit.reports();
     expect(reports).toHaveLength(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5840,8 +5840,8 @@ packages:
     resolution: {integrity: sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==}
     engines: {node: '>=8'}
 
-  cipher-base@1.0.5:
-    resolution: {integrity: sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==}
+  cipher-base@1.0.6:
+    resolution: {integrity: sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==}
     engines: {node: '>= 0.10'}
 
   cjs-module-lexer@1.2.3:
@@ -7542,9 +7542,9 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
 
-  hash-base@3.0.4:
-    resolution: {integrity: sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==}
-    engines: {node: '>=4'}
+  hash-base@3.0.5:
+    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
+    engines: {node: '>= 0.10'}
 
   hash-it@6.0.0:
     resolution: {integrity: sha512-KHzmSFx1KwyMPw0kXeeUD752q/Kfbzhy6dAZrjXV9kAIXGqzGvv8vhkUqj+2MGZldTo0IBpw6v7iWE7uxsvH0w==}
@@ -17118,7 +17118,7 @@ snapshots:
   browserify-aes@1.2.0:
     dependencies:
       buffer-xor: 1.0.3
-      cipher-base: 1.0.5
+      cipher-base: 1.0.6
       create-hash: 1.2.0
       evp_bytestokey: 1.0.3
       inherits: 2.0.4
@@ -17132,7 +17132,7 @@ snapshots:
 
   browserify-des@1.0.2:
     dependencies:
-      cipher-base: 1.0.5
+      cipher-base: 1.0.6
       des.js: 1.1.0
       inherits: 2.0.4
       safe-buffer: 5.2.1
@@ -17150,7 +17150,7 @@ snapshots:
       create-hash: 1.2.0
       create-hmac: 1.1.7
       elliptic: 6.6.1
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       parse-asn1: 5.1.7
       readable-stream: 2.3.8
@@ -17412,7 +17412,7 @@ snapshots:
 
   ci-info@4.0.0: {}
 
-  cipher-base@1.0.5:
+  cipher-base@1.0.6:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
@@ -17634,7 +17634,7 @@ snapshots:
 
   create-hash@1.2.0:
     dependencies:
-      cipher-base: 1.0.5
+      cipher-base: 1.0.6
       inherits: 2.0.4
       md5.js: 1.3.5
       ripemd160: 2.0.2
@@ -17642,7 +17642,7 @@ snapshots:
 
   create-hmac@1.1.7:
     dependencies:
-      cipher-base: 1.0.5
+      cipher-base: 1.0.6
       create-hash: 1.2.0
       inherits: 2.0.4
       ripemd160: 2.0.2
@@ -17690,7 +17690,7 @@ snapshots:
       create-hash: 1.2.0
       create-hmac: 1.1.7
       diffie-hellman: 5.0.3
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       pbkdf2: 3.1.2
       public-encrypt: 4.0.3
@@ -19557,7 +19557,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hash-base@3.0.4:
+  hash-base@3.0.5:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
@@ -20977,7 +20977,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
@@ -22335,7 +22335,7 @@ snapshots:
       asn1.js: 4.10.1
       browserify-aes: 1.2.0
       evp_bytestokey: 1.0.3
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       pbkdf2: 3.1.2
       safe-buffer: 5.2.1
 
@@ -23313,7 +23313,7 @@ snapshots:
 
   ripemd160@2.0.2:
     dependencies:
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
 
   robust-predicates@3.0.1: {}


### PR DESCRIPTION
## Description

The Sentry plugin, while it denpends on Sentry v8, never got updated to use the new APIs introduced by this major version.

For some reason, the testkit still works with the old API, but it doesn't actually work in real world usage.

Fixes #2193 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
