### PR TITLE
feat(response-cache): `onTtl` hook to manipulate the cached response

### DIFF
--- a/.changeset/great-bees-change.md
+++ b/.changeset/great-bees-change.md
@@ -1,0 +1,5 @@
+---
+'@envelop/response-cache': minor
+---
+
+New `onTtl` hook to manipulate TTL of the cached response

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -156,8 +156,6 @@ export type UseResponseCacheParameter<PluginContext extends Record<string, any> 
 
 export type ResponseCacheOnTtlFunction<PluginContext> = (payload: {
   ttl: number;
-  result: ExecutionResult<ObjMap<unknown>, ObjMap<unknown>>;
-  cacheKey: string;
   context: PluginContext;
 }) => number;
 
@@ -579,8 +577,6 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
         if (onTtl) {
           finalTtl = onTtl({
             ttl: finalTtl,
-            result,
-            cacheKey,
             context: onExecuteParams.args.contextValue,
           });
         }

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -304,14 +304,6 @@ type CacheControlDirective = {
   scope?: 'PUBLIC' | 'PRIVATE';
 };
 
-export interface ResponseCachePluginExtensions {
-  http?: {
-    headers?: Record<string, string>;
-  };
-  responseCache: ResponseCacheExtensions;
-  [key: string]: unknown;
-}
-
 export function useResponseCache<PluginContext extends Record<string, any> = {}>({
   cache = createInMemoryCache(),
   ttl: globalTtl = Infinity,
@@ -599,6 +591,7 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
           }
           return;
         }
+
         cacheInstance.set(cacheKey, result, identifier.values(), finalTtl);
         if (includeExtensionMetadata) {
           setResult(resultWithMetadata(result, { hit: false, didCache: true, ttl: finalTtl }));

--- a/packages/plugins/response-cache/src/plugin.ts
+++ b/packages/plugins/response-cache/src/plugin.ts
@@ -585,13 +585,12 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
         // we only use the global ttl if no currentTtl has been determined.
         let finalTtl = currentTtl ?? globalTtl;
         if (onTtl) {
-          finalTtl =
-            onTtl({
-              ttl: finalTtl,
-              result,
-              cacheKey,
-              context: onExecuteParams.args.contextValue,
-            }) || finalTtl;
+          finalTtl = onTtl({
+            ttl: finalTtl,
+            result,
+            cacheKey,
+            context: onExecuteParams.args.contextValue,
+          });
         }
 
         if (skip || !shouldCacheResult({ cacheKey, result }) || finalTtl === 0) {
@@ -604,15 +603,6 @@ export function useResponseCache<PluginContext extends Record<string, any> = {}>
         if (includeExtensionMetadata) {
           setResult(resultWithMetadata(result, { hit: false, didCache: true, ttl: finalTtl }));
         }
-
-        const extensions = (result.extensions ||= {}) as ResponseCachePluginExtensions;
-        const httpExtensions = (extensions.http ||= {});
-        const headers = (httpExtensions.headers ||= {});
-        const now = new Date();
-        const expires = new Date(now.getTime() + finalTtl);
-        headers.ETag = cacheKey;
-        headers['Last-Modified'] = now.toUTCString();
-        headers.Expires = expires.toUTCString();
       }
 
       return setExecutor({


### PR DESCRIPTION
`onTtl` hook allows to manipulate the calculated TTL