### PR TITLE
 fix(rate-limiter): incorrectly applying to non-configured fields

### DIFF
--- a/.changeset/eight-llamas-mate.md
+++ b/.changeset/eight-llamas-mate.md
@@ -1,0 +1,5 @@
+---
+'@envelop/rate-limiter': patch
+---
+
+Fix rate limiting being wrongly applied to all fields with a default configuration.

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -147,9 +147,10 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
             );
           }
 
-          const rateLimitConfig = { ...(rateLimitDirective ?? fieldConfig) };
+          const baseConfig = rateLimitDirective ?? fieldConfig;
 
-          if (rateLimitConfig) {
+          if (baseConfig) {
+            const rateLimitConfig = { ...baseConfig };
             rateLimitConfig.max = rateLimitConfig.max && Number(rateLimitConfig.max);
 
             if (fieldConfig?.identifyFn) {

--- a/packages/plugins/rate-limiter/src/index.ts
+++ b/packages/plugins/rate-limiter/src/index.ts
@@ -147,10 +147,9 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
             );
           }
 
-          const baseConfig = rateLimitDirective ?? fieldConfig;
+          const rateLimitConfig = { ...(rateLimitDirective ?? fieldConfig) };
 
-          if (baseConfig) {
-            const rateLimitConfig = { ...baseConfig };
+          if (rateLimitConfig) {
             rateLimitConfig.max = rateLimitConfig.max && Number(rateLimitConfig.max);
 
             if (fieldConfig?.identifyFn) {

--- a/packages/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
+++ b/packages/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
@@ -490,9 +490,12 @@ describe('Rate-Limiter', () => {
     assertSingleExecutionValue(result2);
     expect(result2.errors?.[0]?.message).toBe("You are trying to access 'limitedField' too often");
 
-    const result3 = await testkit.execute(`{ unlimitedField }`, {}, context);
-    assertSingleExecutionValue(result3);
-    expect(result3).toEqual({ data: { unlimitedField: 'unlimited' } });
-    expect(result3.errors).toBeUndefined();
+    // unlimitedField should not be rate limited at all, so we should be able to call it many times
+    for (let i = 0; i < 10; i++) {
+      const result = await testkit.execute(`{ unlimitedField }`, {}, context);
+      assertSingleExecutionValue(result);
+      expect(result).toEqual({ data: { unlimitedField: 'unlimited' } });
+      expect(result.errors).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Description

Fixed a bug where the rate limiter plugin was incorrectly applying rate limiting to GraphQL fields not configured in `configByField`. Fields that should be unlimited were getting rate limited with default error messages.

The root cause was that `{ ...(rateLimitDirective ?? fieldConfig) }` creates an empty object `{}` when both values are undefined, which is truthy, causing rate limiting to be applied to all fields.

Fixes #2689

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A - This is a backend logic fix with test coverage.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added regression test `'should not rate limit fields that are not in configByField'`
- [x] Verified all existing rate limiter tests continue to pass
- [x] Tested that configured fields are properly rate limited
- [x] Tested that unconfigured fields are never rate limited

**Test Environment**:

- OS: macOS
- `@envelop/rate-limiter`: 8.1.0
- NodeJS: 24.7.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules