### PR TITLE
fix: update the changeset patch for non-major peer-deps updates

### DIFF
--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,8 +1,17 @@
-diff --git a/dist/assemble-release-plan.cjs.dev.js b/dist/assemble-release-plan.cjs.dev.js
-index 3a37c62c975518f975c22e1b4b3974d9b325a5da..6f0e2a47086cf09fc5bf853571bef78927eed4a3 100644
---- a/dist/assemble-release-plan.cjs.dev.js
-+++ b/dist/assemble-release-plan.cjs.dev.js
-@@ -75,7 +75,7 @@ function incrementVersion(release, preInfo) {
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e32a5e5d39c3bd920201b5694632d2b44c92d486..bf9eb78d0a3fb98c57f5d8fbfe42384e59cdf971 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -17,6 +17,8 @@ var semverGt__default = /*#__PURE__*/_interopDefault(semverGt);
+ var semverSatisfies__default = /*#__PURE__*/_interopDefault(semverSatisfies);
+ var semverInc__default = /*#__PURE__*/_interopDefault(semverInc);
+ 
++const ranges = ['patch', 'minor', 'major'];
++
+ function _defineProperty(obj, key, value) {
+   if (key in obj) {
+     Object.defineProperty(obj, key, {
+@@ -169,7 +171,7 @@ function incrementVersion(release, preInfo) {
      // because semver.inc with prereleases is confusing and this seems easier
  
  
@@ -11,12 +20,10 @@ index 3a37c62c975518f975c22e1b4b3974d9b325a5da..6f0e2a47086cf09fc5bf853571bef789
    }
  
    return version;
-@@ -130,38 +130,30 @@ function determineDependents({
-           depType,
-           versionRange
+@@ -228,16 +230,8 @@ function determineDependents({
          } of dependencyVersionRanges) {
--          if (nextRelease.type === "none") {
--            continue;
+           if (nextRelease.type === "none") {
+             continue;
 -          } else if (shouldBumpMajor({
 -            dependent,
 -            depType,
@@ -27,61 +34,12 @@ index 3a37c62c975518f975c22e1b4b3974d9b325a5da..6f0e2a47086cf09fc5bf853571bef789
 -            onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
 -          })) {
 -            type = "major";
--          } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semver__default['default'].satisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
--            switch (depType) {
--              case "dependencies":
--              case "optionalDependencies":
--              case "peerDependencies":
--                if (type !== "major" && type !== "minor") {
--                  type = "patch";
--                }
--
--                break;
--
--              case "devDependencies":
--                {
--                  // We don't need a version bump if the package is only in the devDependencies of the dependent package
--                  if (type !== "major" && type !== "minor" && type !== "patch") {
--                    type = "none";
-+          if (['patch', 'minor', 'major'].indexOf(nextRelease.type) > ['patch', 'minor', 'major'].indexOf(type)) {
-+            type = nextRelease.type
-+          } else if ( // TODO validate this - I don't think it's right anymore
-+            (!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semver__default['default'].satisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
-+              switch (depType) {
-+                case "dependencies":
-+                case "optionalDependencies":
-+                case "peerDependencies":
-+                  if (type !== "major" && type !== "minor") {
-+                    type = "patch";
-                   }
--                }
-+
-+                  break;
-+
-+                case "devDependencies":
-+                  {
-+                    // We don't need a version bump if the package is only in the devDependencies of the dependent package
-+                    if (type !== "major" && type !== "minor" && type !== "patch") {
-+                      type = "none";
-+                    }
-+                  }
-+              }
-             }
--          }
-+
-         }
-       }
- 
-@@ -174,22 +166,31 @@ function determineDependents({
-         type,
-         pkgJSON: dependentPackage.packageJson
-       };
--    }).filter(dependentItem => !!dependentItem.type).forEach(({
-+    }).filter(({
-+      type
-+    }) => type).forEach( // @ts-ignore - I don't know how to make typescript understand that the filter above guarantees this and I got sick of trying
-+    ({
-       name,
++          } else if (ranges.indexOf(nextRelease.type) > ranges.indexOf(type)) {
++            type = nextRelease.type;
+           } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange))) {
+             switch (depType) {
+               case "dependencies":
+@@ -275,17 +269,18 @@ function determineDependents({
        type,
        pkgJSON
      }) => {
@@ -96,71 +54,12 @@ index 3a37c62c975518f975c22e1b4b3974d9b325a5da..6f0e2a47086cf09fc5bf853571bef789
 -        existing.type = "major";
 -        pkgsToSearch.push(existing);
 +      if (existing) {
-+        const index = ["patch", "minor", "major"].indexOf(existing.type)
-+        if (type === "major") {
-+            existing.type = "major";
-+        } else if (type === "minor" && index < 1) {
-+            existing.type = "minor";
-+        } else if (type === "patch" && index < 0) {
-+            existing.type = "patch";
-+       }
-+        // pkgsToSearch.push(existing);
++        existing.type = ranges[Math.max(
++          ranges.indexOf(type),
++          ranges.indexOf(existing.type)
++        )];
        } else {
 +        updated = true;
          let newDependent = {
            name,
            type,
-@@ -307,20 +308,15 @@ function getHighestReleaseType(releases) {
-   let highestReleaseType = "none";
- 
-   for (let release of releases) {
--    switch (release.type) {
--      case "major":
-+      console.log(release, release.type)
-+      if (release.type === "major") {
-         return "major";
--
--      case "minor":
-+      } else if (release.type === "minor") {
-         highestReleaseType = "minor";
--        break;
--
--      case "patch":
-+      } else if (release.type === "patch") {
-         if (highestReleaseType === "none") {
-           highestReleaseType = "patch";
-         }
--
--        break;
-     }
-   }
- 
-diff --git a/dist/assemble-release-plan.cjs.js b/dist/assemble-release-plan.cjs.js
-index f3beb3187f56b512830d4b4ed2724fcdeca8b7d4..42d129091a4a77599e1c6b14ccd5bd8596fbd6c3 100644
---- a/dist/assemble-release-plan.cjs.js
-+++ b/dist/assemble-release-plan.cjs.js
-@@ -1,7 +1,7 @@
- 'use strict';
- 
--if (process.env.NODE_ENV === "production") {
--  module.exports = require("./assemble-release-plan.cjs.prod.js");
--} else {
-+// if (process.env.NODE_ENV === "production") {
-+//   module.exports = require("./assemble-release-plan.cjs.prod.js");
-+// } else {
-   module.exports = require("./assemble-release-plan.cjs.dev.js");
--}
-+// }
-diff --git a/dist/assemble-release-plan.cjs.prod.js b/dist/assemble-release-plan.cjs.prod.js
-index 87b4c104bf3fa53ba498ced6f81eda0ed4c86436..80a63646dc93d097a73acc68213ec87579a78a97 100644
---- a/dist/assemble-release-plan.cjs.prod.js
-+++ b/dist/assemble-release-plan.cjs.prod.js
-@@ -130,7 +130,7 @@ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
- }
- 
- function shouldBumpMajor({dependent: dependent, depType: depType, versionRange: versionRange, releases: releases, nextRelease: nextRelease, preInfo: preInfo, onlyUpdatePeerDependentsWhenOutOfRange: onlyUpdatePeerDependentsWhenOutOfRange}) {
--  return "peerDependencies" === depType && "none" !== nextRelease.type && "patch" !== nextRelease.type && (!onlyUpdatePeerDependentsWhenOutOfRange || !semver__default.default.satisfies(incrementVersion(nextRelease, preInfo), versionRange)) && (!releases.has(dependent) || releases.has(dependent) && "major" !== releases.get(dependent).type);
-+  return "peerDependencies" === depType && "none" !== nextRelease.type && "patch" !== nextRelease.type && !onlyUpdatePeerDependentsWhenOutOfRange && (!releases.has(dependent) || releases.has(dependent) && "major" !== releases.get(dependent).type);
- }
- 
- function flattenReleases(changesets, packagesByName, ignoredPackages) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 
 patchedDependencies:
   '@changesets/assemble-release-plan':
-    hash: 5bb9eede8c30e81867b3e090b3f282db4eca7ea4a0cb9c9e24efc1495a7c6d22
+    hash: e929d4d48a9e0237e7a5b5283297e70eec7ad4472c14fd4f5a8fbab66387eb00
     path: patches/@changesets__assemble-release-plan.patch
   '@ianvs/prettier-plugin-sort-imports':
     hash: db9ab7a110c54b5d60464680286f2c0d90ea2331a1142bc3fc068b09696655ce
@@ -13104,7 +13104,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.1
 
-  '@changesets/assemble-release-plan@6.0.6(patch_hash=5bb9eede8c30e81867b3e090b3f282db4eca7ea4a0cb9c9e24efc1495a7c6d22)':
+  '@changesets/assemble-release-plan@6.0.6(patch_hash=e929d4d48a9e0237e7a5b5283297e70eec7ad4472c14fd4f5a8fbab66387eb00)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -13128,7 +13128,7 @@ snapshots:
   '@changesets/cli@2.28.1':
     dependencies:
       '@changesets/apply-release-plan': 7.0.10
-      '@changesets/assemble-release-plan': 6.0.6(patch_hash=5bb9eede8c30e81867b3e090b3f282db4eca7ea4a0cb9c9e24efc1495a7c6d22)
+      '@changesets/assemble-release-plan': 6.0.6(patch_hash=e929d4d48a9e0237e7a5b5283297e70eec7ad4472c14fd4f5a8fbab66387eb00)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
@@ -13186,7 +13186,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.8':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.6(patch_hash=5bb9eede8c30e81867b3e090b3f282db4eca7ea4a0cb9c9e24efc1495a7c6d22)
+      '@changesets/assemble-release-plan': 6.0.6(patch_hash=e929d4d48a9e0237e7a5b5283297e70eec7ad4472c14fd4f5a8fbab66387eb00)
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.3


### PR DESCRIPTION
The patch for the changeset package has stopped working for some unknown reasons.

This PR is porting the modifications that modifies the behavior of peer-deps updated related version bump.

The patch bumps packages depending on a incoming release with the same version range than the incoming release instead of a major bump.