### PR TITLE
feat(rate-limiter): improve performance

### DIFF
--- a/.changeset/@envelop_rate-limiter-2676-dependencies.md
+++ b/.changeset/@envelop_rate-limiter-2676-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@envelop/rate-limiter": patch
+---
+dependencies updates:
+  - Added dependency [`@types/picomatch@^4.0.2` ↗︎](https://www.npmjs.com/package/@types/picomatch/v/4.0.2) (to `dependencies`)
+  - Added dependency [`picomatch@^4.0.3` ↗︎](https://www.npmjs.com/package/picomatch/v/4.0.3) (to `dependencies`)
+  - Removed dependency [`minimatch@^10.0.1` ↗︎](https://www.npmjs.com/package/minimatch/v/10.0.1) (from `dependencies`)

--- a/.changeset/moody-dodos-post.md
+++ b/.changeset/moody-dodos-post.md
@@ -1,0 +1,6 @@
+---
+'@envelop/rate-limiter': patch
+---
+
+Massive reduction of performance impact on GraphQL execution. Overhead has been minimalized on
+rate-limited fields, and entirely suppressed on other fields.

--- a/.changeset/open-geckos-grin.md
+++ b/.changeset/open-geckos-grin.md
@@ -1,0 +1,9 @@
+---
+'@envelop/rate-limiter': minor
+---
+
+Validate the configuration at schema loading time. The plugin now throws an error on invalid
+configuration, such as:
+
+ - Multiple field configuration matching the same field
+ - A field configuration matching a field already having a directive

--- a/.changeset/silver-poems-stay.md
+++ b/.changeset/silver-poems-stay.md
@@ -1,0 +1,5 @@
+---
+'@envelop/rate-limiter': patch
+---
+
+Fixed `rateLimitDirectiveName` option being ignored.

--- a/packages/plugins/rate-limiter/package.json
+++ b/packages/plugins/rate-limiter/package.json
@@ -53,10 +53,11 @@
   "dependencies": {
     "@envelop/on-resolve": "workspace:^",
     "@graphql-tools/utils": "^10.5.4",
+    "@types/picomatch": "^4.0.2",
     "@whatwg-node/promise-helpers": "^1.2.4",
     "lodash.get": "^4.4.2",
-    "minimatch": "^10.0.1",
     "ms": "^2.1.3",
+    "picomatch": "^4.0.3",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -127,9 +127,15 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
         }
 
         for (const field of Object.values(type.getFields())) {
-          const fieldConfig = configByField?.find(
+          const fieldConfigs = configByField?.filter(
             ({ isMatch }) => isMatch.type(type.name) && isMatch.field(field.name),
           );
+          if (fieldConfigs && fieldConfigs.length > 1) {
+            throw new Error(
+              `Config error: field '${type.name}.${field.name}' has multiple matching configuration`,
+            );
+          }
+          const fieldConfig = fieldConfigs?.[0];
 
           const rateLimitDirective = getDirectiveExtensions(field, schema)[
             directiveName

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1390,18 +1390,21 @@ importers:
       '@graphql-tools/utils':
         specifier: ^10.5.4
         version: 10.9.1(graphql@16.8.1)
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@whatwg-node/promise-helpers':
         specifier: ^1.2.4
         version: 1.3.2
       lodash.get:
         specifier: ^4.4.2
         version: 4.4.2
-      minimatch:
-        specifier: ^10.0.1
-        version: 10.0.3
       ms:
         specifier: ^2.1.3
         version: 2.1.3
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.3
       tslib:
         specifier: ^2.5.0
         version: 2.8.1
@@ -5309,6 +5312,9 @@ packages:
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
+
+  '@types/picomatch@4.0.2':
+    resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -16204,6 +16210,8 @@ snapshots:
       '@types/node': 22.18.1
       pg-protocol: 1.10.3
       pg-types: 2.2.0
+
+  '@types/picomatch@4.0.2': {}
 
   '@types/prop-types@15.7.15': {}
 


### PR DESCRIPTION
## Description

To apply the configuration based on type and field name, the rate limiter plugin is using `minimatch` to allow glob patterns and simplify the configuration.

But `minimatch` implementation is very unefficient. It uses `RegExp` under the hood (which is already pretty expensive), but it doesn't even memoize the `RegExp` instances. This means that a new one is created and compiled for each resolver, for each configured type/field.

Having such heavy process in a hot path like this one can have a big impact of performance.

This PR replaces `minimatch` by `picomatch` and builds all relevant matchers ahead of time. This way, only the actual string test is done in the hot path.

It also moves all the logic for replacing the resolver based on configuration to the `onSchemaChange` hook, to minimize the overhead at execution time.

Realted to https://github.com/graphql-hive/gateway/issues/1485

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Further comments

By reworking the plugin, I also came across some small issues:
 - The `directiveName` option was not honored.
 - Directives on fields with a matching configuration was silently ignored
 - Configurations matching the same field was silently ignored (only the first matching config was used)

