### PR TITLE
fix(core): do not trigger `onSchemaChange` if the schema is the same

### DIFF
--- a/.changeset/afraid-hairs-reflect.md
+++ b/.changeset/afraid-hairs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+When the schema is the same, do not trigger `onSchemaChange` hook

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -86,6 +86,9 @@ export function createEnvelopOrchestrator<PluginsContext extends DefaultContext>
   // to allow setting the schema from the onPluginInit callback. We also need to make sure
   // here not to call the same plugin that initiated the schema switch.
   const replaceSchema = (newSchema: any, ignorePluginIndex = -1) => {
+    if (schema === newSchema) {
+      return;
+    }
     schema = newSchema;
 
     if (initDone) {


### PR DESCRIPTION
If the schema set by the user is the same that has been set before, do not trigger `onSchemaChange` hook.