### PR TITLE
redis cache set ttl in seconds

### DIFF
--- a/packages/plugins/response-cache-redis/src/redis-cache.ts
+++ b/packages/plugins/response-cache-redis/src/redis-cache.ts
@@ -1,11 +1,8 @@
-import Redis from "ioredis";
-import type { Cache } from "@envelop/response-cache";
-import { handleMaybePromise } from "@whatwg-node/promise-helpers";
+import Redis from 'ioredis';
+import type { Cache } from '@envelop/response-cache';
+import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 
-export type BuildRedisEntityId = (
-  typename: string,
-  id: number | string
-) => string;
+export type BuildRedisEntityId = (typename: string, id: number | string) => string;
 export type BuildRedisOperationResultCacheKey = (responseId: string) => string;
 
 export type RedisCacheParameter = {
@@ -29,34 +26,30 @@ export type RedisCacheParameter = {
 export const createRedisCache = (params: RedisCacheParameter): Cache => {
   const store = params.redis;
 
-  const buildRedisEntityId =
-    params?.buildRedisEntityId ?? defaultBuildRedisEntityId;
+  const buildRedisEntityId = params?.buildRedisEntityId ?? defaultBuildRedisEntityId;
   const buildRedisOperationResultCacheKey =
-    params?.buildRedisOperationResultCacheKey ??
-    defaultBuildRedisOperationResultCacheKey;
+    params?.buildRedisOperationResultCacheKey ?? defaultBuildRedisOperationResultCacheKey;
 
-  async function buildEntityInvalidationsKeys(
-    entity: string
-  ): Promise<string[]> {
+  async function buildEntityInvalidationsKeys(entity: string): Promise<string[]> {
     const keysToInvalidate: string[] = [entity];
 
     // find the responseIds for the entity
     const responseIds = await store.smembers(entity);
     // and add each response to be invalidated since they contained the entity data
-    responseIds.forEach((responseId) => {
+    responseIds.forEach(responseId => {
       keysToInvalidate.push(responseId);
       keysToInvalidate.push(buildRedisOperationResultCacheKey(responseId));
     });
 
     // if invalidating an entity like Comment, then also invalidate Comment:1, Comment:2, etc
-    if (!entity.includes(":")) {
+    if (!entity.includes(':')) {
       const entityKeys = await store.keys(`${entity}:*`);
       for (const entityKey of entityKeys) {
         // and invalidate any responses in each of those entity keys
         const entityResponseIds = await store.smembers(entityKey);
         // if invalidating an entity check for associated operations containing that entity
         // and invalidate each response since they contained the entity data
-        entityResponseIds.forEach((responseId) => {
+        entityResponseIds.forEach(responseId => {
           keysToInvalidate.push(responseId);
           keysToInvalidate.push(buildRedisOperationResultCacheKey(responseId));
         });
@@ -77,7 +70,7 @@ export const createRedisCache = (params: RedisCacheParameter): Cache => {
         pipeline.set(responseId, JSON.stringify(result));
       } else {
         // set the ttl in milliseconds
-        pipeline.set(responseId, JSON.stringify(result), "EX", ttl);
+        pipeline.set(responseId, JSON.stringify(result), 'EX', ttl);
       }
 
       const responseKey = buildRedisOperationResultCacheKey(responseId);
@@ -102,7 +95,7 @@ export const createRedisCache = (params: RedisCacheParameter): Cache => {
     get(responseId) {
       return handleMaybePromise(
         () => store.get(responseId),
-        (result: any) => (result ? JSON.parse(result) : undefined)
+        (result: any) => (result ? JSON.parse(result) : undefined),
       );
     },
     async invalidate(entitiesToRemove) {
@@ -111,8 +104,8 @@ export const createRedisCache = (params: RedisCacheParameter): Cache => {
       for (const { typename, id } of entitiesToRemove) {
         invalidationKeys.push(
           await buildEntityInvalidationsKeys(
-            id != null ? buildRedisEntityId(typename, id) : typename
-          )
+            id != null ? buildRedisEntityId(typename, id) : typename,
+          ),
         );
       }
 
@@ -124,7 +117,6 @@ export const createRedisCache = (params: RedisCacheParameter): Cache => {
   };
 };
 
-export const defaultBuildRedisEntityId: BuildRedisEntityId = (typename, id) =>
-  `${typename}:${id}`;
+export const defaultBuildRedisEntityId: BuildRedisEntityId = (typename, id) => `${typename}:${id}`;
 export const defaultBuildRedisOperationResultCacheKey: BuildRedisOperationResultCacheKey =
-  (responseId) => `operations:${responseId}`;
+  responseId => `operations:${responseId}`;

--- a/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
+++ b/packages/plugins/response-cache-redis/test/response-redis-cache.spec.ts
@@ -797,8 +797,8 @@ describeIf(versionInfo.major >= 16)('useResponseCache with Redis cache', () => {
     // so queried just once
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // let's travel in time beyond the ttl of 100
-    jest.advanceTimersByTime(150);
+    // let's travel in time beyond the ttl of 100 seconds
+    jest.advanceTimersByTime(150_000);
 
     // since the cache has expired, now when we query
     await testInstance.execute(query);
@@ -1083,8 +1083,8 @@ describeIf(versionInfo.major >= 16)('useResponseCache with Redis cache', () => {
     await testInstance.execute(query);
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // wait so User expires
-    jest.advanceTimersByTime(201);
+    // wait so User expires, beyond 200 seconds
+    jest.advanceTimersByTime(201_000);
 
     await testInstance.execute(query);
     // now we've queried twice
@@ -1174,8 +1174,8 @@ describeIf(versionInfo.major >= 16)('useResponseCache with Redis cache', () => {
     await testInstance.execute(query);
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // wait so User expires
-    jest.advanceTimersByTime(201);
+    // wait so User expires beyond 200 seconds
+    jest.advanceTimersByTime(201_000);
 
     await testInstance.execute(query);
     // now we've queried twice


### PR DESCRIPTION

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Redis cache for response-cache should follow
the same ttl meaning of the related plugin, so ttl should be in seconds.


Fixes #2539

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

