### PR TITLE
fix(generic-auth): handle default values in variable defs correctly

### DIFF
--- a/.changeset/@envelop_generic-auth-2347-dependencies.md
+++ b/.changeset/@envelop_generic-auth-2347-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@envelop/generic-auth": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-tools/executor@^1.3.6` ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.3.6) (to `dependencies`)

--- a/.changeset/proud-tomatoes-film.md
+++ b/.changeset/proud-tomatoes-film.md
@@ -1,0 +1,32 @@
+---
+'@envelop/generic-auth': patch
+---
+
+Handle operations with \`@include\` and \`@skip\` correctly when they have default values in the
+operation definition
+
+```ts
+{
+    query: /* GraphQL */ `
+      query MyQuery($include: Boolean = true) {
+        field @include(if: $include)
+      }
+    `,
+    variables: {}
+}
+```
+
+should be considered same as
+
+```ts
+{
+    query: /* GraphQL */ `
+      query MyQuery($include: Boolean!) {
+        field @include(if: $include)
+      }
+    `,
+    variables: {
+        include: true
+    }
+}
+```

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,25 +7,7 @@ on:
   pull_request:
 
 jobs:
-  prettier:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup env
-        uses: the-guild-org/shared-config/setup@v1
-      - name: Lint Prettier
-        run: pnpm run lint:prettier
-
-  lint:
-    name: Lint
-    uses: the-guild-org/shared-config/.github/workflows/lint.yml@v1
-    with:
-      script: pnpm run ci:lint && pnpm run lint
-    secrets:
-      githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-  build:
+  check:
     name: build / graphql v${{matrix.graphql_version}}
     runs-on: ubuntu-latest
     strategy:
@@ -40,37 +22,18 @@ jobs:
         run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
       - name: Install Dependencies using pnpm
         run: pnpm install --no-frozen-lockfile && git checkout pnpm-lock.yaml
+      - name: Lint Prettier
+        run: pnpm run lint:prettier
+      - name: Lint
+        run: pnpm run ci:lint && pnpm run lint
       - name: Build
         run: pnpm run ts:check
+      - name: Test ESM & CJS exports integrity
+        run: pnpm bob check
 
   unit:
-    name: Unit Test
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest] # remove windows to speed up the tests
-    steps:
-      - name: Checkout Master
-        uses: actions/checkout@v4
-      - name: Setup env
-        uses: the-guild-org/shared-config/setup@v1
-      - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile && git checkout pnpm-lock.yaml
-      - name: Cache Jest
-        uses: actions/cache@v4
-        with:
-          path: .cache/jest
-          key:
-            ${{ runner.os }}-${{matrix.node-version}}-${{matrix.graphql_version}}-jest-${{
-            hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('patches/*.patch') }}
-      - name: Test
-        run: pnpm run test
-        env:
-          CI: true
-
-  core:
     name:
-      Core Test / ${{matrix.os}} / node v${{matrix.node-version}} / graphql
+      Unit Test / ${{matrix.os}} / node v${{matrix.node-version}} / graphql
       v${{matrix.graphql_version}}
     runs-on: ${{matrix.os}}
     strategy:
@@ -94,8 +57,8 @@ jobs:
           key:
             ${{ runner.os }}-${{matrix.node-version}}-${{matrix.graphql_version}}-jest-${{
             hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('patches/*.patch') }}
-      - name: Test Core
-        run: pnpm run test:core --ci
+      - name: Test
+        run: pnpm run test --ci
         env:
           CI: true
 
@@ -109,5 +72,3 @@ jobs:
         uses: the-guild-org/shared-config/setup@v1
       - name: Build Packages
         run: pnpm run build
-      - name: Test ESM & CJS exports integrity
-        run: pnpm bob check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    name: build / graphql v${{matrix.graphql_version}}
+    name: check / graphql v${{matrix.graphql_version}}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
       - name: Install Dependencies using pnpm
         run: pnpm install --no-frozen-lockfile && git checkout pnpm-lock.yaml
-      - name: Lint Prettier
+      - name: Format
         run: pnpm run lint:prettier
       - name: Lint
         run: pnpm run ci:lint && pnpm run lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,14 +61,3 @@ jobs:
         run: pnpm run test --ci
         env:
           CI: true
-
-  test_esm:
-    name: esm
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup env
-        uses: the-guild-org/shared-config/setup@v1
-      - name: Build Packages
-        run: pnpm run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
-      - name: Use GraphQL v${{matrix.graphql_version}}
-        run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
-      - name: Install Dependencies using pnpm
-        run: pnpm install --no-frozen-lockfile && git checkout pnpm-lock.yaml
       - name: Format
         run: pnpm run lint:prettier
       - name: Lint
         run: pnpm run ci:lint && pnpm run lint
+      - name: Use GraphQL v${{matrix.graphql_version}}
+        run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
+      - name: Install Dependencies using pnpm
+        run: pnpm install --no-frozen-lockfile && git checkout pnpm-lock.yaml
       - name: Build
         run: pnpm run ts:check
       - name: Test ESM & CJS exports integrity

--- a/benchmark/app.js
+++ b/benchmark/app.js
@@ -2,7 +2,6 @@
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const { envelop, useSchema, useEngine } = require('@envelop/core');
 const { useParserCache } = require('@envelop/parser-cache');
-const { usePrometheus } = require('@envelop/prometheus');
 const { useGraphQlJit } = require('@envelop/graphql-jit');
 const { useValidationCache } = require('@envelop/validation-cache');
 const { fastify } = require('fastify');
@@ -143,7 +142,7 @@ app.route({
   },
 });
 
-app.listen(3000, (error, address) => {
+app.listen({ port: 3000 }, (error, address) => {
   if (error) {
     console.error(error);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "release": "pnpm build && changeset publish",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "jest --coverage",
-    "test:core": "jest ./packages/core --coverage",
     "ts:check": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/plugins/generic-auth/package.json
+++ b/packages/plugins/generic-auth/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@envelop/extended-validation": "^4.1.0",
+    "@graphql-tools/executor": "^1.3.6",
     "@graphql-tools/utils": "^10.5.1",
     "tslib": "^2.5.0"
   },

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -4,7 +4,6 @@ import {
   FieldNode,
   getNamedType,
   getOperationAST,
-  getVariableValues,
   GraphQLError,
   GraphQLField,
   GraphQLInterfaceType,
@@ -20,6 +19,7 @@ import {
 } from 'graphql';
 import { DefaultContext, Maybe, Plugin, PromiseOrValue } from '@envelop/core';
 import { useExtendedValidation } from '@envelop/extended-validation';
+import { getVariableValues } from '@graphql-tools/executor';
 import {
   createGraphQLError,
   getDefinedRootType,

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -4,6 +4,7 @@ import {
   FieldNode,
   getNamedType,
   getOperationAST,
+  getVariableValues,
   GraphQLError,
   GraphQLField,
   GraphQLInterfaceType,
@@ -318,6 +319,22 @@ export const useGenericAuth = <
               function AuthorizationExtendedValidationRule(context, args) {
                 const user = (args.contextValue as any)[contextFieldName];
 
+                const schema = context.getSchema();
+                const operationAST = getOperationAST(args.document, args.operationName);
+                const variableDefinitions = operationAST?.variableDefinitions;
+                let variableValues: typeof args.variableValues | undefined;
+                if (variableDefinitions?.length) {
+                  const { coerced } = getVariableValues(
+                    schema,
+                    variableDefinitions,
+                    args.variableValues || {},
+                  );
+                  variableValues = coerced;
+                } else {
+                  variableValues = args.variableValues;
+                }
+                const operationType = operationAST?.operation ?? ('query' as OperationTypeNode);
+
                 const handleField = (
                   {
                     node: fieldNode,
@@ -337,7 +354,6 @@ export const useGenericAuth = <
                     return;
                   }
 
-                  const schema = context.getSchema();
                   // @ts-expect-error - Fix this
                   const typeDirectives = parentType && getDirectiveExtensions(parentType, schema);
                   const typeAuthArgs = typeDirectives[authDirectiveName]?.[0];
@@ -354,8 +370,6 @@ export const useGenericAuth = <
                   const resolvePath: (string | number)[] = [];
 
                   let curr: any = args.document;
-                  const operationAST = getOperationAST(args.document, args.operationName);
-                  const operationType = operationAST?.operation ?? ('query' as OperationTypeNode);
                   let currType: GraphQLOutputType | undefined | null = getDefinedRootType(
                     schema,
                     operationType,
@@ -408,7 +422,7 @@ export const useGenericAuth = <
 
                 return {
                   Field(node, key, parent, path, ancestors) {
-                    if (!shouldIncludeNode(args.variableValues, node)) {
+                    if (variableValues && !shouldIncludeNode(variableValues, node)) {
                       return;
                     }
 

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -519,5 +519,31 @@ describe('useGenericAuth', () => {
         public: 'public',
       });
     });
+    it('should not validate fields with @include and @skip directives with default values', async () => {
+      const testInstance = createTestkit(
+        [
+          useGenericAuth({
+            mode: 'protect-granular',
+            resolveUserFn: invalidresolveUserFn,
+          }),
+        ],
+        schemaWithDirective,
+      );
+
+      const result = await testInstance.execute(/* GraphQL */ `
+        query ($skip: Boolean! = true, $include: Boolean! = false) {
+          public
+          p1: protected @skip(if: $skip)
+          p2: protected @skip(if: true)
+          p3: protected @include(if: false)
+          p4: protected @include(if: $include)
+        }
+      `);
+      assertSingleExecutionValue(result);
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({
+        public: 'public',
+      });
+    });
   });
 });

--- a/packages/plugins/response-cache-redis/package.json
+++ b/packages/plugins/response-cache-redis/package.json
@@ -56,6 +56,7 @@
     "@envelop/core": "workspace:^",
     "@graphql-tools/schema": "10.0.11",
     "@types/ioredis": "4.28.10",
+    "graphql": "16.9.0",
     "ioredis-mock": "5.9.1",
     "typescript": "5.1.3"
   },

--- a/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
+++ b/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
@@ -1,3 +1,4 @@
+import { versionInfo } from 'graphql';
 import Redis from 'ioredis';
 import { useResponseCache } from '@envelop/response-cache';
 import { createTestkit } from '@envelop/testing';
@@ -10,7 +11,9 @@ import {
 
 jest.mock('ioredis', () => require('ioredis-mock/jest'));
 
-describe('useResponseCache with Redis cache', () => {
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip);
+
+describeIf(versionInfo.major >= 16)('useResponseCache with Redis cache', () => {
   const redis = new Redis();
   const cache = createRedisCache({ redis });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,9 @@ importers:
       '@envelop/extended-validation':
         specifier: ^4.1.0
         version: 4.1.0(@envelop/core@packages+core+dist)(graphql@16.6.0)
+      '@graphql-tools/executor':
+        specifier: ^1.3.6
+        version: 1.3.6(graphql@16.6.0)
       '@graphql-tools/utils':
         specifier: ^10.5.1
         version: 10.5.4(graphql@16.6.0)
@@ -3167,6 +3170,12 @@ packages:
 
   '@graphql-tools/executor@1.3.1':
     resolution: {integrity: sha512-tgJDdGf9SCAm64ofEMZdv925u6/J+eTmv36TGNLxgP2DpCJsZ6gnJ4A+0D28EazDXqJIvMiPd+3d+o3cCRCAnQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: 16.6.0
+
+  '@graphql-tools/executor@1.3.6':
+    resolution: {integrity: sha512-ZmWsWdUhTez2b4w9NkmL4wpPb8n8WZmLOMIPTXH2A2yEe2nHrK/tk653JZXvZFtx2HrBIcoZD4Fe/STYWIR74Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: 16.6.0
@@ -5799,8 +5808,16 @@ packages:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
 
+  call-bind-apply-helpers@1.0.1:
+    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
+    engines: {node: '>= 0.4'}
+
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -6443,6 +6460,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decode-named-character-reference@1.0.1:
     resolution: {integrity: sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==}
 
@@ -6601,6 +6627,10 @@ packages:
     resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.0:
+    resolution: {integrity: sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==}
+    engines: {node: '>= 0.4'}
+
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -6709,6 +6739,10 @@ packages:
 
   es-define-property@1.0.0:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
@@ -7372,6 +7406,10 @@ packages:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
 
+  get-intrinsic@1.2.5:
+    resolution: {integrity: sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -7488,6 +7526,10 @@ packages:
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -7607,6 +7649,10 @@ packages:
 
   has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.0:
@@ -14011,7 +14057,7 @@ snapshots:
   '@graphql-tools/delegate@10.0.3(graphql@16.6.0)':
     dependencies:
       '@graphql-tools/batch-execute': 9.0.2(graphql@16.6.0)
-      '@graphql-tools/executor': 1.3.1(graphql@16.6.0)
+      '@graphql-tools/executor': 1.3.6(graphql@16.6.0)
       '@graphql-tools/schema': 10.0.11(graphql@16.6.0)
       '@graphql-tools/utils': 10.6.2(graphql@16.6.0)
       dataloader: 2.2.2
@@ -14035,6 +14081,15 @@ snapshots:
       '@repeaterjs/repeater': 3.0.5
       graphql: 16.6.0
       tslib: 2.6.2
+      value-or-promise: 1.0.12
+
+  '@graphql-tools/executor@1.3.6(graphql@16.6.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.6.2(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@repeaterjs/repeater': 3.0.5
+      graphql: 16.6.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   '@graphql-tools/merge@8.3.1(graphql@16.6.0)':
@@ -17467,12 +17522,24 @@ snapshots:
       union-value: 1.0.1
       unset-value: 1.0.0
 
+  call-bind-apply-helpers@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   call-bind@1.0.7:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
+      set-function-length: 1.2.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-define-property: 1.0.1
+      get-intrinsic: 1.2.5
       set-function-length: 1.2.2
 
   callsites@3.1.0: {}
@@ -18166,6 +18233,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   decode-named-character-reference@1.0.1:
     dependencies:
       character-entities: 2.0.1
@@ -18310,6 +18381,12 @@ snapshots:
   dotenv@8.6.0: {}
 
   dset@3.1.2: {}
+
+  dunder-proto@1.0.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   duplexer@0.1.2: {}
 
@@ -18481,6 +18558,8 @@ snapshots:
   es-define-property@1.0.0:
     dependencies:
       get-intrinsic: 1.2.4
+
+  es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
@@ -19452,6 +19531,17 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.2
 
+  get-intrinsic@1.2.5:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      dunder-proto: 1.0.0
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+
   get-package-type@0.1.0: {}
 
   get-port@3.2.0: {}
@@ -19621,6 +19711,8 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -19740,6 +19832,8 @@ snapshots:
   has-proto@1.0.3: {}
 
   has-symbols@1.0.3: {}
+
+  has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.0:
     dependencies:
@@ -20163,7 +20257,7 @@ snapshots:
   ioredis@4.28.5:
     dependencies:
       cluster-key-slot: 1.1.2
-      debug: 4.3.7
+      debug: 4.4.0
       denque: 1.5.1
       lodash.defaults: 4.2.0
       lodash.flatten: 4.4.0
@@ -22416,9 +22510,9 @@ snapshots:
 
   object.assign@4.1.5:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
       object-keys: 1.1.1
 
   object.fromentries@2.0.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1453,6 +1453,9 @@ importers:
       '@types/ioredis':
         specifier: 4.28.10
         version: 4.28.10
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
       ioredis-mock:
         specifier: 5.9.1
         version: 5.9.1(ioredis@4.27.9)(redis-commands@1.7.0)


### PR DESCRIPTION
Handle operations with \`@include\` and \`@skip\` correctly when they have default values in the
operation definition

```ts
{
    query: /* GraphQL */ `
      query MyQuery($include: Boolean = true) {
        field @include(if: $include)
      }
    `,
    variables: {}
}
```

should be considered same as

```ts
{
    query: /* GraphQL */ `
      query MyQuery($include: Boolean!) {
        field @include(if: $include)
      }
    `,
    variables: {
        include: true
    }
}
```